### PR TITLE
fix: reduce dedup TTL from 30s to 5s (Issue #129)

### DIFF
--- a/chatapps/base/webhook.go
+++ b/chatapps/base/webhook.go
@@ -23,7 +23,9 @@ type WebhookRunner struct {
 func NewWebhookRunner(logger *slog.Logger) *WebhookRunner {
 	return &WebhookRunner{
 		logger:       logger,
-		deduplicator: dedup.NewDeduplicator(30*time.Second, 10*time.Second),
+		// Issue #129: Reduce TTL from 30s to 5s to prevent normal messages being skipped
+		// Short window is sufficient to prevent network jitter/button double-click duplicates
+		deduplicator: dedup.NewDeduplicator(5*time.Second, 10*time.Second),
 		keyStrategy:  dedup.NewSlackKeyStrategy(),
 	}
 }


### PR DESCRIPTION
## Problem

Current 30-second dedup TTL is too long, causing legitimate messages to be incorrectly filtered as duplicates.

## Solution

Reduce TTL from 30s to 5s, which is sufficient to prevent:
- Network jitter duplicates
- Button double-click duplicates

## Testing

- [ ] Verify normal message flow is not interrupted
- [ ] Confirm duplicate prevention still works for rapid re-submissions

Closes #129