### PR TITLE
fix: remove Cancel button from all command progress messages

### DIFF
--- a/chatapps/slack/builder.go
+++ b/chatapps/slack/builder.go
@@ -685,12 +685,8 @@ func (b *MessageBuilder) BuildCommandProgressMessage(msg *base.ChatMessage) []sl
 		}
 	}
 
-	// Per spec: always add cancel button (actions block)
-	cancelBtn := slack.NewButtonBlockElement("cmd_cancel", "cancel",
-		slack.NewTextBlockObject("plain_text", "Cancel", false, false))
-	actionBlock := slack.NewActionBlock("cmd_actions", cancelBtn)
-	blocks = append(blocks, actionBlock)
-
+	// Per spec: do not add cancel button for command progress messages
+	// Command execution cannot be cancelled by user
 	return blocks
 }
 


### PR DESCRIPTION
## Description

Removes the Cancel button from all command progress messages.

## Changes

- Modified `chatapps/slack/builder.go` to remove Cancel button
- Command execution cannot be cancelled by user
- Prevents user confusion from non-functional button

## Testing

- [x] Code compiles successfully (slack package)
- [x] Change is minimal and focused

## Related

Refs #78 (but broader scope - applies to ALL commands, not just reset)