### PR TITLE
fix(chatapps): ensure all goroutines respect ctx.Done() (Issue #64)

### DIFF
--- a/chatapps/base/adapter.go
+++ b/chatapps/base/adapter.go
@@ -47,8 +47,10 @@ type Adapter struct {
 	running        bool
 	runningMu      sync.Mutex // Protects running state
 	sessionTimeout time.Duration
-	cleanupDone    chan struct{}
-	cleanupOnce    sync.Once // Prevents double-close of cleanupDone
+	ctx            context.Context
+	cancel         context.CancelFunc
+	cleanupWg      sync.WaitGroup // Wait for cleanup goroutine to finish
+	cleanupOnce    sync.Once      // Prevents double-cancel
 
 	// Platform-specific implementations
 	platformName    string
@@ -79,13 +81,16 @@ func NewAdapter(
 		config.ServerAddr = ":8080"
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	a := &Adapter{
 		config:                config,
 		logger:                logger,
 		sessions:              make(map[string]*Session),
 		sessionsByUserChannel: make(map[string]*Session),
 		sessionTimeout:        30 * time.Minute,
-		cleanupDone:           make(chan struct{}),
+		ctx:                   ctx,
+		cancel:                cancel,
 		platformName:          platform,
 		httpHandlers:          make(map[string]http.HandlerFunc),
 		sessionIDGenerator:    NewUUID5Generator("hotplex"), // Default to UUID5 generator
@@ -206,6 +211,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 
 	// Serverless mode: skip HTTP server, just start session cleanup
 	if a.disableServer {
+		a.cleanupWg.Add(1)
 		go a.cleanupSessions()
 		a.running = true
 		a.logger.Debug("Adapter started (serverless mode)", "platform", a.platformName)
@@ -232,6 +238,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 	}()
 
 	// Start session cleanup goroutine
+	a.cleanupWg.Add(1)
 	go a.cleanupSessions()
 
 	a.running = true
@@ -247,10 +254,11 @@ func (a *Adapter) Stop() error {
 		return nil
 	}
 
-	// Signal cleanup goroutine to stop (use Once to prevent double-close)
+	// Signal cleanup goroutine to stop (use Once to prevent double-cancel)
 	a.cleanupOnce.Do(func() {
-		close(a.cleanupDone)
+		a.cancel()
 	})
+	a.cleanupWg.Wait() // Wait for cleanup goroutine to finish
 
 	// Skip server shutdown in serverless mode
 	if a.disableServer {
@@ -340,12 +348,14 @@ func (a *Adapter) GetOrCreateSession(userID, botUserID, channelID string) string
 
 // cleanupSessions periodically removes expired sessions
 func (a *Adapter) cleanupSessions() {
+	defer a.cleanupWg.Done()
+
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-a.cleanupDone:
+		case <-a.ctx.Done():
 			a.logger.Info("Session cleanup stopped", "platform", a.platformName)
 			return
 		case <-ticker.C:

--- a/chatapps/base/pending_store.go
+++ b/chatapps/base/pending_store.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -10,6 +11,9 @@ type PendingMessageStore struct {
 	messages map[string]*PendingMessage // sessionID -> PendingMessage
 	mu       sync.RWMutex
 	ttl      time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
 }
 
 // PendingMessage represents a message pending approval
@@ -28,12 +32,17 @@ func NewPendingMessageStore(ttl time.Duration) *PendingMessageStore {
 		ttl = 5 * time.Minute // Default 5 minute TTL
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	store := &PendingMessageStore{
 		messages: make(map[string]*PendingMessage),
 		ttl:      ttl,
+		ctx:      ctx,
+		cancel:   cancel,
 	}
 
 	// Start cleanup goroutine
+	store.wg.Add(1)
 	go store.cleanupLoop()
 
 	return store
@@ -76,12 +85,25 @@ func (s *PendingMessageStore) Delete(sessionID string) {
 
 // cleanupLoop periodically removes expired pending messages
 func (s *PendingMessageStore) cleanupLoop() {
+	defer s.wg.Done()
+
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		s.cleanup()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			s.cleanup()
+		}
 	}
+}
+
+// Stop stops the cleanup goroutine
+func (s *PendingMessageStore) Stop() {
+	s.cancel()
+	s.wg.Wait()
 }
 
 // cleanup removes expired pending messages

--- a/chatapps/engine_handler.go
+++ b/chatapps/engine_handler.go
@@ -233,6 +233,13 @@ type StreamCallback struct {
 	sessionOps SessionOperations
 }
 
+// Close releases resources held by the callback
+func (c *StreamCallback) Close() {
+	if c.processor != nil {
+		c.processor.Close()
+	}
+}
+
 // msgRecord tracks a sent message for later deletion or sliding window management.
 type msgRecord struct {
 	ChannelID string
@@ -1382,6 +1389,13 @@ func NewEngineMessageHandler(engine *engine.Engine, adapters *AdapterManager, op
 	return h
 }
 
+// Close releases resources held by the handler
+func (h *EngineMessageHandler) Close() {
+	if h.pendingStore != nil {
+		h.pendingStore.Stop()
+	}
+}
+
 // EngineMessageHandlerOption configures the EngineMessageHandler
 type EngineMessageHandlerOption func(*EngineMessageHandler)
 
@@ -1472,6 +1486,8 @@ func (h *EngineMessageHandler) Handle(ctx context.Context, msg *ChatMessage) err
 
 	// Create stream callback with injected dependencies
 	callback := NewStreamCallback(ctx, msg.SessionID, msg.Platform, h.adapters, h.logger, msg.Metadata, messageOps, sessionOps, turnState)
+	defer callback.Close() // Ensure processor resources are released
+
 	wrappedCallback := func(eventType string, data any) error {
 		return callback.Handle(eventType, data)
 	}

--- a/chatapps/interaction_manager.go
+++ b/chatapps/interaction_manager.go
@@ -1,6 +1,7 @@
 package chatapps
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -38,7 +39,8 @@ type InteractionManager struct {
 	pending         map[string]*PendingInteraction // interaction_id -> PendingInteraction
 	cleanupInterval time.Duration
 	defaultTTL      time.Duration
-	stopCleanup     chan struct{}
+	ctx             context.Context
+	cancel          context.CancelFunc
 	wg              sync.WaitGroup
 }
 
@@ -62,12 +64,15 @@ func NewInteractionManager(logger *slog.Logger, opts InteractionManagerOptions) 
 		opts.TTL = 10 * time.Minute
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	m := &InteractionManager{
 		logger:          logger,
 		pending:         make(map[string]*PendingInteraction),
 		cleanupInterval: opts.CleanupInterval,
 		defaultTTL:      opts.TTL,
-		stopCleanup:     make(chan struct{}),
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 
 	// Start cleanup goroutine
@@ -181,7 +186,7 @@ func (m *InteractionManager) HandleCallback(interactionID, userID, actionID, cal
 
 // Stop stops the cleanup goroutine.
 func (m *InteractionManager) Stop() {
-	close(m.stopCleanup)
+	m.cancel()
 	m.wg.Wait()
 	m.logger.Debug("InteractionManager: stopped")
 }
@@ -195,7 +200,7 @@ func (m *InteractionManager) cleanupLoop() {
 
 	for {
 		select {
-		case <-m.stopCleanup:
+		case <-m.ctx.Done():
 			return
 		case <-ticker.C:
 			m.cleanup()

--- a/chatapps/processor_chain.go
+++ b/chatapps/processor_chain.go
@@ -197,5 +197,19 @@ func (c *ProcessorChain) Order() int {
 	return 0 // Chain doesn't have a specific order, it contains processors with orders
 }
 
+// Close stops all processors that have background goroutines
+func (c *ProcessorChain) Close() {
+	c.mu.RLock()
+	processors := make([]MessageProcessor, len(c.processors))
+	copy(processors, c.processors)
+	c.mu.RUnlock()
+
+	for _, p := range processors {
+		if stoppable, ok := p.(interface{ Stop() }); ok {
+			stoppable.Stop()
+		}
+	}
+}
+
 // Verify ProcessorChain implements MessageProcessor at compile time
 var _ MessageProcessor = (*ProcessorChain)(nil)

--- a/chatapps/processor_chain.go
+++ b/chatapps/processor_chain.go
@@ -206,7 +206,20 @@ func (c *ProcessorChain) Close() {
 
 	for _, p := range processors {
 		if stoppable, ok := p.(interface{ Stop() }); ok {
-			stoppable.Stop()
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						processorName := "unknown"
+						if namer, ok := p.(interface{ Name() string }); ok {
+							processorName = namer.Name()
+						}
+						slog.Default().Error("Processor Stop() panic recovered",
+							"processor", processorName,
+							"panic", r)
+					}
+				}()
+				stoppable.Stop()
+			}()
 		}
 	}
 }

--- a/chatapps/processor_thread.go
+++ b/chatapps/processor_thread.go
@@ -17,7 +17,8 @@ type ThreadProcessor struct {
 	threads         sync.Map // sessionID -> ThreadInfo
 	cleanupInterval time.Duration
 	ttl             time.Duration
-	stopCleanup     chan struct{}
+	ctx             context.Context
+	cancel          context.CancelFunc
 	wg              sync.WaitGroup
 }
 
@@ -48,11 +49,14 @@ func NewThreadProcessor(logger *slog.Logger, opts ThreadProcessorOptions) *Threa
 		opts.TTL = 30 * time.Minute
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	p := &ThreadProcessor{
 		logger:          logger,
 		cleanupInterval: opts.CleanupInterval,
 		ttl:             opts.TTL,
-		stopCleanup:     make(chan struct{}),
+		ctx:             ctx,
+		cancel:          cancel,
 	}
 
 	// Start cleanup goroutine
@@ -187,7 +191,7 @@ func (p *ThreadProcessor) Delete(sessionID string) {
 
 // Stop stops the cleanup goroutine.
 func (p *ThreadProcessor) Stop() {
-	close(p.stopCleanup)
+	p.cancel()
 	p.wg.Wait()
 	p.logger.Debug("ThreadProcessor: stopped")
 }
@@ -201,7 +205,7 @@ func (p *ThreadProcessor) cleanupLoop() {
 
 	for {
 		select {
-		case <-p.stopCleanup:
+		case <-p.ctx.Done():
 			return
 		case <-ticker.C:
 			p.cleanup()

--- a/chatapps/queue.go
+++ b/chatapps/queue.go
@@ -25,6 +25,7 @@ type MessageQueue struct {
 	workers int
 	ctx     context.Context
 	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 }
 
 func NewMessageQueue(logger *slog.Logger, maxSize, dlqSize, workers int) *MessageQueue {
@@ -108,11 +109,14 @@ func (q *MessageQueue) Size() int {
 
 func (q *MessageQueue) Start(adapterGetter func(string) (ChatAdapter, bool), sendFn func(context.Context, string, string, *ChatMessage) error) {
 	for i := 0; i < q.workers; i++ {
+		q.wg.Add(1)
 		go q.worker(i, adapterGetter, sendFn)
 	}
 }
 
 func (q *MessageQueue) worker(_ int, _ func(string) (ChatAdapter, bool), sendFn func(context.Context, string, string, *ChatMessage) error) {
+	defer q.wg.Done()
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -156,6 +160,7 @@ func (q *MessageQueue) Requeue(msg *QueuedMessage) error {
 
 func (q *MessageQueue) Stop() {
 	q.cancel()
+	q.wg.Wait()
 }
 
 var ErrQueueFull = &QueueError{Message: "queue is full"}


### PR DESCRIPTION
## Summary

Fix P0 goroutine leak issue by ensuring all background goroutines properly respond to `ctx.Done()` for graceful shutdown.

## Changes

### Context Pattern Migration
- **processor_thread.go**: Replace `stopCleanup chan struct{}` with `ctx.Done()` pattern
- **interaction_manager.go**: Migrate from `close(stopCleanup)` to `ctx.Done()` pattern
- **adapter.go**: Use `ctx.Done()` + `cleanupWg` for session cleanup goroutine

### Resource Lifecycle Management
- **pending_store.go**: Add `ctx`, `cancel`, `wg` fields and `Stop()` method
- **queue.go**: Add `wg` field to wait for worker goroutines on `Stop()`
- **processor_chain.go**: Add `Close()` method to stop all processors with background goroutines
- **engine_handler.go**: 
  - Add `StreamCallback.Close()` to release processor resources
  - Add `EngineMessageHandler.Close()` to release pending store resources

## Test Plan

- [x] All existing tests pass: `go test ./... -count=1`
- [x] Build succeeds: `go build ./...`
- [x] Pre-commit hooks pass (golangci-lint, go fmt)
- [x] 5 rounds of code review completed

## Impact

| Component | Before | After |
|-----------|--------|-------|
| ThreadProcessor | `close(chan)` pattern | `ctx.Done()` pattern |
| Adapter | `close(chan)` pattern | `ctx.Done()` + WaitGroup |
| PendingMessageStore | No shutdown mechanism | `Stop()` with WaitGroup |
| InteractionManager | `close(chan)` pattern | `ctx.Done()` pattern |
| MessageQueue | `cancel()` only | `cancel()` + `wg.Wait()` |
| ProcessorChain | No cleanup | `Close()` method |
| StreamCallback | No cleanup | `defer Close()` |
| EngineMessageHandler | No cleanup | `Close()` method |

Resolves #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)