### PR TITLE
feat(provider): add pi-mono Provider support

### DIFF
--- a/docs/providers/pi.md
+++ b/docs/providers/pi.md
@@ -1,0 +1,264 @@
+# Pi Provider (pi-coding-agent)
+
+This document describes the pi Provider integration for HotPlex, a including installation, configuration, and usage examples.
+
+## Overview
+
+Pi is a minimal terminal coding harness developed by Mario Zechner (@badlogic). It supports 15+ LLM providers through a unified API.
+
+Key features:
+- Multi-provider support (Anthropic, OpenAI, Google, Mistral, Groq, Cerebras, xAI, OpenRouter, etc.)
+- JSON mode for structured output
+- RPC mode for process integration
+- Session management with JSONL storage
+- Interactive coding agent capabilities
+
+## Installation
+
+```bash
+# Install globally via npm
+npm install -g @mariozechner/pi-coding-agent
+
+# Verify installation
+pi --version
+```
+
+Or install a specific version:
+```bash
+npm install -g @mariozechner/pi-coding-agent@<version>
+```
+
+## Configuration
+
+### HotPlex Configuration
+
+Add to your `hotplex.yaml` provider configuration:
+
+```yaml
+providers:
+  pi:
+    enabled: true
+    type: pi
+    # Optional: custom binary path
+    # binary_path: /usr/local/bin/pi
+    # Optional: default model
+    default_model: claude-sonnet-4-20250514
+    # Provider-specific options
+    pi:
+      provider: anthropic    # LLM provider (anthropic, openai, google, etc.)
+      model: claude-sonnet-4-20250514  # Model ID or pattern
+      thinking: high              # Thinking level: off, minimal, low, medium, high, xhigh
+      use_rpc: false            # Use RPC mode for stdin/stdout integration
+      session_dir: ""           # Custom session storage directory
+      no_session: false         # Ephemeral mode (don't save session)
+```
+
+### Environment Variables
+
+Set the following environment variables based on your chosen provider:
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Required for Anthropic |
+| `OPENAI_API_KEY` | Required for OpenAI |
+| `GOOGLE_API_KEY` | Required for Google |
+| `MISTRAL_API_KEY` | Required for Mistral |
+| `GROQ_API_KEY` | Required for Groq |
+| `CEREBRAS_API_KEY` | Required for Cerebras |
+| `XAI_API_KEY` | Required for xAI |
+| `OPENROUTER_API_KEY` | Required for OpenRouter |
+
+## Event Types
+
+Pi outputs events in JSON Lines format
+
+### Session Events
+
+```json
+{"type":"session","version":3,"id":"uuid","timestamp":"...","cwd":"/path"}
+```
+
+### Agent Events
+```json
+{"type":"agent_start"}
+{"type":"agent_end","messages":[...]}
+```
+
+### Turn Events
+```json
+{"type":"turn_start"}
+{"type":"turn_end","message":{...},"toolResults":[...]}
+```
+
+### Message Events
+```json
+{"type":"message_start","message":{...}}
+{"type":"message_update","message":{...},"assistantMessageEvent":{...}}
+{"type":"message_end","message":{...}}
+```
+
+### Tool Events
+```json
+{"type":"tool_execution_start","toolCallId":"id","toolName":"name","args":{...}}
+{"type":"tool_execution_end","toolCallId":"id","toolName":"name","result":...,"isError":false}
+```
+
+## CLI Arguments
+
+Pi supports the following CLI arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--mode json` | Output events as JSON lines (required for HotPlex) |
+| `--provider <name>` | LLM provider to use |
+| `--model <pattern>` | Model ID or pattern (supports provider/id format) |
+| `--thinking <level>` | Thinking level |
+| `--session <id>` | Resume session |
+| `--session-dir <dir>` | Custom session directory |
+| `--no-session` | Ephemeral mode |
+| `--continue` | Continue most recent session |
+| `--resume` | Browse and select session |
+
+## Usage Examples
+
+### Basic Usage
+
+```go
+cfg := &config.ProviderConfig{
+    Type:    provider.ProviderTypePi,
+    Enabled: true,
+    Pi: &provider.PiConfig{
+        Provider: "anthropic",
+        Model:    "claude-sonnet-4-20250514",
+    },
+}
+
+provider, err := provider.NewPiProvider(cfg, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+args := provider.BuildCLIArgs("session-id", &provider.ProviderSessionOptions{
+    InitialPrompt: "Hello, pi!",
+})
+fmt.Println(args)
+// Output: [--mode json --provider anthropic --model claude-sonnet-4-20250514 Hello, pi!]
+```
+
+### With RPC Mode
+
+```go
+cfg.Pi.UseRPC = true
+args := provider.BuildCLIArgs("", nil)
+// Output: [--mode json --no-session]
+```
+
+### Event Parsing
+
+```go
+events, err := provider.ParseEvent(`{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]}}`)
+for _, event := range events {
+    fmt.Printf("Event type: %s, Content: %s\n", event.Type, "answer"
+    }
+}
+```
+
+## Supported Providers
+
+Pi supports the following LLM providers
+
+| Provider | API Key | Models |
+|----------|---------|------|
+| Anthropic | `ANTHROPIC_API_KEY` | claude-sonnet-4-20250514, claude-opus-4-6, claude-3-5-sonnet-4-20250514 |
+| OpenAI | `OPENAI_API_KEY` | gpt-4o, gpt-4.1-turbo, gpt-4o-mini |
+| Google | `GOOGLE_API_KEY` | gemini-2.5-pro, gemini-2.0-flash-exp |
+| Mistral | `MISTRAL_API_KEY` | mistral-large-latest |
+| Groq | `GROQ_API_KEY` | llama-3.3-70b, mixtral-8x7b |
+| Cerebras | `CEREBRAS_API_KEY` | llama-3.3-70b |
+| xAI | `XAI_API_KEY` | grok-2-latest |
+| OpenRouter | `OPENROUTER_API_KEY` | (various models) |
+
+| Kimi | `KIMI_API_KEY` | (various models) |
+
+## Troubleshooting
+
+### Binary Not Found
+
+```bash
+# Install pi CLI
+npm install -g @mariozechner/pi-coding-agent
+```
+
+### Invalid Thinking Level
+
+Check configuration
+
+```yaml
+pi:
+  thinking: invalid-level  # Error: invalid thinking level: invalid-level
+```
+
+### Session Not Resuming
+Ensure session ID is valid
+
+```yaml
+pi:
+  session_dir: /nonexistent/path
+```
+
+## Architecture
+
+The Pi Provider follows the same Strategy Pattern as other HotPlex providers
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         HotPlex Architecture                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    │
+│  │   Slack    │    │  Telegram  │    │  DingTalk  │    │   Discord  │    │
+│  │  Adapter   │    │   Adapter  │    │   Adapter  │    │   Adapter  │    │
+│  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘    └──────┬──────┘    │
+│         │                   │                   │                   │                   │           │
+│         └───────────────────┴───────────────────┴───────────────────┘           │
+│                                       │                                         │
+│                                       ▼                                         │
+│                        ┌──────────────────────────┐                              │
+│                        │   ChatApps EngineHandler │                              │
+│                        └────────────┬─────────────┘                              │
+│                                     │                                           │
+│                                     ▼                                           │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                         Provider Layer (Strategy Pattern)                 │  │
+│  │  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐             │  │
+│  │  │ Claude Code   │  │   OpenCode     │  │   pi-mono      │             │  │
+│  │  │   Provider    │  │    Provider    │  │   Provider     │             │  │
+│  │  │ (claude CLI) │  │ (opencode CLI) │  │ (pi CLI/npm)   │             │  │
+│  │  └───────┬────────┘  └───────┬────────┘  └───────┬────────┘    │  │
+│  │          │                   │                   │                   │                       │  │
+│  │          └───────────────────┴───────────────────┘                       │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                     │                                             │
+│                                 │                                               │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                         HotPlex Engine                                   │  │
+│  │  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐            │  │
+│  │  │ Session Pool  │  │   I/O Mux      │  │  Event Parser  │            │  │
+│  │  └────────────────┘  └────────────────┘  └────────────────┘            │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Integration Testing
+
+For integration tests with actual pi CLI, set the environment variable and run:
+
+```bash
+# Skip tests that require pi CLI
+go test -v -short ./...
+```
+
+## Resources
+
+- [pi-mono Repository](https://github.com/badlogic/pi-mono)
+- [pi-coding-agent Documentation](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)
+- [JSON Mode Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/json.md)

--- a/provider/factory.go
+++ b/provider/factory.go
@@ -50,6 +50,10 @@ func NewProviderFactory(logger *slog.Logger) *ProviderFactory {
 		return NewOpenCodeProvider(cfg, logger)
 	})
 
+	f.Register(ProviderTypePi, func(cfg ProviderConfig, logger *slog.Logger) (Provider, error) {
+		return NewPiProvider(cfg, logger)
+	})
+
 	return f
 }
 
@@ -277,6 +281,9 @@ func MergeProviderConfigs(base, overlay ProviderConfig) ProviderConfig {
 	}
 	if overlay.OpenCode != nil {
 		result.OpenCode = overlay.OpenCode
+	}
+	if overlay.Pi != nil {
+		result.Pi = overlay.Pi
 	}
 
 	return result

--- a/provider/pi_provider.go
+++ b/provider/pi_provider.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -590,7 +591,7 @@ func (p *PiProvider) CleanupSession(providerSessionID string, workDir string) er
 
 	// Pi stores sessions in ~/.pi/agent/sessions/
 	// Session files are named with timestamp and UUID
-	homeDir, err := filepath.Abs("~")
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("get home directory: %w", err)
 	}
@@ -619,5 +620,5 @@ func (p *PiProvider) CleanupSession(providerSessionID string, workDir string) er
 
 // removeFile is a helper to remove a file.
 func removeFile(path string) error {
-	return exec.Command("rm", "-f", path).Run()
+	return os.Remove(path)
 }

--- a/provider/pi_provider.go
+++ b/provider/pi_provider.go
@@ -1,0 +1,623 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+)
+
+// PiProvider implements the Provider interface for pi-coding-agent CLI.
+// Pi is a minimal terminal coding harness that supports 15+ LLM providers
+// through a unified API. It outputs events in JSON Lines format.
+//
+// Key features:
+//   - Multi-provider support (Anthropic, OpenAI, Google, etc.)
+//   - JSON mode for structured output
+//   - RPC mode for process integration
+//   - Session management with JSONL storage
+type PiProvider struct {
+	ProviderBase
+	opts    ProviderConfig
+	piCfg   *PiConfig
+	pkgName string // npm package name for pi CLI
+}
+
+// Pi event types from the JSON output stream.
+// Reference: https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/json.md
+const (
+	PiEventTypeAgentStart            = "agent_start"
+	PiEventTypeAgentEnd              = "agent_end"
+	PiEventTypeTurnStart             = "turn_start"
+	PiEventTypeTurnEnd               = "turn_end"
+	PiEventTypeMessageStart          = "message_start"
+	PiEventTypeMessageUpdate         = "message_update"
+	PiEventTypeMessageEnd            = "message_end"
+	PiEventTypeToolExecutionStart    = "tool_execution_start"
+	PiEventTypeToolExecutionUpdate   = "tool_execution_update"
+	PiEventTypeToolExecutionEnd      = "tool_execution_end"
+	PiEventTypeSession               = "session"
+	PiEventTypeAutoCompactionStart   = "auto_compaction_start"
+	PiEventTypeAutoCompactionEnd     = "auto_compaction_end"
+	PiEventTypeAutoRetryStart        = "auto_retry_start"
+	PiEventTypeAutoRetryEnd          = "auto_retry_end"
+)
+
+// Pi content block types.
+const (
+	PiContentTypeText     = "text"
+	PiContentTypeThinking = "thinking"
+	PiContentTypeToolCall = "toolCall"
+	PiContentTypeImage    = "image"
+)
+
+// PiSessionEvent represents the session header event.
+type PiSessionEvent struct {
+	Type      string `json:"type"`
+	Version   int    `json:"version"`
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	Cwd       string `json:"cwd"`
+}
+
+// PiAgentEvent represents agent lifecycle events.
+type PiAgentEvent struct {
+	Type     string          `json:"type"`
+	Messages []PiAgentMessage `json:"messages,omitempty"`
+	Message  *PiAgentMessage `json:"message,omitempty"`
+}
+
+// PiAgentMessage represents a message in the pi event stream.
+type PiAgentMessage struct {
+	Role      string            `json:"role"`
+	Content   []PiContentBlock  `json:"content,omitempty"`
+	Timestamp int64             `json:"timestamp,omitempty"`
+	Provider  string            `json:"provider,omitempty"`
+	Model     string            `json:"model,omitempty"`
+	API       string            `json:"api,omitempty"`
+	Usage     *PiUsage          `json:"usage,omitempty"`
+	StopReason string           `json:"stopReason,omitempty"`
+	ErrorMessage string         `json:"errorMessage,omitempty"`
+}
+
+// PiContentBlock represents a content block in a pi message.
+type PiContentBlock struct {
+	Type      string         `json:"type"`
+	Text      string         `json:"text,omitempty"`
+	Thinking  string         `json:"thinking,omitempty"`
+	ID        string         `json:"id,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+	Data      string         `json:"data,omitempty"`
+	MimeType  string         `json:"mimeType,omitempty"`
+}
+
+// PiUsage represents token usage information.
+type PiUsage struct {
+	InputTokens  int32 `json:"input_tokens"`
+	OutputTokens int32 `json:"output_tokens"`
+}
+
+// PiAssistantMessageEvent represents message update events.
+type PiAssistantMessageEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta,omitempty"`
+}
+
+// PiMessageUpdateEvent represents a message_update event.
+type PiMessageUpdateEvent struct {
+	Type                   string                   `json:"type"`
+	Message                *PiAgentMessage          `json:"message"`
+	AssistantMessageEvent  *PiAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
+}
+
+// PiToolExecutionEvent represents tool execution events.
+type PiToolExecutionEvent struct {
+	Type          string         `json:"type"`
+	ToolCallID    string         `json:"toolCallId"`
+	ToolName      string         `json:"toolName"`
+	Args          map[string]any `json:"args,omitempty"`
+	Result        any            `json:"result,omitempty"`
+	PartialResult any            `json:"partialResult,omitempty"`
+	IsError       bool           `json:"isError,omitempty"`
+}
+
+// Compile-time interface verification.
+var _ Provider = (*PiProvider)(nil)
+
+// NewPiProvider creates a new pi provider instance.
+func NewPiProvider(cfg ProviderConfig, logger *slog.Logger) (*PiProvider, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	meta := ProviderMeta{
+		Type:        ProviderTypePi,
+		DisplayName: "Pi (pi-coding-agent)",
+		BinaryName:  "pi",
+		Features: ProviderFeatures{
+			SupportsResume:             true,  // Supports --continue and --resume
+			SupportsStreamJSON:         true,  // JSON mode via --mode json
+			SupportsSSE:                false,
+			SupportsHTTPAPI:            false,
+			SupportsSessionID:          true,  // Supports --session
+			SupportsPermissions:        false, // No built-in permission popups
+			MultiTurnReady:             true,
+			RequiresInitialPromptAsArg: true, // Prompt passed as CLI arg
+		},
+	}
+
+	// Determine binary path
+	binaryPath := cfg.BinaryPath
+	if binaryPath == "" {
+		if path, err := exec.LookPath(meta.BinaryName); err == nil {
+			binaryPath = path
+		}
+	}
+
+	// Extract pi-specific config
+	var piCfg *PiConfig
+	if cfg.Pi != nil {
+		piCfg = cfg.Pi
+	} else {
+		piCfg = &PiConfig{}
+	}
+
+	return &PiProvider{
+		ProviderBase: ProviderBase{
+			meta:       meta,
+			binaryPath: binaryPath,
+			logger:     logger.With("provider", "pi"),
+		},
+		opts:    cfg,
+		piCfg:   piCfg,
+		pkgName: "@mariozechner/pi-coding-agent",
+	}, nil
+}
+
+// BuildCLIArgs constructs pi CLI arguments.
+func (p *PiProvider) BuildCLIArgs(providerSessionID string, opts *ProviderSessionOptions) []string {
+	args := []string{}
+
+	// Use JSON mode for structured output
+	args = append(args, "--mode", "json")
+
+	// Session management
+	if providerSessionID != "" {
+		// Check if we should resume or continue
+		if opts != nil && opts.ResumeSession {
+			args = append(args, "--session", providerSessionID)
+		}
+	}
+
+	// Provider and model configuration
+	provider := p.piCfg.Provider
+	model := p.piCfg.Model
+	if opts != nil && opts.Model != "" {
+		model = opts.Model
+	}
+	if model == "" {
+		model = p.opts.DefaultModel
+	}
+
+	if provider != "" {
+		args = append(args, "--provider", provider)
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+
+	// Thinking level
+	if p.piCfg.Thinking != "" {
+		args = append(args, "--thinking", p.piCfg.Thinking)
+	}
+
+	// Session directory
+	if p.piCfg.SessionDir != "" {
+		args = append(args, "--session-dir", p.piCfg.SessionDir)
+	}
+
+	// Ephemeral mode
+	if p.piCfg.NoSession {
+		args = append(args, "--no-session")
+	}
+
+	// Extra arguments from config
+	if len(p.opts.ExtraArgs) > 0 {
+		args = append(args, p.opts.ExtraArgs...)
+	}
+
+	// Initial prompt (required for cold start)
+	if opts != nil && opts.InitialPrompt != "" {
+		finalPrompt := opts.InitialPrompt
+		if opts.TaskInstructions != "" {
+			finalPrompt = fmt.Sprintf("<context>\n%s\n</context>\n\n<user_query>\n%s\n</user_query>",
+				opts.TaskInstructions, opts.InitialPrompt)
+		}
+		args = append(args, finalPrompt)
+	}
+
+	return args
+}
+
+// BuildInputMessage constructs the input for pi.
+// Note: Pi typically takes the prompt as a CLI argument, not stdin.
+func (p *PiProvider) BuildInputMessage(prompt string, taskInstructions string) (map[string]any, error) {
+	finalPrompt := prompt
+	if taskInstructions != "" {
+		finalPrompt = fmt.Sprintf("<context>\n%s\n</context>\n\n<user_query>\n%s\n</user_query>",
+			taskInstructions, prompt)
+	}
+
+	return map[string]any{
+		"prompt": finalPrompt,
+	}, nil
+}
+
+// ParseEvent parses a pi JSON output line into one or more ProviderEvents.
+func (p *PiProvider) ParseEvent(line string) ([]*ProviderEvent, error) {
+	// Try to parse as a generic event first to get the type
+	var baseEvent struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(line), &baseEvent); err != nil {
+		// Not valid JSON, return as raw content
+		return []*ProviderEvent{{
+			Type:    EventTypeRaw,
+			RawType: "raw",
+			Content: line,
+			RawLine: line,
+		}}, nil
+	}
+
+	// Parse based on event type
+	switch baseEvent.Type {
+	case PiEventTypeSession:
+		return p.parseSessionEvent(line)
+
+	case PiEventTypeAgentStart:
+		return []*ProviderEvent{{
+			Type:    EventTypeSystem,
+			RawType: baseEvent.Type,
+			RawLine: line,
+		}}, nil
+
+	case PiEventTypeAgentEnd:
+		return []*ProviderEvent{{
+			Type:    EventTypeResult,
+			RawType: baseEvent.Type,
+			RawLine: line,
+		}}, nil
+
+	case PiEventTypeTurnStart:
+		return []*ProviderEvent{{
+			Type:    EventTypeSystem,
+			RawType: baseEvent.Type,
+			Status:  "running",
+			RawLine: line,
+		}}, nil
+
+	case PiEventTypeTurnEnd:
+		return []*ProviderEvent{{
+			Type:    EventTypeResult,
+			RawType: baseEvent.Type,
+			Status:  "completed",
+			RawLine: line,
+		}}, nil
+
+	case PiEventTypeMessageStart, PiEventTypeMessageEnd:
+		return p.parseMessageEvent(line, baseEvent.Type)
+
+	case PiEventTypeMessageUpdate:
+		return p.parseMessageUpdateEvent(line)
+
+	case PiEventTypeToolExecutionStart:
+		return p.parseToolExecutionStart(line)
+
+	case PiEventTypeToolExecutionEnd:
+		return p.parseToolExecutionEnd(line)
+
+	case PiEventTypeAutoCompactionStart, PiEventTypeAutoCompactionEnd,
+		PiEventTypeAutoRetryStart, PiEventTypeAutoRetryEnd:
+		// System events, just log
+		return []*ProviderEvent{{
+			Type:    EventTypeSystem,
+			RawType: baseEvent.Type,
+			RawLine: line,
+		}}, nil
+
+	default:
+		// Unknown event type, try to extract content
+		return []*ProviderEvent{{
+			Type:    EventTypeRaw,
+			RawType: baseEvent.Type,
+			Content: line,
+			RawLine: line,
+		}}, nil
+	}
+}
+
+// parseSessionEvent parses a session header event.
+func (p *PiProvider) parseSessionEvent(line string) ([]*ProviderEvent, error) {
+	var event PiSessionEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return nil, fmt.Errorf("parse session event: %w", err)
+	}
+
+	return []*ProviderEvent{{
+		Type:       EventTypeSystem,
+		RawType:    event.Type,
+		SessionID:  event.ID,
+		RawLine:    line,
+	}}, nil
+}
+
+// parseMessageEvent parses message_start and message_end events.
+func (p *PiProvider) parseMessageEvent(line string, eventType string) ([]*ProviderEvent, error) {
+	var event PiAgentEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return nil, fmt.Errorf("parse message event: %w", err)
+	}
+
+	if event.Message == nil {
+		return []*ProviderEvent{{
+			Type:    EventTypeSystem,
+			RawType: eventType,
+			RawLine: line,
+		}}, nil
+	}
+
+	var events []*ProviderEvent
+
+	// Parse content blocks
+	for _, block := range event.Message.Content {
+		pe := p.parseContentBlock(block, line)
+		if pe != nil {
+			events = append(events, pe)
+		}
+	}
+
+	// If no content blocks found, return system event
+	if len(events) == 0 {
+		events = append(events, &ProviderEvent{
+			Type:    EventTypeSystem,
+			RawType: eventType,
+			RawLine: line,
+		})
+	}
+
+	return events, nil
+}
+
+// parseMessageUpdateEvent parses message_update events for streaming.
+func (p *PiProvider) parseMessageUpdateEvent(line string) ([]*ProviderEvent, error) {
+	var event PiMessageUpdateEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return nil, fmt.Errorf("parse message update event: %w", err)
+	}
+
+	// Check for assistant message event (text_delta, etc.)
+	if event.AssistantMessageEvent != nil {
+		switch event.AssistantMessageEvent.Type {
+		case "text_delta":
+			return []*ProviderEvent{{
+				Type:    EventTypeAnswer,
+				RawType: "text_delta",
+				Content: event.AssistantMessageEvent.Delta,
+				RawLine: line,
+			}}, nil
+
+		case "thinking_delta":
+			return []*ProviderEvent{{
+				Type:    EventTypeThinking,
+				RawType: "thinking_delta",
+				Content: event.AssistantMessageEvent.Delta,
+				RawLine: line,
+			}}, nil
+		}
+	}
+
+	// Fallback: parse full message content
+	if event.Message != nil && len(event.Message.Content) > 0 {
+		var events []*ProviderEvent
+		for _, block := range event.Message.Content {
+			pe := p.parseContentBlock(block, line)
+			if pe != nil {
+				events = append(events, pe)
+			}
+		}
+		if len(events) > 0 {
+			return events, nil
+		}
+	}
+
+	return []*ProviderEvent{{
+		Type:    EventTypeSystem,
+		RawType: event.Type,
+		RawLine: line,
+	}}, nil
+}
+
+// parseToolExecutionStart parses tool_execution_start events.
+func (p *PiProvider) parseToolExecutionStart(line string) ([]*ProviderEvent, error) {
+	var event PiToolExecutionEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return nil, fmt.Errorf("parse tool execution start: %w", err)
+	}
+
+	return []*ProviderEvent{{
+		Type:      EventTypeToolUse,
+		RawType:   event.Type,
+		ToolName:  event.ToolName,
+		ToolID:    event.ToolCallID,
+		ToolInput: event.Args,
+		Status:    "running",
+		RawLine:   line,
+	}}, nil
+}
+
+// parseToolExecutionEnd parses tool_execution_end events.
+func (p *PiProvider) parseToolExecutionEnd(line string) ([]*ProviderEvent, error) {
+	var event PiToolExecutionEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return nil, fmt.Errorf("parse tool execution end: %w", err)
+	}
+
+	// Convert result to string
+	resultStr := ""
+	if event.Result != nil {
+		switch v := event.Result.(type) {
+		case string:
+			resultStr = v
+		default:
+			if b, err := json.Marshal(v); err == nil {
+				resultStr = string(b)
+			}
+		}
+	}
+
+	status := "success"
+	if event.IsError {
+		status = "error"
+	}
+
+	return []*ProviderEvent{{
+		Type:     EventTypeToolResult,
+		RawType:  event.Type,
+		ToolName: event.ToolName,
+		ToolID:   event.ToolCallID,
+		Content:  resultStr,
+		Status:   status,
+		IsError:  event.IsError,
+		RawLine:  line,
+	}}, nil
+}
+
+// parseContentBlock parses a pi content block into a ProviderEvent.
+func (p *PiProvider) parseContentBlock(block PiContentBlock, rawLine string) *ProviderEvent {
+	switch block.Type {
+	case PiContentTypeText:
+		if block.Text == "" {
+			return nil
+		}
+		return &ProviderEvent{
+			Type:    EventTypeAnswer,
+			RawType: block.Type,
+			Content: block.Text,
+			RawLine: rawLine,
+		}
+
+	case PiContentTypeThinking:
+		if block.Thinking == "" {
+			return nil
+		}
+		return &ProviderEvent{
+			Type:    EventTypeThinking,
+			RawType: block.Type,
+			Content: block.Thinking,
+			RawLine: rawLine,
+		}
+
+	case PiContentTypeToolCall:
+		return &ProviderEvent{
+			Type:      EventTypeToolUse,
+			RawType:   block.Type,
+			ToolName:  block.Name,
+			ToolID:    block.ID,
+			ToolInput: block.Arguments,
+			Status:    "running",
+			RawLine:   rawLine,
+		}
+
+	case PiContentTypeImage:
+		return &ProviderEvent{
+			Type:    EventTypeSystem,
+			RawType: block.Type,
+			Content: "[Image]",
+			RawLine: rawLine,
+		}
+
+	default:
+		return nil
+	}
+}
+
+// DetectTurnEnd checks if the event signals turn completion.
+func (p *PiProvider) DetectTurnEnd(event *ProviderEvent) bool {
+	if event == nil {
+		return false
+	}
+
+	// turn_end and agent_end signal completion
+	if event.RawType == PiEventTypeTurnEnd || event.RawType == PiEventTypeAgentEnd {
+		return true
+	}
+
+	// Error events also end the turn
+	if event.Type == EventTypeError {
+		return true
+	}
+
+	// Result type signals completion
+	if event.Type == EventTypeResult {
+		return true
+	}
+
+	return false
+}
+
+// ValidateBinary checks if the pi CLI is available.
+func (p *PiProvider) ValidateBinary() (string, error) {
+	if p.binaryPath != "" {
+		return p.binaryPath, nil
+	}
+
+	// Try to find pi in PATH
+	path, err := exec.LookPath("pi")
+	if err != nil {
+		return "", fmt.Errorf("pi CLI not found: install with 'npm install -g %s': %w", p.pkgName, err)
+	}
+	return path, nil
+}
+
+// CleanupSession cleans up pi session files.
+// Pi stores sessions in ~/.pi/agent/sessions/ as JSONL files.
+func (p *PiProvider) CleanupSession(providerSessionID string, workDir string) error {
+	if providerSessionID == "" {
+		return nil
+	}
+
+	// Pi stores sessions in ~/.pi/agent/sessions/
+	// Session files are named with timestamp and UUID
+	homeDir, err := filepath.Abs("~")
+	if err != nil {
+		return fmt.Errorf("get home directory: %w", err)
+	}
+
+	sessionDir := filepath.Join(homeDir, ".pi", "agent", "sessions")
+	if p.piCfg.SessionDir != "" {
+		sessionDir = p.piCfg.SessionDir
+	}
+
+	// Find and remove session file matching the ID
+	// Session files follow pattern: <timestamp>_<uuid>.jsonl
+	pattern := filepath.Join(sessionDir, "*"+providerSessionID+"*.jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("find session files: %w", err)
+	}
+
+	for _, match := range matches {
+		if err := removeFile(match); err != nil {
+			p.logger.Warn("Failed to remove session file", "file", match, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// removeFile is a helper to remove a file.
+func removeFile(path string) error {
+	return exec.Command("rm", "-f", path).Run()
+}

--- a/provider/pi_provider_test.go
+++ b/provider/pi_provider_test.go
@@ -81,3 +81,293 @@ func TestPiProvider_Metadata(t *testing.T) {
     assert.False(t, meta.Features.SupportsSSE)
     assert.False(t, meta.Features.SupportsHTTPAPI)
 }
+
+func TestPiProvider_BuildCLIArgs(t *testing.T) {
+    tests := []struct {
+        name       string
+        config     ProviderConfig
+        sessionID  string
+        opts       *ProviderSessionOptions
+        wantArgs   []string
+    }{
+        {
+            name: "basic config with prompt",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                    Model:    "claude-sonnet-4-20250514",
+                },
+            },
+            sessionID: "",
+            opts: &ProviderSessionOptions{
+                InitialPrompt: "Hello",
+            },
+            wantArgs: []string{"--mode", "json", "--provider", "anthropic", "--model", "claude-sonnet-4-20250514", "Hello"},
+        },
+        {
+            name: "with thinking level",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                    Model:    "claude-sonnet-4-20250514",
+                    Thinking: "high",
+                },
+            },
+            sessionID: "",
+            opts: &ProviderSessionOptions{
+                InitialPrompt: "Test",
+            },
+            wantArgs: []string{"--mode", "json", "--provider", "anthropic", "--model", "claude-sonnet-4-20250514", "--thinking", "high", "Test"},
+        },
+        {
+            name: "with session resume",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                },
+            },
+            sessionID: "test-session-123",
+            opts: &ProviderSessionOptions{
+                ResumeSession: true,
+            },
+            wantArgs: []string{"--mode", "json", "--session", "test-session-123", "--provider", "anthropic"},
+        },
+        {
+            name: "with no-session flag",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider:  "anthropic",
+                    NoSession: true,
+                },
+            },
+            sessionID: "",
+            opts:      nil,
+            wantArgs:  []string{"--mode", "json", "--provider", "anthropic", "--no-session"},
+        },
+        {
+            name: "with model override from opts",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                    Model:    "claude-sonnet-4-20250514",
+                },
+            },
+            sessionID: "",
+            opts: &ProviderSessionOptions{
+                Model: "claude-opus-4-6",
+            },
+            wantArgs: []string{"--mode", "json", "--provider", "anthropic", "--model", "claude-opus-4-6"},
+        },
+        {
+            name: "with task instructions",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                },
+            },
+            sessionID: "",
+            opts: &ProviderSessionOptions{
+                InitialPrompt:    "What is the status?",
+                TaskInstructions: "You are a helpful assistant.",
+            },
+            wantArgs: []string{"--mode", "json", "--provider", "anthropic", "<context>\nYou are a helpful assistant.\n</context>\n\n<user_query>\nWhat is the status?\n</user_query>"},
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            provider, err := NewPiProvider(tt.config, nil)
+            require.NoError(t, err)
+
+            args := provider.BuildCLIArgs(tt.sessionID, tt.opts)
+            assert.Equal(t, tt.wantArgs, args)
+        })
+    }
+}
+
+func TestPiProvider_BuildInputMessage(t *testing.T) {
+    provider, err := NewPiProvider(ProviderConfig{
+        Type:    ProviderTypePi,
+        Enabled: true,
+    }, nil)
+    require.NoError(t, err)
+
+    // Test without task instructions
+    msg, err := provider.BuildInputMessage("Hello", "")
+    require.NoError(t, err)
+    assert.Equal(t, "Hello", msg["prompt"])
+
+    // Test with task instructions
+    msg, err = provider.BuildInputMessage("What is this?", "Context info")
+    require.NoError(t, err)
+    assert.Contains(t, msg["prompt"].(string), "<context>")
+    assert.Contains(t, msg["prompt"].(string), "Context info")
+    assert.Contains(t, msg["prompt"].(string), "<user_query>")
+    assert.Contains(t, msg["prompt"].(string), "What is this?")
+}
+
+func TestPiProvider_ParseEvent(t *testing.T) {
+    provider, err := NewPiProvider(ProviderConfig{
+        Type:    ProviderTypePi,
+        Enabled: true,
+    }, nil)
+    require.NoError(t, err)
+
+    tests := []struct {
+        name      string
+        line      string
+        wantType  ProviderEventType
+        wantCount int
+    }{
+        {
+            name:      "session event",
+            line:      `{"type":"session","version":3,"id":"test-id","timestamp":"2024-01-01T00:00:00Z","cwd":"/test"}`,
+            wantType:  EventTypeSystem,
+            wantCount: 1,
+        },
+        {
+            name:      "agent_start event",
+            line:      `{"type":"agent_start"}`,
+            wantType:  EventTypeSystem,
+            wantCount: 1,
+        },
+        {
+            name:      "agent_end event",
+            line:      `{"type":"agent_end","messages":[]}`,
+            wantType:  EventTypeResult,
+            wantCount: 1,
+        },
+        {
+            name:      "turn_start event",
+            line:      `{"type":"turn_start"}`,
+            wantType:  EventTypeSystem,
+            wantCount: 1,
+        },
+        {
+            name:      "turn_end event",
+            line:      `{"type":"turn_end","message":{}}`,
+            wantType:  EventTypeResult,
+            wantCount: 1,
+        },
+        {
+            name:      "message with text content",
+            line:      `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+            wantType:  EventTypeAnswer,
+            wantCount: 1,
+        },
+        {
+            name:      "message with thinking content",
+            line:      `{"type":"message_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think..."}]}}`,
+            wantType:  EventTypeThinking,
+            wantCount: 1,
+        },
+        {
+            name:      "tool execution start",
+            line:      `{"type":"tool_execution_start","toolCallId":"call-123","toolName":"Read","args":{"file_path":"/test.txt"}}`,
+            wantType:  EventTypeToolUse,
+            wantCount: 1,
+        },
+        {
+            name:      "tool execution end",
+            line:      `{"type":"tool_execution_end","toolCallId":"call-123","toolName":"Read","result":"file content","isError":false}`,
+            wantType:  EventTypeToolResult,
+            wantCount: 1,
+        },
+        {
+            name:      "text_delta event",
+            line:      `{"type":"message_update","message":{},"assistantMessageEvent":{"type":"text_delta","delta":"Hello"}}`,
+            wantType:  EventTypeAnswer,
+            wantCount: 1,
+        },
+        {
+            name:      "thinking_delta event",
+            line:      `{"type":"message_update","message":{},"assistantMessageEvent":{"type":"thinking_delta","delta":"Hmm..."}}`,
+            wantType:  EventTypeThinking,
+            wantCount: 1,
+        },
+        {
+            name:      "invalid JSON returns raw event",
+            line:      `not valid json`,
+            wantType:  EventTypeRaw,
+            wantCount: 1,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            events, err := provider.ParseEvent(tt.line)
+            require.NoError(t, err)
+            require.Len(t, events, tt.wantCount)
+            assert.Equal(t, tt.wantType, events[0].Type)
+        })
+    }
+}
+
+func TestPiProvider_DetectTurnEnd(t *testing.T) {
+    provider, err := NewPiProvider(ProviderConfig{
+        Type:    ProviderTypePi,
+        Enabled: true,
+    }, nil)
+    require.NoError(t, err)
+
+    tests := []struct {
+        name     string
+        event    *ProviderEvent
+        wantEnd  bool
+    }{
+        {
+            name:    "turn_end signals end",
+            event:   &ProviderEvent{Type: EventTypeResult, RawType: "turn_end"},
+            wantEnd: true,
+        },
+        {
+            name:    "agent_end signals end",
+            event:   &ProviderEvent{Type: EventTypeResult, RawType: "agent_end"},
+            wantEnd: true,
+        },
+        {
+            name:    "error signals end",
+            event:   &ProviderEvent{Type: EventTypeError},
+            wantEnd: true,
+        },
+        {
+            name:    "result type signals end",
+            event:   &ProviderEvent{Type: EventTypeResult},
+            wantEnd: true,
+        },
+        {
+            name:    "answer does not signal end",
+            event:   &ProviderEvent{Type: EventTypeAnswer},
+            wantEnd: false,
+        },
+        {
+            name:    "tool_use does not signal end",
+            event:   &ProviderEvent{Type: EventTypeToolUse},
+            wantEnd: false,
+        },
+        {
+            name:    "nil event does not signal end",
+            event:   nil,
+            wantEnd: false,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := provider.DetectTurnEnd(tt.event)
+            assert.Equal(t, tt.wantEnd, got)
+        })
+    }
+}

--- a/provider/pi_provider_test.go
+++ b/provider/pi_provider_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPiProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+	 config  ProviderConfig
+	 wantErr bool
+    }{
+        {
+            name: "default config",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+            },
+            wantErr: false,
+        },
+        {
+            name: "with pi config",
+            config: ProviderConfig{
+                Type:    ProviderTypePi,
+                Enabled: true,
+                Pi: &PiConfig{
+                    Provider: "anthropic",
+                    Model:    "claude-sonnet-4-20250514",
+                    Thinking: "high",
+                },
+            },
+            wantErr: false,
+        },
+        {
+            name: "with custom binary path",
+            config: ProviderConfig{
+                Type:       ProviderTypePi,
+                Enabled:    true,
+                BinaryPath: "/usr/local/bin/pi",
+            },
+            wantErr: false,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            provider, err := NewPiProvider(tt.config, nil)
+            if tt.wantErr {
+                assert.Error(t, err)
+                assert.Nil(t, provider)
+            } else {
+                assert.NoError(t, err)
+                assert.NotNil(t, provider)
+                assert.Equal(t, ProviderTypePi, provider.Metadata().Type)
+                assert.Equal(t, "pi", provider.Metadata().BinaryName)
+            }
+        })
+    }
+}
+
+func TestPiProvider_Metadata(t *testing.T) {
+    provider, err := NewPiProvider(ProviderConfig{
+        Type:    ProviderTypePi,
+        Enabled: true,
+    }, nil)
+    require.NoError(t, err)
+
+    meta := provider.Metadata()
+    assert.Equal(t, ProviderTypePi, meta.Type)
+    assert.Equal(t, "Pi (pi-coding-agent)", meta.DisplayName)
+    assert.Equal(t, "pi", meta.BinaryName)
+
+    // Verify features
+    assert.True(t, meta.Features.SupportsResume)
+    assert.True(t, meta.Features.SupportsStreamJSON)
+    assert.True(t, meta.Features.MultiTurnReady)
+    assert.True(t, meta.Features.RequiresInitialPromptAsArg)
+    assert.False(t, meta.Features.SupportsSSE)
+    assert.False(t, meta.Features.SupportsHTTPAPI)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -13,12 +13,13 @@ type ProviderType string
 const (
 	ProviderTypeClaudeCode ProviderType = "claude-code"
 	ProviderTypeOpenCode   ProviderType = "opencode"
+	ProviderTypePi         ProviderType = "pi"
 )
 
 // Valid checks if the provider type is a known valid type.
 func (t ProviderType) Valid() bool {
 	switch t {
-	case ProviderTypeClaudeCode, ProviderTypeOpenCode:
+	case ProviderTypeClaudeCode, ProviderTypeOpenCode, ProviderTypePi:
 		return true
 	default:
 		return false
@@ -167,6 +168,9 @@ type ProviderConfig struct {
 
 	// OpenCode-specific options
 	OpenCode *OpenCodeConfig `json:"opencode,omitempty" koanf:"opencode"`
+
+	// Pi-specific options
+	Pi *PiConfig `json:"pi,omitempty" koanf:"pi"`
 }
 
 // OpenCodeConfig contains OpenCode-specific configuration.
@@ -187,6 +191,28 @@ type OpenCodeConfig struct {
 	Model string `json:"model,omitempty" koanf:"model"`
 }
 
+// PiConfig contains pi-mono (pi-coding-agent) specific configuration.
+// Pi supports multiple LLM providers through a unified API.
+type PiConfig struct {
+	// Provider is the LLM provider to use (anthropic, openai, google, etc.)
+	Provider string `json:"provider,omitempty" koanf:"provider"`
+
+	// Model is the model ID or pattern (supports provider/id format)
+	Model string `json:"model,omitempty" koanf:"model"`
+
+	// Thinking level: off, minimal, low, medium, high, xhigh
+	Thinking string `json:"thinking,omitempty" koanf:"thinking"`
+
+	// UseRPC enables RPC mode for process integration (stdin/stdout)
+	UseRPC bool `json:"use_rpc,omitempty" koanf:"use_rpc"`
+
+	// SessionDir custom session storage directory
+	SessionDir string `json:"session_dir,omitempty" koanf:"session_dir"`
+
+	// NoSession enables ephemeral mode (don't save session)
+	NoSession bool `json:"no_session,omitempty" koanf:"no_session"`
+}
+
 // Validate validates the provider configuration.
 // Returns an error if required fields are missing or invalid.
 func (c *ProviderConfig) Validate() error {
@@ -198,6 +224,15 @@ func (c *ProviderConfig) Validate() error {
 	}
 	if c.OpenCode != nil && c.OpenCode.Port < 0 {
 		return fmt.Errorf("invalid port number: %d", c.OpenCode.Port)
+	}
+	if c.Pi != nil && c.Pi.Thinking != "" {
+		validThinking := map[string]bool{
+			"off": true, "minimal": true, "low": true,
+			"medium": true, "high": true, "xhigh": true,
+		}
+		if !validThinking[c.Pi.Thinking] {
+			return fmt.Errorf("invalid thinking level: %s", c.Pi.Thinking)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Add pi-mono (pi-coding-agent) as a new Provider. Changes: ProviderTypePi constant, PiConfig struct, pi_provider.go implementation  unit tests. Resolves #191