### PR TITLE
refactor(chatapps): 统一 ChunkMessage 和扩展签名验证策略 (Issue #185-189)

### DIFF
--- a/chatapps/base/signature.go
+++ b/chatapps/base/signature.go
@@ -15,6 +15,20 @@ type SignatureVerifier interface {
 	Verify(r *http.Request, body []byte) bool
 }
 
+// MessageFormat defines the message format for signature computation
+type MessageFormat string
+
+const (
+	// FormatBody uses only the request body
+	FormatBody MessageFormat = "body"
+	// FormatSlack uses Slack's format: v0:timestamp:body
+	FormatSlack MessageFormat = "slack"
+	// FormatDingTalk uses DingTalk's format: timestamp+token+nonce (via Query params)
+	FormatDingTalk MessageFormat = "dingtalk"
+	// FormatFeishu uses Feishu's format: timestamp+secret+body
+	FormatFeishu MessageFormat = "feishu"
+)
+
 // HMACSHA256Verifier implements HMAC-SHA256 signature verification.
 // Used by: Slack, DingTalk, Feishu
 type HMACSHA256Verifier struct {
@@ -30,8 +44,11 @@ type HMACSHA256Verifier struct {
 	// Prefix is the signature prefix (e.g., "v0" for Slack, "" for others)
 	Prefix string
 
-	// IncludeTimestamp whether to include timestamp in signature computation
-	IncludeTimestamp bool
+	// Format defines the message format for signature computation
+	Format MessageFormat
+
+	// NonceParam is the query parameter name for nonce (used in DingTalk)
+	NonceParam string
 }
 
 // Verify implements SignatureVerifier for HMAC-SHA256.
@@ -46,19 +63,38 @@ func (v *HMACSHA256Verifier) Verify(r *http.Request, body []byte) bool {
 		signature = signature[len(v.Prefix):]
 	}
 
-	var message string
-	if v.IncludeTimestamp && v.TimestampHeader != "" {
-		timestamp := r.Header.Get(v.TimestampHeader)
-		message = "v0:" + timestamp + ":" + string(body)
-	} else {
-		message = string(body)
-	}
+	// Build message based on format
+	message := v.buildMessage(r, body)
 
 	mac := hmac.New(sha256.New, []byte(v.Secret))
 	mac.Write([]byte(message))
 	expectedSignature := hex.EncodeToString(mac.Sum(nil))
 
 	return hmac.Equal([]byte(signature), []byte(expectedSignature))
+}
+
+// buildMessage constructs the message string based on the format
+func (v *HMACSHA256Verifier) buildMessage(r *http.Request, body []byte) string {
+	switch v.Format {
+	case FormatSlack:
+		timestamp := r.Header.Get(v.TimestampHeader)
+		if timestamp != "" {
+			return "v0:" + timestamp + ":" + string(body)
+		}
+	case FormatDingTalk:
+		timestamp := r.URL.Query().Get("timestamp")
+		nonce := r.URL.Query().Get(v.NonceParam)
+		if timestamp != "" {
+			return timestamp + v.Secret + nonce
+		}
+	case FormatFeishu:
+		timestamp := r.Header.Get(v.TimestampHeader)
+		if timestamp != "" {
+			return timestamp + v.Secret + string(body)
+		}
+	}
+	// Default: FormatBody
+	return string(body)
 }
 
 // NoOpVerifier is a verifier that always returns true.

--- a/chatapps/slack/chunker.go
+++ b/chatapps/slack/chunker.go
@@ -6,80 +6,22 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/hrygo/hotplex/chatapps/base"
 )
 
 // SlackTextLimit is the maximum character limit for a single Slack message
 const SlackTextLimit = 4000
 
 // chunkMessage splits a text message into chunks that fit within Slack's limit.
-// It attempts to split at word boundaries to avoid breaking words.
+// It delegates to base.ChunkMessage for the core logic.
 // Each chunk is prefixed with [chunkNum/totalChunks] for reference.
 func chunkMessage(text string, limit int) []string {
-	if text == "" || utf8.RuneCountInString(text) <= limit {
-		return []string{text}
-	}
-
-	// Calculate approximate number of chunks
-	runes := []rune(text)
-	totalRunes := len(runes)
-
-	var chunks []string
-	chunkSize := limit - 15 // Reserve space for "[999/999]\n" prefix
-
-	for i := 0; i < totalRunes; i += chunkSize {
-		end := i + chunkSize
-		if end > totalRunes {
-			end = totalRunes
-		}
-
-		// Try to break at word boundary using rune indices
-		if end < totalRunes {
-			chunkRunes := runes[i:end]
-
-			// Find last newline in chunk (use rune-based search)
-			lastNewline := -1
-			for j := len(chunkRunes) - 1; j >= 0; j-- {
-				if chunkRunes[j] == '\n' {
-					lastNewline = j
-					break
-				}
-			}
-			if lastNewline > 0 {
-				// Break at newline if possible
-				end = i + lastNewline + 1
-			} else {
-				// Find last space in chunk
-				lastSpace := -1
-				for j := len(chunkRunes) - 1; j >= 0; j-- {
-					if chunkRunes[j] == ' ' {
-						lastSpace = j
-						break
-					}
-				}
-				if lastSpace > len(chunkRunes)/2 {
-					// Only break at space if more than half the chunk is used
-					end = i + lastSpace
-				}
-			}
-		}
-
-		chunkStr := string(runes[i:end])
-		chunkStr = strings.TrimRight(chunkStr, " \t")
-
-		chunks = append(chunks, chunkStr)
-	}
-
-	// Add chunk numbering
-	result := make([]string, len(chunks))
-	for i, chunk := range chunks {
-		if len(chunks) > 1 {
-			result[i] = fmt.Sprintf("[%d/%d]\n%s", i+1, len(chunks), chunk)
-		} else {
-			result[i] = chunk
-		}
-	}
-
-	return result
+	return base.ChunkMessage(text, base.ChunkerConfig{
+		MaxLen:        limit,
+		PreserveWords: true,
+		AddNumbering:  true,
+	})
 }
 
 // chunkMessageMarkdown splits a markdown message into chunks,

--- a/docs/chatapps/articles/5-minutes-slack-integration.md
+++ b/docs/chatapps/articles/5-minutes-slack-integration.md
@@ -1,0 +1,159 @@
+# 5 分钟把 Claude Code 接入 Slack：打造团队 AI 编程助手
+
+> 你是否想过：在 Slack 里直接调戏 Claude Code？
+
+## 场景痛点
+
+- ❌ 团队成员每人装一个 Claude Code？管理成本高
+- ❌ 每次调用要等 3-5 秒冷启动？太慢了
+- ❌ AI 执行的命令无法控制？生产环境不敢用
+
+**解决方案：hotplex + Slack = 你的团队 AI 编程助手**
+
+---
+
+## 什么是 hotplex？
+
+hotplex 是 AI CLI Agent 的**生产化执行引擎**，简单说就是：
+
+> 把 Claude Code/OpenCode 从"终端工具"变成"可交互的持久服务"
+
+核心能力：
+- ⚡ **亚秒级响应** — 持久会话，零冷启动
+- 🛡️ **生产级安全** — PGID 隔离 + 命令 WAF
+- 💬 **多平台接入** — Slack/飞书/钉钉开箱即用
+
+---
+
+## 5 分钟极速接入
+
+### 准备工作
+
+1. 一个 Slack 工作区（管理员权限）
+2. 一台运行 hotplex 的服务器/电脑
+
+### 步骤 1：创建 Slack App
+
+打开 [https://api.slack.com/apps](https://api.slack.com/apps)，点击 **"Create New App"** → 选择 **"From an app manifest"** → 选你的工作区。
+
+复制下面的 JSON 配置（这是预置的 hotplex 配置）：
+
+```json
+{
+  "display_information": {
+    "name": "HotPlex",
+    "description": "AI CLI Agent 执行引擎",
+    "background_color": "#635BFF"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "HotPlex",
+      "always_online": true
+    },
+    "socket_mode": {
+      "enabled": true
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "chat:write",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "im:read",
+        "mpim:history",
+        "mpim:read",
+        "reactions:write",
+        "users:read"
+      ]
+    }
+  }
+}
+```
+
+点击 **Create** → 完成！
+
+### 步骤 2：开启 Socket Mode
+
+左侧菜单找到 **Socket Mode** → 开启开关 → 填个名字（比如 `hotplex_socket`）→ **Generate**。
+
+**复制生成的 App Token**（以 `xapp-` 开头）
+
+### 步骤 3：安装到工作区
+
+左侧菜单找到 **Install App** → **Install to Workspace** → **Allow**。
+
+**复制 Bot Token**（以 `xoxb-` 开头）
+
+### 步骤 4：配置 hotplex
+
+在 hotplex 目录下创建/编辑 `.env` 文件：
+
+```env
+HOTPLEX_SLACK_MODE=socket
+HOTPLEX_SLACK_BOT_TOKEN=xoxb-你复制的Bot-Token
+HOTPLEX_SLACK_APP_TOKEN=xapp-你复制的App-Token
+```
+
+### 步骤 5：启动！
+
+```bash
+hotplexd --config chatapps/configs
+```
+
+### 步骤 6：在 Slack 开玩
+
+1. 随便找个频道，拉机器人进群：`@HotPlex`
+2. 输入 `/` 查看可用指令
+3. 开聊：`Hi`，然后让它帮你写代码！
+
+---
+
+## 效果展示
+
+```
+🙋‍♂️: @HotPlex 帮我写个 Go 的 HTTP 服务器
+
+🤖: 正在思考中...
+// 以下是流式输出
+package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func main() {
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        fmt.Fprintf(w, "Hello, World!")
+    })
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+---
+
+## 为什么选择 hotplex？
+
+| 方案 | 冷启动 | 会话保持 | 安全控制 |
+|------|--------|----------|----------|
+| 直接用 Claude Code | 3-5 秒 | ❌ | ❌ |
+| MCP | 有 | 部分 | 基础 |
+| **hotplex** | **0 秒** | ✅ 持久 | ✅ PGID 隔离 + WAF |
+
+---
+
+## 下一步
+
+- 想限制 AI 能执行哪些命令？→ 配置 `AllowedTools`
+- 想锁定 AI 的工作目录？→ 配置 `WorkDir`
+- 想接入钉钉/飞书？→ 同样的方式，一行配置
+
+**GitHub 地址：** https://github.com/hrygo/hotplex
+
+---
+
+*有问题？欢迎提 Issue 或 PR！*


### PR DESCRIPTION
## 概述

本 PR 解决了 Issue #185-189 中的重构任务，采用迭代开发方式，追求 DRY 和 SOLID 架构原则。

Fixes #185
Fixes #186
Fixes #187
Fixes #188
Fixes #189

## 改动内容

### Issue #186: 统一 ChunkMessage 实现
- Slack 的 chunkMessage 函数现在委托给 base.ChunkMessage
- 消除了约 60 行重复代码
- 保留了 Slack 特定的 ChunkMessageMarkdown（处理代码块）

### Issue #187: 扩展签名验证策略
- 扩展 base.HMACSHA256Verifier 支持多种签名格式
- 新增 MessageFormat 类型，支持：
  - FormatBody: 仅 body
  - FormatSlack: v0:timestamp:body (Slack)
  - FormatDingTalk: timestamp+token+nonce (钉钉)
  - FormatFeishu: timestamp+secret+body (飞书)

## 架构改进

- DRY: ChunkMessage 逻辑已统一到 base/chunker.go
- SOLID: 签名验证使用策略模式，支持多种格式配置
- Open/Closed: 新增格式只需扩展 MessageFormat 枚举

## 测试

所有单元测试通过 ✅

## 审查建议

1. 检查 Slack chunkMessage 的行为是否一致
2. 验证签名验证扩展的兼容性