### PR TITLE
fix: prevent duplicate messages for slash commands (Issue #130)

### DIFF
--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -842,9 +842,10 @@ func (a *Adapter) handleSocketModeSlashCommand(evt socketmode.Event) {
 	result, err := a.cmdRegistry.Execute(context.Background(), req, callback)
 	if err != nil {
 		a.Logger().Error("Command execution failed", "command", cmd.Command, "error", err)
-	} else if result != nil && result.Message != "" {
-		_ = a.sendCommandResponse(cmd.ResponseURL, cmd.ChannelID, "", result.Message)
 	}
+	// Issue #130: Don't send result.Message separately when using progress callback
+	// The command executor already sends completion message via emitter.Complete()
+	// Sending result.Message would cause duplicate messages
 }
 
 // handleSocketModeInteractive handles interactive events via Socket Mode
@@ -1499,10 +1500,9 @@ func (a *Adapter) processSlashCommand(cmd SlashCommand) {
 		return
 	}
 
-	// Send response
-	if result != nil && result.Message != "" {
-		_ = a.sendCommandResponse(cmd.ResponseURL, cmd.ChannelID, cmd.ThreadTS, result.Message)
-	}
+	// Issue #130: Don't send result.Message separately when using progress callback
+	// The command executor already sends completion message via emitter.Complete()
+	// Sending result.Message would cause duplicate messages
 }
 
 // =============================================================================
@@ -1598,10 +1598,8 @@ func (a *Adapter) processHashCommand(cmd string, userID, channelID, threadTS str
 			a.Logger().Error("Command execution failed", "command", cmd, "error", err)
 			return
 		}
-		// Send response if needed
-		if result != nil && result.Message != "" {
-			_ = a.sendCommandResponse("", channelID, threadTS, result.Message)
-		}
+		// Issue #130: Don't send result.Message separately when using progress callback
+		// The command executor already sends completion message via emitter.Complete()
 	})
 
 	return true

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -839,13 +839,11 @@ func (a *Adapter) handleSocketModeSlashCommand(evt socketmode.Event) {
 	// Execute command via registry
 	// Note: Using context.Background() is acceptable here as commands run asynchronously
 	// and should not be cancelled if the original HTTP request context is cancelled
-	result, err := a.cmdRegistry.Execute(context.Background(), req, callback)
+	// Issue #130: Don't send result.Message separately - emitter.Complete() already sends it
+	_, err := a.cmdRegistry.Execute(context.Background(), req, callback)
 	if err != nil {
 		a.Logger().Error("Command execution failed", "command", cmd.Command, "error", err)
 	}
-	// Issue #130: Don't send result.Message separately when using progress callback
-	// The command executor already sends completion message via emitter.Complete()
-	// Sending result.Message would cause duplicate messages
 }
 
 // handleSocketModeInteractive handles interactive events via Socket Mode
@@ -1493,16 +1491,13 @@ func (a *Adapter) processSlashCommand(cmd SlashCommand) {
 	}
 
 	// Execute command via registry
-	result, err := a.cmdRegistry.Execute(context.Background(), req, callback)
+	// Issue #130: Don't send result.Message separately - emitter.Complete() already sends it
+	_, err := a.cmdRegistry.Execute(context.Background(), req, callback)
 	if err != nil {
 		a.Logger().Error("Command execution failed", "command", cmd.Command, "error", err)
 		_ = a.sendCommandResponse(cmd.ResponseURL, cmd.ChannelID, cmd.ThreadTS, "Command execution failed: "+err.Error())
 		return
 	}
-
-	// Issue #130: Don't send result.Message separately when using progress callback
-	// The command executor already sends completion message via emitter.Complete()
-	// Sending result.Message would cause duplicate messages
 }
 
 // =============================================================================
@@ -1593,13 +1588,12 @@ func (a *Adapter) processHashCommand(cmd string, userID, channelID, threadTS str
 
 	// Execute command via registry (async)
 	panicx.SafeGo(a.Logger(), func() {
-		result, err := a.cmdRegistry.Execute(context.Background(), req, callback)
+		// Issue #130: Don't send result.Message separately - emitter.Complete() already sends it
+		_, err := a.cmdRegistry.Execute(context.Background(), req, callback)
 		if err != nil {
 			a.Logger().Error("Command execution failed", "command", cmd, "error", err)
 			return
 		}
-		// Issue #130: Don't send result.Message separately when using progress callback
-		// The command executor already sends completion message via emitter.Complete()
 	})
 
 	return true


### PR DESCRIPTION
## Problem

Slash commands (/reset, /dc) were sending duplicate messages in Slack:
1. First message via ProgressEmitter.Complete() callback
2. Second message via sendCommandResponse(result.Message)

## Solution

Removed redundant sendCommandResponse calls after command execution when using progress callback.

## Testing

- [ ] Test /reset command - should show single completion message
- [ ] Test /dc command - should show single completion message

Closes #130