### PR TITLE
fix: add panic recovery to WhatsApp message handler

### DIFF
--- a/chatapps/whatsapp/adapter.go
+++ b/chatapps/whatsapp/adapter.go
@@ -2,9 +2,11 @@ package whatsapp
 
 import (
 	"bytes"
+
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hrygo/hotplex/internal/panicx"
 	"io"
 	"log/slog"
 	"net/http"
@@ -223,11 +225,11 @@ func (a *Adapter) handleMessage(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if a.Handler() != nil {
-					go func() {
+					panicx.SafeGo(a.Logger(), func() {
 						if err := a.Handler()(r.Context(), chatMsg); err != nil {
 							a.Logger().Error("Handle message failed", "error", err)
 						}
-					}()
+					})
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Adds panic recovery to WhatsApp message handler goroutine.

## Resolve/Related Issues

Resolves #68

## Changes

- Use `panicx.SafeGo()` for WhatsApp message handler goroutine
- Prevents application crash from unhandled panics

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code follows style guidelines
- [x] Self-review performed
- [x] Tests pass locally