### PR TITLE
docs(feishu): 配置文件完善 (#134 followup)

### DIFF
--- a/chatapps/configs/feishu.env.example
+++ b/chatapps/configs/feishu.env.example
@@ -1,0 +1,63 @@
+# HotPlex Feishu Adapter Environment Variables
+# Copy this file to .env and fill in your actual values
+# 
+# Setup Guide: docs/chatapps/chatapps-feishu-manual.md
+
+# =============================================================================
+# Required: Feishu Application Credentials
+# =============================================================================
+# Obtain from: https://open.feishu.cn/app → Your App → Credentials
+
+# App ID (format: cli_xxxxxxxxxxxxx)
+FEISHU_APP_ID=cli_a1b2c3d4e5f6g7h8
+
+# App Secret (from App Credentials page)
+FEISHU_APP_SECRET=your_app_secret_here
+
+# Verification Token (from Event Subscription page)
+FEISHU_VERIFICATION_TOKEN=your_verification_token_here
+
+# Encrypt Key (from Event Subscription page - REQUIRED for message encryption)
+FEISHU_ENCRYPT_KEY=your_encrypt_key_here
+
+# =============================================================================
+# Optional: Server Configuration
+# =============================================================================
+
+# HTTP server listen address (default: :8082)
+FEISHU_SERVER_ADDR=:8082
+
+# Max message length in bytes (default: 4096, Feishu limit)
+FEISHU_MAX_MESSAGE_LEN=4096
+
+# =============================================================================
+# Development: Local Testing with ngrok
+# =============================================================================
+# For local development, use ngrok to expose your local server:
+#
+# 1. Start HotPlex:
+#    hotplex serve --config chatapps/configs/feishu.yaml
+#
+# 2. In another terminal, start ngrok:
+#    ngrok http 8082
+#
+# 3. Copy the ngrok URL to Feishu Developer Console:
+#    https://xxxx.ngrok.io/feishu/events
+#
+# Note: Feishu requires HTTPS, ngrok provides this automatically
+
+# =============================================================================
+# Production: Environment Variables
+# =============================================================================
+# For production deployment, set these in your environment:
+#
+# Docker:
+#   docker run -e FEISHU_APP_ID=xxx -e FEISHU_APP_SECRET=xxx ...
+#
+# Kubernetes:
+#   Use Secrets to store credentials
+#
+# Linux/Mac:
+#   export FEISHU_APP_ID=cli_xxx
+#   export FEISHU_APP_SECRET=xxx
+#   ...

--- a/chatapps/configs/feishu.env.example
+++ b/chatapps/configs/feishu.env.example
@@ -1,30 +1,38 @@
+# =============================================================================
 # HotPlex Feishu Adapter Environment Variables
+# =============================================================================
 # Copy this file to .env and fill in your actual values
 # 
 # Setup Guide: docs/chatapps/chatapps-feishu-manual.md
+# Config File: chatapps/configs/feishu.yaml
 
 # =============================================================================
-# Required: Feishu Application Credentials
+# [Required] Feishu Application Credentials
 # =============================================================================
 # Obtain from: https://open.feishu.cn/app → Your App → Credentials
 
 # App ID (format: cli_xxxxxxxxxxxxx)
+# Location: 应用凭证 → App ID
 FEISHU_APP_ID=cli_a1b2c3d4e5f6g7h8
 
 # App Secret (from App Credentials page)
+# Location: 应用凭证 → App Secret
 FEISHU_APP_SECRET=your_app_secret_here
 
 # Verification Token (from Event Subscription page)
+# Location: 事件订阅 → Verification Token
 FEISHU_VERIFICATION_TOKEN=your_verification_token_here
 
 # Encrypt Key (from Event Subscription page - REQUIRED for message encryption)
+# Location: 事件订阅 → Encrypt Key
 FEISHU_ENCRYPT_KEY=your_encrypt_key_here
 
 # =============================================================================
-# Optional: Server Configuration
+# [Optional] Server Configuration
 # =============================================================================
 
 # HTTP server listen address (default: :8082)
+# Used for: Webhook events from Feishu
 FEISHU_SERVER_ADDR=:8082
 
 # Max message length in bytes (default: 4096, Feishu limit)

--- a/chatapps/configs/feishu.yaml
+++ b/chatapps/configs/feishu.yaml
@@ -1,0 +1,147 @@
+# =============================================================================
+# HotPlex Feishu (Lark) Adapter Configuration
+# =============================================================================
+# Detailed Setup Guide: docs/chatapps/chatapps-feishu-manual.md
+
+# [Required] Platform identifier
+platform: feishu
+
+# -----------------------------------------------------------------------------
+# AI Provider Settings
+# -----------------------------------------------------------------------------
+provider:
+  type: claude-code                # AI backend: claude-code or opencode
+  default_model: sonnet            # Model: sonnet, haiku, opus
+  default_permission_mode: bypass-permissions # bypass-permissions or ask
+
+# -----------------------------------------------------------------------------
+# Workspace & Engine Settings
+# -----------------------------------------------------------------------------
+engine:
+  work_dir: ~/.feishu/BOT_cli_a1b2c3d4/hotplex  # Agent's working directory
+  # timeout: 30m                                # Max wait for AI response
+  # idle_timeout: 30m                           # Session persistence time
+
+# -----------------------------------------------------------------------------
+# Connection Settings
+# -----------------------------------------------------------------------------
+# Feishu only supports HTTP Webhook mode (no Socket Mode like Slack)
+# For local development, use ngrok/cloudflared to expose local server
+mode: http
+
+# HTTP server address (Webhook events)
+server_addr: ${FEISHU_SERVER_ADDR:-:8082}
+
+# -----------------------------------------------------------------------------
+# Feishu API Credentials (Required)
+# -----------------------------------------------------------------------------
+# Obtain from Feishu Developer Console: https://open.feishu.cn/app
+credentials:
+  app_id: ${FEISHU_APP_ID}                    # App ID (cli_xxxxxxxxxxxxx)
+  app_secret: ${FEISHU_APP_SECRET}            # App Secret
+  verification_token: ${FEISHU_VERIFICATION_TOKEN}  # Event Subscription Token
+  encrypt_key: ${FEISHU_ENCRYPT_KEY}          # Message Encryption Key
+
+# -----------------------------------------------------------------------------
+# AI Identity & Behavior
+# -----------------------------------------------------------------------------
+system_prompt: |
+  You are HotPlex AI, an expert software engineer in a Feishu conversation.
+
+  ## Environment
+  - Running under HotPlex engine (stdin/stdout)
+  - Headless mode - cannot prompt for user input
+
+  ## Feishu Context
+  - Replies go to thread automatically
+  - Keep answers concise - user expects quick responses
+
+  ## Output
+  - Be concise - short messages preferred
+  - Use bullet lists over paragraphs
+  - Use code blocks for code snippets
+  - Avoid tables - use lists instead
+
+task_instructions: |
+  1. Understand before acting
+  2. Avoid operations requiring user input
+  3. Summarize tool output - don't dump raw data
+  4. Write detailed content to docs/ directory
+
+# -----------------------------------------------------------------------------
+# Feature Toggles
+# -----------------------------------------------------------------------------
+features:
+  # Split messages > 4096 chars (Feishu limit)
+  chunking:
+    enabled: true
+    max_chars: 4096
+    
+  # Reply in threads to keep channels clean
+  threading:
+    enabled: true
+
+  # Auto-retry on Feishu API rate limits (HTTP 429)
+  rate_limit:
+    enabled: true
+    max_attempts: 3
+    base_delay_ms: 500
+    max_delay_ms: 5000
+
+  # Convert standard Markdown to Feishu card format
+  markdown:
+    enabled: true
+
+  # Interactive card features
+  cards:
+    enabled: true
+    # Card types: thinking, tool_use, answer, error, session_stats
+    templates:
+      - thinking
+      - tool_use
+      - answer
+      - error
+      - session_stats
+
+# -----------------------------------------------------------------------------
+# Security & Access Control
+# -----------------------------------------------------------------------------
+security:
+  # Verify Feishu request signatures (mandatory)
+  verify_signature: true
+
+  # User & Group Permissions
+  permission:
+    # DM Policy: "allow" (all), "pairing" (active users only), "block"
+    dm_policy: allow
+    
+    # Group Policy: "allow" (all), "mention" (only when @bot), "block"
+    group_policy: allow
+    
+    # Whitelist/Blacklist (Leave empty to skip)
+    allowed_users: []      # Example: ["ou_12345", "ou_67890"]
+    blocked_users: []
+    
+    # Slash Command rate limit (requests per second per user)
+    # Default: 10.0
+    slash_command_rate_limit: 10.0
+
+# -----------------------------------------------------------------------------
+# Session Lifecycle
+# -----------------------------------------------------------------------------
+session:
+  timeout_minutes: 30            # Minutes of inactivity before cleanup
+  cleanup_interval_minutes: 5    # Frequency of scanning for expired sessions
+
+# -----------------------------------------------------------------------------
+# Advanced Settings (Optional)
+# -----------------------------------------------------------------------------
+# Max message length in bytes (Feishu default: 4096)
+# max_message_len: 4096
+
+# Command rate limit configuration
+# command_rate_limit: 10.0       # Requests per second
+# command_rate_burst: 20         # Burst capacity
+
+# Custom system prompt for specific use cases
+# custom_system_prompt: ""


### PR DESCRIPTION
## 📋 概述

完善飞书适配器配置文件，确保与 Slack 配置结构完全一致。

### 配置对比

| 配置项 | slack.yaml | feishu.yaml | 状态 |
|--------|------------|-------------|------|
| **platform** | slack | feishu | ✅ |
| **provider** | type/model/permission_mode | type/model/permission_mode | ✅ |
| **engine.work_dir** | ~/.slack/BOT_xxx/hotplex | ~/.feishu/BOT_cli_xxx/hotplex | ✅ |
| **mode** | socket/http | http (飞书仅支持 Webhook) | ✅ |
| **server_addr** | :8080 | :8082 | ✅ |
| **credentials** | (Slack 用环境变量) | app_id/app_secret/verification_token/encrypt_key | ✅ |
| **system_prompt** | 完整多行 | 完整多行 | ✅ |
| **task_instructions** | ✅ | ✅ | ✅ |
| **features.chunking** | max_chars: 4000 | max_chars: 4096 | ✅ |
| **features.threading** | ✅ | ✅ | ✅ |
| **features.rate_limit** | ✅ | ✅ | ✅ |
| **features.markdown** | ✅ | ✅ | ✅ |
| **features.cards** | (Slack 用 Blocks) | (飞书互动卡片) | ✅ |
| **security.verify_signature** | ✅ | ✅ | ✅ |
| **security.permission** | dm_policy/group_policy/bot_user_id | dm_policy/group_policy | ✅ |
| **session** | timeout/cleanup_interval | timeout/cleanup_interval | ✅ |

### feishu.yaml 核心配置

- AI Provider: type/model/default_permission_mode
- Engine: work_dir
- AI 行为：system_prompt + task_instructions
- 功能开关：chunking/threading/rate_limit/markdown/cards
- 安全控制：verify_signature/permission
- 会话管理：timeout/cleanup_interval

---

## 🔗 关联 Issue

- Closes #134 (Phase 3 生产就绪 - 配置文件)

---

**分支**: feat/168-feishu-config-fix