### PR TITLE
fix(ci): add Docker Buildx setup for SBOM attestation support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- Add `docker/setup-buildx-action@v3` to GitHub Actions release workflow
- Enables `docker-container` driver which supports SBOM attestation

## Problem
GoReleaser v2 `dockers_v2` uses `--attest=type=sbom` by default, but GitHub Actions default `docker` driver doesn't support attestation.

## Error Fixed
```
ERROR: failed to build: Attestation is not supported for the docker driver.
```

## Test Plan
- [ ] Merge this PR
- [ ] Re-run release with existing v0.21.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)