### PR TITLE
fix(ci): fix binary path for GoReleaser multi-platform builds

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -65,8 +65,9 @@ RUN ARCH=$(uname -m) && \
 # Install Claude Code
 RUN npm install -g @anthropic-ai/claude-code@latest
 
-# Copy pre-built binary from GoReleaser
-COPY hotplexd /app/hotplexd
+# Copy pre-built binary from GoReleaser (multi-platform path)
+ARG TARGETARCH
+COPY linux/${TARGETARCH}/hotplexd /app/hotplexd
 RUN chmod +x /app/hotplexd
 
 # Verify installations


### PR DESCRIPTION
## Summary
- Fix Dockerfile.release to use `TARGETARCH` for multi-platform binary path
- GoReleaser v2 places binaries in `linux/{arch}/hotplexd` structure

## Problem
Docker build failed with:
```
ERROR: "/hotplexd": not found
COPY hotplexd /app/hotplexd
```

## Root Cause
GoReleaser multi-platform builds place binaries in platform-specific directories:
```
├── linux
│   ├── amd64
│   │   └── hotplexd
│   └── arm64
│       └── hotplexd
```

## Test Plan
- [ ] Merge this PR
- [ ] Re-trigger release with v0.21.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)