### PR TITLE
fix: resolve CI test failures and improve ToolResultBlock

### DIFF
--- a/chatapps/slack/block_builder.go
+++ b/chatapps/slack/block_builder.go
@@ -422,6 +422,19 @@ func (b *BlockBuilder) BuildToolResultBlock(success bool, durationMs int64, outp
 
 	blocks = append(blocks, resultBlock)
 
+	// Add file path context block if provided
+	if filePath != "" {
+		displayPath := truncatePath(filePath, 50)
+		blocks = append(blocks, map[string]any{
+			"type": "context",
+			"elements": []map[string]any{
+				mrkdwnText(fmt.Sprintf(":page_facing_up: *File:* %s", displayPath)),
+			},
+		})
+	}
+
+	// Add metadata context block (Duration)
+	// Only show duration if it exceeds threshold
 	// Add metadata context block (Duration)
 	if durationMs > 0 {
 		blocks = append(blocks, map[string]any{


### PR DESCRIPTION
## Summary
修复 3 个 CI 失败的测试，并为 ToolResultBlock 添加 filePath 支持。

## Changes
- `chatapps/slack/block_builder.go`: 添加 filePath 可变参数
- `chatapps/engine_handler.go`: 清理重复的 handleAnswer 函数定义

## Testing
修复的测试:
- TestBuildPlanItem_TypeValidation/empty_type
- TestBuildURLSource_DangerousScheme
- TestValidateTableBlock_ZeroRows