### PR TITLE
fix: remove Cancel button for /reset command

### DIFF
--- a/chatapps/slack/builder.go
+++ b/chatapps/slack/builder.go
@@ -685,11 +685,14 @@ func (b *MessageBuilder) BuildCommandProgressMessage(msg *base.ChatMessage) []sl
 		}
 	}
 
-	// Per spec: always add cancel button (actions block)
-	cancelBtn := slack.NewButtonBlockElement("cmd_cancel", "cancel",
-		slack.NewTextBlockObject("plain_text", "Cancel", false, false))
-	actionBlock := slack.NewActionBlock("cmd_actions", cancelBtn)
-	blocks = append(blocks, actionBlock)
+	// Per spec: add cancel button only for cancellable commands
+	// Reset command is NOT cancellable (terminate session is irreversible)
+	if commandName != "reset" {
+		cancelBtn := slack.NewButtonBlockElement("cmd_cancel", "cancel",
+			slack.NewTextBlockObject("plain_text", "Cancel", false, false))
+		actionBlock := slack.NewActionBlock("cmd_actions", cancelBtn)
+		blocks = append(blocks, actionBlock)
+	}
 
 	return blocks
 }


### PR DESCRIPTION
## Description

Fixes #78

## Changes

- Modified `chatapps/slack/builder.go` to only show Cancel button for cancellable commands
- Reset command is irreversible (terminate session cannot be cancelled), so Cancel button is hidden
- Prevents user confusion when clicking Cancel on reset progress message

## Testing

- [x] Code compiles successfully (slack package)
- [x] Change is minimal and focused on the specific issue

**Note**: Force-pushed to fix commit location (was accidentally committed to wrong directory initially)