### PR TITLE
fix(ci): add Dockerfile.release for GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ dockers:
   - image_templates:
       - ghcr.io/hrygo/hotplex:{{ .Version }}
       - ghcr.io/hrygo/hotplex:latest
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.release
     build_flag_templates:
       - --build-arg=VERSION={{ .Version }}
       - --build-arg=HOST_UID=1000

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,94 @@
+# ============================================
+# HotPlex Release Image (for GoReleaser)
+# ============================================
+# This Dockerfile is used by GoReleaser which provides
+# pre-built binaries. Use Dockerfile for local builds.
+# ============================================
+
+FROM golang:1.25-alpine
+
+WORKDIR /app
+
+# Install complete development toolchain
+RUN apk add --no-cache \
+    # Version control
+    git \
+    github-cli \
+    # Build tools
+    make \
+    bash \
+    # Modern file tools (Claude Code recommended)
+    ripgrep \
+    fd \
+    bat \
+    fzf \
+    eza \
+    # Network debugging (essential for WebSocket Gateway)
+    curl \
+    jq \
+    wget \
+    netcat-openbsd \
+    openssl \
+    # Node.js (for Claude Code)
+    nodejs \
+    npm \
+    # Code quality
+    golangci-lint \
+    # Process management
+    procps \
+    htop \
+    # Config processing
+    yq \
+    # Script runtime
+    python3 \
+    # Editor
+    vim \
+    # Timezone support
+    tzdata \
+    # Archive tools
+    zip \
+    # Runtime deps
+    ca-certificates
+
+# Install Go tools
+RUN go install github.com/air-verse/air@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Install websocat (WebSocket client for debugging)
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; \
+    elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; fi && \
+    wget -qO /usr/local/bin/websocat \
+    "https://github.com/vi/websocat/releases/download/v1.14.1/websocat.${ARCH}-unknown-linux-musl" && \
+    chmod +x /usr/local/bin/websocat
+
+# Install Claude Code
+RUN npm install -g @anthropic-ai/claude-code@latest
+
+# Copy pre-built binary from GoReleaser
+COPY hotplexd /app/hotplexd
+RUN chmod +x /app/hotplexd
+
+# Verify installations
+RUN go version && \
+    gh --version && \
+    websocat --version && \
+    nc -h 2>&1 | head -1 && \
+    openssl version && \
+    claude --version || claude-code --version
+
+# Create user with Go environment in home directory
+ARG HOST_UID=1000
+RUN adduser -D -u ${HOST_UID} hotplex && \
+    mkdir -p /home/hotplex/go/pkg/mod /home/hotplex/.cache/go-build && \
+    chown -R hotplex:hotplex /home/hotplex
+
+# Set up Go environment for hotplex user
+ENV GOPATH=/home/hotplex/go
+ENV GOCACHE=/home/hotplex/.cache/go-build
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+USER hotplex
+
+EXPOSE 8080
+ENTRYPOINT ["/app/hotplexd"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile.release` for GoReleaser CI builds
- Uses pre-built binary instead of building from source
- Fixes "go.mod not found" error in release workflow

## Test plan
- [ ] Merge this PR
- [ ] Delete and re-create tag v0.20.0
- [ ] Verify release workflow succeeds

Resolves #201