### PR TITLE
feat(discord): add configuration validation (Issue #72)

### DIFF
--- a/chatapps/discord/config.go
+++ b/chatapps/discord/config.go
@@ -1,8 +1,32 @@
 package discord
 
+import "fmt"
+
 type Config struct {
 	BotToken     string
 	ServerAddr   string
 	PublicKey    string
 	SystemPrompt string
+}
+
+// Validate validates the Discord configuration
+func (c *Config) Validate() error {
+	// Bot token is always required
+	if c.BotToken == "" {
+		return fmt.Errorf("bot token is required")
+	}
+	
+	// Discord bot tokens typically start with "Bot " or are just long strings
+	// Basic validation: must be at least 50 characters (typical Discord token length)
+	if len(c.BotToken) < 50 {
+		return fmt.Errorf("invalid bot token format: token too short")
+	}
+	
+	// ServerAddr is optional for some deployments
+	// PublicKey is required for interaction handling
+	if c.PublicKey == "" {
+		return fmt.Errorf("public key is required for interaction handling")
+	}
+	
+	return nil
 }


### PR DESCRIPTION
## Description

Implements configuration validation for Discord platform to address Issue #72.

## Resolve/Related Issues

Refs #72

## Changes

- Added `Validate()` method to Discord Config
- Validates bot token presence and format (minimum 50 characters)
- Validates public key for interaction handling
- Provides early error detection before runtime

## Testing

- [x] Code compiles successfully (discord package)
- [x] Follows same pattern as Slack's Validate() implementation

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings