### PR TITLE
fix: session cleanup and engine API v0.17.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! echo "$BODY" | grep -Eiq "(resolves|fixes|closes|refs|fix)\s+#([0-9]+)"; then
+          if ! echo "$BODY" | grep -Eiq "\*?(resolves|fixes|closes|refs|fix)\*?\s*:?\s*#([0-9]+)"; then
             echo "::error::PR body must contain an issue link"
             echo "Add one of: Resolves #N, Fixes #N, Closes #N, or Refs #N"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ This release focuses on ChatApps user experience refinements, goroutine safety i
 #### Daemon & Session Management
 - **Make Restart POSIX Compliance** - Replaced `nohup` with POSIX-compliant stdin redirection (`< /dev/null`) in daemon restart target to ensure background process survives Ctrl+C and works across all Unix platforms.
 - **Reset Command Race Condition** - Fixed `/reset` command execution order (terminate process → delete marker → delete session file) to prevent "Session ID is already in use" errors caused by concurrent message processing recreating markers after deletion.
+- **Session Cleanup Consolidation** - Refactored session file deletion into unified Engine API, removing duplicated cleanup code across ResetExecutor and SessionPool. Added `CleanupSession` method to Provider interface for extensible session file management.
+
+#### Engine Session File Management
+- **Stale Session File Cleanup** - Added automatic deletion of stale CLI session files (`.jsonl`) on session start to prevent "Session ID is already in use" errors after daemon restart.
+- **Provider Abstraction** - Added `CleanupSession` to Provider interface with default no-op implementation; ClaudeCodeProvider now properly deletes `.jsonl` files.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ This release focuses on ChatApps user experience refinements, goroutine safety i
 - **macOS Launchctl** - Corrected PID extraction logic in launch daemon scripts for reliable process management.
 - **CI Arithmetic** - Fixed arithmetic evaluation failures under `set -e` in SVG-to-PNG conversion scripts.
 
+#### Daemon & Session Management
+- **Make Restart POSIX Compliance** - Replaced `nohup` with POSIX-compliant stdin redirection (`< /dev/null`) in daemon restart target to ensure background process survives Ctrl+C and works across all Unix platforms.
+- **Reset Command Race Condition** - Fixed `/reset` command execution order (terminate process → delete marker → delete session file) to prevent "Session ID is already in use" errors caused by concurrent message processing recreating markers after deletion.
+
 ### Documentation
 
 - **Slack Architecture** - Fixed broken link to `slack-architecture.md` in developer documentation.

--- a/chatapps/command/reset_executor.go
+++ b/chatapps/command/reset_executor.go
@@ -3,9 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/hrygo/hotplex/engine"
 	"github.com/hrygo/hotplex/event"
@@ -13,9 +10,8 @@ import (
 
 // ResetExecutor implements the /reset command
 type ResetExecutor struct {
-	engine   *engine.Engine
-	workDir  string
-	adapters interface{} // Will be cast to *chatapps.AdapterManager
+	engine  *engine.Engine
+	workDir string
 }
 
 // Verify ResetExecutor implements Executor at compile time
@@ -27,11 +23,6 @@ func NewResetExecutor(eng *engine.Engine, workDir string) *ResetExecutor {
 		engine:  eng,
 		workDir: workDir,
 	}
-}
-
-// SetAdapterManager sets the adapter manager for session cleanup
-func (e *ResetExecutor) SetAdapterManager(adapters interface{}) {
-	e.adapters = adapters
 }
 
 // Command returns the command name
@@ -93,21 +84,19 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 
 	_ = emitter.Success(1, "Process terminated")
 
-	// Step 3: Delete HotPlex marker (60%)
+	// Step 3 & 4: Delete session context via unified Engine API (60%-80%)
 	_ = emitter.Running(2)
 
-	markerDeleted := e.deleteHotPlexMarker(providerSessionID)
-	if markerDeleted {
-		_ = emitter.Success(2, "Marker deleted")
+	// Calls down to Provider interface to scrape `.jsonl` and HotPlex to drop the `.lock` marker
+	if err := e.engine.CleanupSessionFiles(sessionID); err != nil {
+		_ = emitter.Error(2, fmt.Sprintf("Cleanup incomplete: %v", err))
+		// We still consider it a success overall because the process is dead
 	} else {
-		_ = emitter.Success(2, "Marker cleanup done")
+		_ = emitter.Success(2, "Marker deleted")
 	}
 
-	// Step 4: Delete Claude Code session file (80%)
 	_ = emitter.Running(3)
-
-	deletedCount := e.deleteClaudeCodeSessionFile(providerSessionID)
-	_ = emitter.Success(3, fmt.Sprintf("Deleted %d file(s)", deletedCount))
+	_ = emitter.Success(3, "Session file deleted")
 
 	// Complete
 	_ = emitter.Emit("Resetting Context")
@@ -117,60 +106,7 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 		Success: true,
 		Message: "Context reset. Ready for fresh start!",
 		Metadata: map[string]any{
-			"files_deleted":       deletedCount,
-			"marker_deleted":      markerDeleted,
 			"provider_session_id": providerSessionID,
 		},
 	}, nil
-}
-
-// deleteClaudeCodeSessionFile deletes the Claude Code session file
-func (e *ResetExecutor) deleteClaudeCodeSessionFile(providerSessionID string) int {
-	if providerSessionID == "" {
-		return 0
-	}
-
-	projectsDir := filepath.Join(os.Getenv("HOME"), ".claude", "projects")
-
-	// Derive workspace directory from workDir
-	cwd := e.workDir
-	if cwd == "" {
-		var err error
-		cwd, err = os.Getwd()
-		if err != nil {
-			cwd = os.TempDir() // Fallback to temp directory
-		}
-	}
-	workspaceKey := strings.ReplaceAll(cwd, "/", "-")
-	workspaceDir := filepath.Join(projectsDir, workspaceKey)
-
-	sessionPath := filepath.Join(workspaceDir, providerSessionID+".jsonl")
-
-	if _, err := os.Stat(sessionPath); err == nil {
-		if err := os.Remove(sessionPath); err == nil {
-			return 1
-		}
-	}
-	return 0
-}
-
-// deleteHotPlexMarker deletes the HotPlex session marker file
-func (e *ResetExecutor) deleteHotPlexMarker(providerSessionID string) bool {
-	if providerSessionID == "" {
-		return false
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-
-	markerPath := filepath.Join(homeDir, ".hotplex", "sessions", providerSessionID+".lock")
-
-	if _, err := os.Stat(markerPath); err == nil {
-		if err := os.Remove(markerPath); err == nil {
-			return true
-		}
-	}
-	return false
 }

--- a/chatapps/command/reset_executor.go
+++ b/chatapps/command/reset_executor.go
@@ -49,9 +49,9 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 	// Define progress steps
 	steps := []ProgressStep{
 		{Name: "find_session", Message: "Finding session...", Status: "pending"},
-		{Name: "delete_claude", Message: "Deleting session file...", Status: "pending"},
-		{Name: "delete_marker", Message: "Deleting marker...", Status: "pending"},
 		{Name: "terminate", Message: "Terminating process...", Status: "pending"},
+		{Name: "delete_marker", Message: "Deleting marker...", Status: "pending"},
+		{Name: "delete_claude", Message: "Deleting session file...", Status: "pending"},
 	}
 
 	emitter := NewProgressEmitter(e.Command(), callback, steps)
@@ -75,11 +75,23 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 
 	_ = emitter.Success(0, "Session located")
 
-	// Step 2: Delete Claude Code session file (40%)
+	// Step 2: Terminate session FIRST (40%)
+	// This prevents race conditions where new messages could recreate the marker
 	_ = emitter.Running(1)
 
-	deletedCount := e.deleteClaudeCodeSessionFile(providerSessionID)
-	_ = emitter.Success(1, fmt.Sprintf("Deleted %d file(s)", deletedCount))
+	// Note: Adapter cleanup is handled by engine.StopSession callback
+	// Adapters will clean up their own state (aggregator buffers, etc.)
+
+	if err := e.engine.StopSession(sessionID, "user_requested_reset"); err != nil {
+		_ = emitter.Error(1, fmt.Sprintf("Failed: %v", err))
+		_ = emitter.Emit("Reset Failed")
+		return &Result{
+			Success: false,
+			Message: fmt.Sprintf("Failed to terminate session: %v", err),
+		}, nil
+	}
+
+	_ = emitter.Success(1, "Process terminated")
 
 	// Step 3: Delete HotPlex marker (60%)
 	_ = emitter.Running(2)
@@ -91,25 +103,14 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 		_ = emitter.Success(2, "Marker cleanup done")
 	}
 
-	// Step 4: Terminate session (80%)
+	// Step 4: Delete Claude Code session file (80%)
 	_ = emitter.Running(3)
 
-	// Note: Adapter cleanup is handled by engine.StopSession callback
-	// Adapters will clean up their own state (aggregator buffers, etc.)
-
-	if err := e.engine.StopSession(sessionID, "user_requested_reset"); err != nil {
-		_ = emitter.Error(3, fmt.Sprintf("Failed: %v", err))
-		_ = emitter.Emit("Reset Failed")
-		return &Result{
-			Success: false,
-			Message: fmt.Sprintf("Failed to terminate session: %v", err),
-		}, nil
-	}
-
-	_ = emitter.Success(3, "Process terminated")
-	_ = emitter.Emit("Resetting Context")
+	deletedCount := e.deleteClaudeCodeSessionFile(providerSessionID)
+	_ = emitter.Success(3, fmt.Sprintf("Deleted %d file(s)", deletedCount))
 
 	// Complete
+	_ = emitter.Emit("Resetting Context")
 	_ = emitter.Complete("Context reset. Ready for fresh start!")
 
 	return &Result{
@@ -123,7 +124,7 @@ func (e *ResetExecutor) Execute(ctx context.Context, req *Request, callback even
 	}, nil
 }
 
-// deleteClaudeCodeSessionFile renames the Claude Code session file
+// deleteClaudeCodeSessionFile deletes the Claude Code session file
 func (e *ResetExecutor) deleteClaudeCodeSessionFile(providerSessionID string) int {
 	if providerSessionID == "" {
 		return 0
@@ -144,10 +145,9 @@ func (e *ResetExecutor) deleteClaudeCodeSessionFile(providerSessionID string) in
 	workspaceDir := filepath.Join(projectsDir, workspaceKey)
 
 	sessionPath := filepath.Join(workspaceDir, providerSessionID+".jsonl")
-	deletedPath := sessionPath + ".deleted"
 
 	if _, err := os.Stat(sessionPath); err == nil {
-		if err := os.Rename(sessionPath, deletedPath); err == nil {
+		if err := os.Remove(sessionPath); err == nil {
 			return 1
 		}
 	}
@@ -166,10 +166,9 @@ func (e *ResetExecutor) deleteHotPlexMarker(providerSessionID string) bool {
 	}
 
 	markerPath := filepath.Join(homeDir, ".hotplex", "sessions", providerSessionID+".lock")
-	deletedPath := markerPath + ".deleted"
 
 	if _, err := os.Stat(markerPath); err == nil {
-		if err := os.Rename(markerPath, deletedPath); err == nil {
+		if err := os.Remove(markerPath); err == nil {
 			return true
 		}
 	}

--- a/engine/runner.go
+++ b/engine/runner.go
@@ -716,6 +716,21 @@ func (r *Engine) ResetSessionProvider(sessionID string) {
 	}
 }
 
+// CleanupSessionFiles deletes all session files associated with the provider session.
+// This handles the complete removal of context on disk for commands like /reset.
+func (r *Engine) CleanupSessionFiles(sessionID string) error {
+	if pool, ok := r.manager.(*intengine.SessionPool); ok {
+		if sess, exists := pool.GetSession(sessionID); exists {
+			// Also delete the hotplex lock/marker so it won't be resumed next time
+			if err := pool.DeleteMarker(sess.ProviderSessionID); err != nil {
+				r.logger.Warn("Failed to delete session marker", "error", err)
+			}
+			return pool.CleanupSessionFiles(sess.ProviderSessionID, sess.Config.WorkDir)
+		}
+	}
+	return nil
+}
+
 // GetSession retrieves an active session by sessionID.
 // Returns the session and true if found, or nil and false if not found.
 func (r *Engine) GetSession(sessionID string) (*intengine.Session, bool) {

--- a/internal/engine/pool.go
+++ b/internal/engine/pool.go
@@ -275,15 +275,6 @@ func (sm *SessionPool) startSession(ctx context.Context, sessionID string, cfg S
 		// For absolute paths, also clean to resolve . and .. elements
 		cmd.Dir = filepath.Clean(cfg.WorkDir)
 	}
-	if cfg.WorkDir == "." || !filepath.IsAbs(cfg.WorkDir) {
-		if absPath, err := filepath.Abs(cfg.WorkDir); err == nil {
-			cmd.Dir = absPath
-		} else {
-			cmd.Dir = cfg.WorkDir // Fallback to original if error
-		}
-	} else {
-		cmd.Dir = cfg.WorkDir
-	}
 
 	// Setup process attributes and get job handle (Windows) or zero (Unix)
 	jobHandle, err := sys.SetupCmdSysProcAttr(cmd)

--- a/internal/engine/pool.go
+++ b/internal/engine/pool.go
@@ -165,6 +165,22 @@ func (sm *SessionPool) ListActiveSessions() []*Session {
 	return list
 }
 
+// DeleteMarker removes the HotPlex session marker file, preventing future resumption.
+func (sm *SessionPool) DeleteMarker(providerSessionID string) error {
+	if providerSessionID == "" {
+		return nil
+	}
+	return sm.markerStore.Delete(providerSessionID)
+}
+
+// CleanupSessionFiles proxies the cleanup call to the underlying provider.
+func (sm *SessionPool) CleanupSessionFiles(providerSessionID string, workDir string) error {
+	if sm.provider != nil {
+		return sm.provider.CleanupSession(providerSessionID, workDir)
+	}
+	return nil
+}
+
 // cleanupSessionLocked stops the process and removes from map. Caller must hold lock.
 func (sm *SessionPool) cleanupSessionLocked(sessionID string) error {
 	sess, ok := sm.sessions[sessionID]
@@ -370,8 +386,8 @@ func (sm *SessionPool) buildCLIArgs(providerSessionID string, sessLog *slog.Logg
 		// This prevents "Session ID is already in use" errors when:
 		// - /reset deleted the marker but not the CLI session file (old bug)
 		// - Daemon restart with stale CLI session files on disk
-		if err := sm.deleteCLISessionFile(providerSessionID, cfg.WorkDir); err != nil {
-			sessLog.Debug("Cleaned up stale CLI session file", "error", err)
+		if err := sm.provider.CleanupSession(providerSessionID, cfg.WorkDir); err != nil {
+			sessLog.Warn("Failed to cleanup stale CLI session file", "error", err)
 		}
 
 		_ = sm.markerStore.Create(providerSessionID)
@@ -379,37 +395,6 @@ func (sm *SessionPool) buildCLIArgs(providerSessionID string, sessLog *slog.Logg
 	}
 
 	return sm.provider.BuildCLIArgs(providerSessionID, opts)
-}
-
-// deleteCLISessionFile deletes the CLI session file from disk.
-// This is necessary when starting a fresh session to prevent "Session ID is already in use" errors
-// from CLI providers that check for existing session files on disk.
-func (sm *SessionPool) deleteCLISessionFile(providerSessionID string, workDir string) error {
-	if providerSessionID == "" {
-		return nil
-	}
-
-	// Derive workspace directory from workDir
-	cwd := workDir
-	if cwd == "" {
-		var err error
-		cwd, err = os.Getwd()
-		if err != nil {
-			cwd = os.TempDir()
-		}
-	}
-
-	// Claude Code stores sessions in ~/.claude/projects/<workspace-key>/<session-id>.jsonl
-	projectsDir := filepath.Join(os.Getenv("HOME"), ".claude", "projects")
-	workspaceKey := strings.ReplaceAll(cwd, "/", "-")
-	sessionPath := filepath.Join(projectsDir, workspaceKey, providerSessionID+".jsonl")
-
-	// Best effort deletion - ignore errors if file doesn't exist
-	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove CLI session file: %w", err)
-	}
-
-	return nil
 }
 
 func setupCmdPipes(cmd *exec.Cmd) (io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {

--- a/internal/engine/pool.go
+++ b/internal/engine/pool.go
@@ -237,7 +237,7 @@ func (sm *SessionPool) startSession(ctx context.Context, sessionID string, cfg S
 		"provider_session_id", providerSessionID,
 	)
 
-	args := sm.buildCLIArgs(providerSessionID, sessLog, prompt, cfg.TaskInstructions)
+	args := sm.buildCLIArgs(providerSessionID, sessLog, prompt, cfg)
 	cmd := exec.CommandContext(sessCtx, sm.cliPath, args...)
 
 	// Clear CLAUDECODE env var to allow nested CLI sessions
@@ -345,14 +345,15 @@ func (sm *SessionPool) startSession(ctx context.Context, sessionID string, cfg S
 	return sess, nil
 }
 
-func (sm *SessionPool) buildCLIArgs(providerSessionID string, sessLog *slog.Logger, prompt string, taskInstructions string) []string {
+func (sm *SessionPool) buildCLIArgs(providerSessionID string, sessLog *slog.Logger, prompt string, cfg SessionConfig) []string {
 	// Build ProviderSessionOptions
 	opts := &provider.ProviderSessionOptions{
+		WorkDir:          cfg.WorkDir,
 		PermissionMode:   sm.opts.PermissionMode,
 		AllowedTools:     sm.opts.AllowedTools,
 		DisallowedTools:  sm.opts.DisallowedTools,
 		BaseSystemPrompt: sm.opts.BaseSystemPrompt,
-		TaskInstructions: taskInstructions,
+		TaskInstructions: cfg.TaskInstructions,
 		InitialPrompt:    prompt,
 		SessionID:        providerSessionID,
 	}
@@ -364,11 +365,51 @@ func (sm *SessionPool) buildCLIArgs(providerSessionID string, sessLog *slog.Logg
 		sessLog.Info("Resuming existing persistent CLI session")
 	} else {
 		opts.ProviderSessionID = providerSessionID
+
+		// Critical: Delete stale CLI session file before creating new marker
+		// This prevents "Session ID is already in use" errors when:
+		// - /reset deleted the marker but not the CLI session file (old bug)
+		// - Daemon restart with stale CLI session files on disk
+		if err := sm.deleteCLISessionFile(providerSessionID, cfg.WorkDir); err != nil {
+			sessLog.Debug("Cleaned up stale CLI session file", "error", err)
+		}
+
 		_ = sm.markerStore.Create(providerSessionID)
 		sessLog.Info("Creating new persistent CLI session")
 	}
 
 	return sm.provider.BuildCLIArgs(providerSessionID, opts)
+}
+
+// deleteCLISessionFile deletes the CLI session file from disk.
+// This is necessary when starting a fresh session to prevent "Session ID is already in use" errors
+// from CLI providers that check for existing session files on disk.
+func (sm *SessionPool) deleteCLISessionFile(providerSessionID string, workDir string) error {
+	if providerSessionID == "" {
+		return nil
+	}
+
+	// Derive workspace directory from workDir
+	cwd := workDir
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			cwd = os.TempDir()
+		}
+	}
+
+	// Claude Code stores sessions in ~/.claude/projects/<workspace-key>/<session-id>.jsonl
+	projectsDir := filepath.Join(os.Getenv("HOME"), ".claude", "projects")
+	workspaceKey := strings.ReplaceAll(cwd, "/", "-")
+	sessionPath := filepath.Join(projectsDir, workspaceKey, providerSessionID+".jsonl")
+
+	// Best effort deletion - ignore errors if file doesn't exist
+	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove CLI session file: %w", err)
+	}
+
+	return nil
 }
 
 func setupCmdPipes(cmd *exec.Cmd) (io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {

--- a/internal/engine/pool_test.go
+++ b/internal/engine/pool_test.go
@@ -138,7 +138,10 @@ func TestSessionPool_buildCLIArgs(t *testing.T) {
 		BaseSystemPrompt: "You are helpful",
 	}, "/tmp/claude", prv)
 
-	args := pool.buildCLIArgs("test-session-id", logger, "unit test prompt", "unit test instructions")
+	args := pool.buildCLIArgs("test-session-id", logger, "unit test prompt", SessionConfig{
+		TaskInstructions: "unit test instructions",
+		WorkDir:          "/tmp/test",
+	})
 
 	// Check essential args
 	if !containsInSlice(args, "--print") {
@@ -180,7 +183,7 @@ func TestSessionPool_buildCLIArgs_Resume(t *testing.T) {
 	}
 	defer func() { _ = pool.markerStore.Delete("existing-session") }()
 
-	args := pool.buildCLIArgs("existing-session", logger, "unit test resume prompt", "")
+	args := pool.buildCLIArgs("existing-session", logger, "unit test resume prompt", SessionConfig{})
 
 	// Should have --resume for existing sessions
 	if !containsInSlice(args, "--resume") {
@@ -227,7 +230,7 @@ func TestStartSession_ResolvesRelativeWorkDir(t *testing.T) {
 			sessCtx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			args := pool.buildCLIArgs("test-session", logger, "test", "")
+			args := pool.buildCLIArgs("test-session", logger, "test", SessionConfig{WorkDir: tc.workDir})
 			cmd := exec.CommandContext(sessCtx, "/tmp/claude", args...)
 
 			// Apply the same path resolution logic as in startSession

--- a/internal/engine/workdir_integration_test.go
+++ b/internal/engine/workdir_integration_test.go
@@ -108,7 +108,7 @@ func TestChatAppsWorkDirFunction(t *testing.T) {
 		t.Fatalf("Failed to get current working directory: %v", err)
 	}
 
-	workDirFn := func(sessionID string, configWorkDir string) string {
+	workDirFn := func(configWorkDir string) string {
 		if configWorkDir != "" {
 			workDir := expandPathFixed(configWorkDir)
 			return workDir
@@ -129,7 +129,7 @@ func TestChatAppsWorkDirFunction(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			workDir := workDirFn("test-session", tc.configWorkDir)
+			workDir := workDirFn(tc.configWorkDir)
 
 			if workDir != tc.expectedWorkDir {
 				t.Errorf("workDirFn(%q) = %q, want %q", tc.configWorkDir, workDir, tc.expectedWorkDir)

--- a/provider/claude_provider.go
+++ b/provider/claude_provider.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -430,6 +432,37 @@ func (p *ClaudeCodeProvider) ValidateBinary() (string, error) {
 // GetMarkerDir returns the session marker directory path.
 func (p *ClaudeCodeProvider) GetMarkerDir() string {
 	return p.markerStore.Dir()
+}
+
+// CleanupSession overrides ProviderBase to delete Claude Code's project session file.
+// This is necessary when starting a fresh session to prevent "Session ID is already in use" errors
+// or when executing a /reset command to completely scrub the context.
+func (p *ClaudeCodeProvider) CleanupSession(providerSessionID string, workDir string) error {
+	if providerSessionID == "" {
+		return nil
+	}
+
+	cwd := workDir
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			cwd = os.TempDir()
+		}
+	}
+
+	// Claude Code stores sessions in ~/.claude/projects/<workspace-key>/<providerSessionID>.jsonl
+	projectsDir := filepath.Join(os.Getenv("HOME"), ".claude", "projects")
+	workspaceKey := strings.ReplaceAll(cwd, "/", "-")
+	sessionPath := filepath.Join(projectsDir, workspaceKey, providerSessionID+".jsonl")
+
+	// Best effort deletion
+	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove Claude Code session file: %w", err)
+	}
+
+	p.logger.Debug("Cleaned up Claude Code session file", "path", sessionPath)
+	return nil
 }
 
 // CheckSessionMarker checks if a session marker exists for the given ID.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -58,6 +58,9 @@ type Provider interface {
 	// ValidateBinary checks if the CLI binary is available and returns its path.
 	ValidateBinary() (string, error)
 
+	// CleanupSession cleans up provider-specific session files from disk (e.g. for /reset).
+	CleanupSession(providerSessionID string, workDir string) error
+
 	// Name returns the provider name for logging and identification.
 	Name() string
 }
@@ -215,4 +218,10 @@ func (p *ProviderBase) ValidateBinary() (string, error) {
 		return p.binaryPath, nil
 	}
 	return exec.LookPath(p.meta.BinaryName)
+}
+
+// CleanupSession provides a default no-op implementation for cleaning up session files.
+// Providers that store session files on disk (like Claude Code) should override this.
+func (p *ProviderBase) CleanupSession(providerSessionID string, workDir string) error {
+	return nil
 }

--- a/scripts/test_claude_reset.py
+++ b/scripts/test_claude_reset.py
@@ -37,7 +37,6 @@ print("\n=== Comparison ===")
 print("""
 | Command | Session File | Marker | Process | Next Message |
 |---------|-------------|--------|---------|--------------|
-| Normal  | Keep        | Keep   | Keep    | Resume       |
 | /dc     | Keep        | Keep   | Kill    | Resume       |
 | /reset  | DELETE      | DELETE | Kill    | COLD START   |
 """)


### PR DESCRIPTION
## Summary

- Fix race condition in `/reset` by terminating process first
- Delete stale CLI session files to prevent "Session ID is already in use" errors
- Consolidate session cleanup into unified Engine API
- Add v0.17.0 changelog entries

Resolves #128
Refs #145

## Test plan

- [x] `go test -short ./...` passes
- [x] `go build ./cmd/hotplexd` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)