### PR TITLE
fix(slack): resolve native streaming invalid_arguments error (#150)

### DIFF
--- a/chatapps/engine_handler.go
+++ b/chatapps/engine_handler.go
@@ -920,14 +920,16 @@ func (c *StreamCallback) handleAnswer(data any) error {
 	if active && writer != nil {
 		_, err := writer.Write([]byte(content))
 		if err != nil {
-			c.logger.Warn("Failed to write to stream", "error", err)
+			c.logger.Warn("Failed to write to stream, falling back to legacy streaming", "error", err)
+			// Fall through to legacy streaming path - do NOT clear session state here
+		} else {
+			// Clear processor session state only on successful answer
+			c.processor.ResetSession(c.platform, c.sessionID)
+			return nil
 		}
-		// Clear processor session state on successful answer
-		c.processor.ResetSession(c.platform, c.sessionID)
-		return nil
 	}
 
-	// Fallback to legacy throttled streaming update
+	// Fallback to legacy throttled streaming update (also used when native streaming fails)
 	msg := &base.ChatMessage{
 		Type:    base.MessageTypeAnswer,
 		Content: content,

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -1823,10 +1823,14 @@ func (a *Adapter) StartStream(ctx context.Context, channelID, threadTS string) (
 		return "", fmt.Errorf("slack client not initialized")
 	}
 
-	// Start streaming message (empty content to begin)
-	_, ts, err := a.client.StartStreamContext(ctx, channelID,
-		slack.MsgOptionText("", false),
-	)
+	// Build message options with thread support
+	options := []slack.MsgOption{slack.MsgOptionText("", false)}
+	if threadTS != "" {
+		options = append(options, slack.MsgOptionTS(threadTS))
+	}
+
+	// Start streaming message
+	_, ts, err := a.client.StartStreamContext(ctx, channelID, options...)
 	if err != nil {
 		return "", fmt.Errorf("start stream: %w", err)
 	}


### PR DESCRIPTION
## 🐛 Bug Fix

修复 Slack 原生流式消息在 Thread 中启动失败的 `invalid_arguments` 错误。

---

## 问题描述

运行时日志显示流式写入失败：
```
level=WARN source=chatapps/engine_handler.go:923 
msg="Failed to write to stream" 
error="start stream: start stream: invalid_arguments"
```

**根本原因：**
1. `StartStream` 方法接收 `threadTS` 参数但从未使用
2. `StartStreamContext` 调用缺少 `MsgOptionTS(threadTS)`，导致在 Thread 中启动流式时 Slack API 拒绝请求
3. 错误处理策略不当：流式失败后仍清除会话状态

---

## 修复内容

### 1. 添加 ThreadTS 支持

**文件：** `chatapps/slack/adapter.go`

```go
// Build message options with thread support
options := []slack.MsgOption{slack.MsgOptionText("", false)}
if threadTS != "" {
    options = append(options, slack.MsgOptionTS(threadTS))
}

// Start streaming message
_, ts, err := a.client.StartStreamContext(ctx, channelID, options...)
```

### 2. 改进错误处理策略

**文件：** `chatapps/engine_handler.go`

- 流式失败时 fallback 到旧版流式，而非直接清除状态
- 仅在成功时才调用 `ResetSession()`

---

## 测试

- [x] `go test -race ./chatapps/slack/...` 通过
- [x] `go build ./chatapps/...` 编译成功
- [ ] 手动验证：在 Slack Thread 中测试流式输出

---

## 影响

- 修复后流式消息将正确在 Thread 内启动
- 用户体验从 ~500ms 批量推送恢复为实时流式
- 错误场景下优雅降级到旧版流式

---

Closes #150