### PR TITLE
feat(slack): integrate MessageStorePlugin for message persistence

### DIFF
--- a/chatapps/base/message_store_plugin.go
+++ b/chatapps/base/message_store_plugin.go
@@ -274,6 +274,11 @@ func (p *MessageStorePlugin) ListUserSessions(ctx context.Context, platform, use
 	return p.store.ListUserSessions(ctx, platform, userID)
 }
 
+// ListMessages 列出会话的消息列表
+func (p *MessageStorePlugin) ListMessages(ctx context.Context, query *storage.MessageQuery) ([]*storage.ChatAppMessage, error) {
+	return p.store.List(ctx, query)
+}
+
 // Close 关闭插件
 func (p *MessageStorePlugin) Close() error {
 	if p.streamStore != nil {

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -292,7 +292,7 @@ func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 //   - SessionID is derived from (platform, botUserID, channelID, threadTS) - NOT userID
 //   - Empty ChatUserID in MessageContext indicates bot as sender
 //   - This ensures bot responses are grouped with user messages in the same thread session
-func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, threadTS, content string) {
+func (a *Adapter) storeBotResponse(ctx context.Context, _ string, channelID, threadTS, content string) {
 	if a.storePlugin == nil {
 		return
 	}
@@ -301,7 +301,7 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 	sessionCtx := a.sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
 
 	msgCtx, err := base.NewMessageContextBuilder().
-		WithChatSession(sessionID, "slack", "", sessionCtx.ChatBotUserID, channelID, threadTS).
+		WithChatSession(sessionCtx.ChatSessionID, "slack", "", sessionCtx.ChatBotUserID, channelID, threadTS).
 		WithEngineSession(sessionCtx.EngineSessionID, sessionCtx.EngineNamespace).
 		WithProviderSession(sessionCtx.ProviderSessionID, sessionCtx.ProviderType).
 		WithMessage(types.MessageTypeFinalResponse, base.DirectionBotToUser, content).
@@ -327,6 +327,9 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 func (a *Adapter) GetThreadHistory(ctx context.Context, channelID, threadTS string, limit int) ([]*storage.ChatAppMessage, error) {
 	if a.storePlugin == nil {
 		return nil, fmt.Errorf("storage not enabled")
+	}
+	if a.sessionMgr == nil {
+		return nil, fmt.Errorf("session manager not initialized")
 	}
 
 	// Generate session ID with empty userID - must match storeUserMessage/storeBotResponse
@@ -392,6 +395,9 @@ func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threa
 func (a *Adapter) GetThreadHistoryByUser(ctx context.Context, channelID, threadTS, userID string, limit int) ([]*storage.ChatAppMessage, error) {
 	if a.storePlugin == nil {
 		return nil, fmt.Errorf("storage not enabled")
+	}
+	if a.sessionMgr == nil {
+		return nil, fmt.Errorf("session manager not initialized")
 	}
 
 	// Generate session ID with empty userID for thread-level session

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -341,7 +341,7 @@ func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threa
 		} else {
 			role = "Assistant"
 		}
-		sb.WriteString(fmt.Sprintf("[%s] %s: %s\n", timestamp, role, msg.Content))
+		fmt.Fprintf(&sb, "[%s] %s: %s\n", timestamp, role, msg.Content)
 	}
 
 	return sb.String(), nil

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/hrygo/hotplex/chatapps/base"
 	"github.com/hrygo/hotplex/chatapps/command"
+	"github.com/hrygo/hotplex/chatapps/session"
 	"github.com/hrygo/hotplex/engine"
+	"github.com/hrygo/hotplex/plugins/storage"
+	"github.com/hrygo/hotplex/types"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
@@ -34,6 +37,9 @@ type Adapter struct {
 
 	// Command registry
 	cmdRegistry *command.Registry
+
+	// Message storage plugin (optional)
+	storePlugin *base.MessageStorePlugin
 
 	channelToTeam sync.Map // Map channelID to TeamID for streaming functions
 	channelToUser sync.Map // Map channelID to UserID for streaming functions
@@ -110,7 +116,72 @@ func NewAdapter(config *Config, logger *slog.Logger, opts ...base.AdapterOption)
 		a.sender.SetSender(a.defaultSender)
 	}
 
+	// Initialize message storage plugin if enabled
+	if config.Storage != nil && config.Storage.Enabled {
+		if err := a.initStoragePlugin(config.Storage, logger); err != nil {
+			logger.Error("Failed to initialize storage plugin", "error", err)
+		} else {
+			logger.Info("Message storage plugin initialized", "type", config.Storage.Type)
+		}
+	}
+
 	return a
+}
+
+// initStoragePlugin initializes the message storage plugin
+func (a *Adapter) initStoragePlugin(cfg *StorageConfig, logger *slog.Logger) error {
+	// Create storage backend using factory
+	registry := storage.GlobalRegistry()
+	pluginConfig := storage.PluginConfig{}
+
+	// Set storage-specific config
+	switch cfg.Type {
+	case "sqlite":
+		if cfg.SQLitePath != "" {
+			pluginConfig["path"] = cfg.SQLitePath
+		} else {
+			pluginConfig["path"] = "data/slack_messages.db"
+		}
+	case "memory":
+		// No additional config needed
+	default:
+		logger.Warn("Unknown storage type, falling back to memory", "type", cfg.Type)
+		cfg.Type = "memory"
+	}
+
+	store, err := registry.Get(cfg.Type, pluginConfig)
+	if err != nil {
+		return err
+	}
+	if store == nil {
+		logger.Warn("Storage plugin not found, using memory", "type", cfg.Type)
+		store, _ = registry.Get("memory", nil)
+	}
+
+	// Initialize storage
+	if err := store.Initialize(context.Background()); err != nil {
+		return err
+	}
+
+	// Create session manager
+	sessionMgr := session.NewSessionManager("hotplex")
+
+	// Create message store plugin
+	pluginCfg := base.MessageStorePluginConfig{
+		Store:          store,
+		SessionManager: sessionMgr,
+		StreamEnabled:  cfg.StreamEnabled,
+		StreamTimeout:  cfg.StreamTimeout,
+		Logger:         logger,
+	}
+
+	plugin, err := base.NewMessageStorePlugin(pluginCfg)
+	if err != nil {
+		return err
+	}
+
+	a.storePlugin = plugin
+	return nil
 }
 
 // SetEngine sets the engine for the adapter (used for slash commands)
@@ -145,8 +216,73 @@ func (a *Adapter) Stop() error {
 		a.rateLimiter.Stop()
 	}
 
+	// Close storage plugin
+	if a.storePlugin != nil {
+		if err := a.storePlugin.Close(); err != nil {
+			a.Logger().Error("Failed to close storage plugin", "error", err)
+		}
+	}
+
 	a.webhook.Stop()
 	return a.Adapter.Stop()
+}
+
+// storeUserMessage stores user message if storage is enabled
+func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
+	if a.storePlugin == nil {
+		return
+	}
+
+	channelID, _ := msg.Metadata["channel_id"].(string)
+	threadTS, _ := msg.Metadata["thread_ts"].(string)
+
+	// Generate a session context for storage
+	sessionMgr := session.NewSessionManager("hotplex")
+	sessionCtx := sessionMgr.CreateSessionContext("slack", msg.UserID, a.config.BotUserID, channelID, threadTS, "claude")
+
+	msgCtx, err := base.NewMessageContextBuilder().
+		WithChatSession(sessionCtx.ChatSessionID, sessionCtx.ChatPlatform, sessionCtx.ChatUserID,
+			sessionCtx.ChatBotUserID, sessionCtx.ChatChannelID, sessionCtx.ChatThreadID).
+		WithEngineSession(sessionCtx.EngineSessionID, sessionCtx.EngineNamespace).
+		WithProviderSession(sessionCtx.ProviderSessionID, sessionCtx.ProviderType).
+		WithMessage(types.MessageTypeUserInput, base.DirectionUserToBot, msg.Content).
+		Build()
+
+	if err != nil {
+		a.Logger().Debug("Failed to build message context", "error", err)
+		return
+	}
+
+	if err := a.storePlugin.OnUserMessage(ctx, msgCtx); err != nil {
+		a.Logger().Debug("Failed to store user message", "error", err)
+	}
+}
+
+// storeBotResponse stores bot response if storage is enabled
+func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, threadTS, content string) {
+	if a.storePlugin == nil {
+		return
+	}
+
+	// Generate a session context for storage
+	sessionMgr := session.NewSessionManager("hotplex")
+	sessionCtx := sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
+
+	msgCtx, err := base.NewMessageContextBuilder().
+		WithChatSession(sessionID, "slack", "", sessionCtx.ChatBotUserID, channelID, threadTS).
+		WithEngineSession(sessionCtx.EngineSessionID, sessionCtx.EngineNamespace).
+		WithProviderSession(sessionCtx.ProviderSessionID, sessionCtx.ProviderType).
+		WithMessage(types.MessageTypeFinalResponse, base.DirectionBotToUser, content).
+		Build()
+
+	if err != nil {
+		a.Logger().Debug("Failed to build message context", "error", err)
+		return
+	}
+
+	if err := a.storePlugin.OnBotResponse(ctx, msgCtx); err != nil {
+		a.Logger().Debug("Failed to store bot response", "error", err)
+	}
 }
 
 // Start starts the adapter

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -43,6 +43,9 @@ type Adapter struct {
 	// Message storage plugin (optional)
 	storePlugin *base.MessageStorePlugin
 
+	// Session manager for consistent session ID generation
+	sessionMgr session.SessionManager
+
 	channelToTeam sync.Map // Map channelID to TeamID for streaming functions
 	channelToUser sync.Map // Map channelID to UserID for streaming functions
 
@@ -183,6 +186,7 @@ func (a *Adapter) initStoragePlugin(cfg *StorageConfig, logger *slog.Logger) err
 	}
 
 	a.storePlugin = plugin
+	a.sessionMgr = sessionMgr
 	return nil
 }
 
@@ -238,12 +242,12 @@ func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 	channelID, _ := msg.Metadata["channel_id"].(string)
 	threadTS, _ := msg.Metadata["thread_ts"].(string)
 
-	// Generate a session context for storage
-	sessionMgr := session.NewSessionManager("hotplex")
-	sessionCtx := sessionMgr.CreateSessionContext("slack", msg.UserID, a.config.BotUserID, channelID, threadTS, "claude")
+	// Use stored session manager for consistent session ID generation
+	// Note: sessionID is thread-based (empty userID) to ensure user and bot messages share the same session
+	sessionCtx := a.sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
 
 	msgCtx, err := base.NewMessageContextBuilder().
-		WithChatSession(sessionCtx.ChatSessionID, sessionCtx.ChatPlatform, sessionCtx.ChatUserID,
+		WithChatSession(sessionCtx.ChatSessionID, sessionCtx.ChatPlatform, msg.UserID,
 			sessionCtx.ChatBotUserID, sessionCtx.ChatChannelID, sessionCtx.ChatThreadID).
 		WithEngineSession(sessionCtx.EngineSessionID, sessionCtx.EngineNamespace).
 		WithProviderSession(sessionCtx.ProviderSessionID, sessionCtx.ProviderType).
@@ -251,12 +255,12 @@ func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 		Build()
 
 	if err != nil {
-		a.Logger().Debug("Failed to build message context", "error", err)
+		a.Logger().Warn("Failed to build message context", "error", err)
 		return
 	}
 
 	if err := a.storePlugin.OnUserMessage(ctx, msgCtx); err != nil {
-		a.Logger().Debug("Failed to store user message", "error", err)
+		a.Logger().Warn("Failed to store user message", "error", err)
 	}
 }
 
@@ -266,9 +270,9 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 		return
 	}
 
-	// Generate a session context for storage
-	sessionMgr := session.NewSessionManager("hotplex")
-	sessionCtx := sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
+	// Use stored session manager for consistent session ID generation
+	// Note: userID is empty for bot responses, matching sessionID generation in GetThreadHistory
+	sessionCtx := a.sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
 
 	msgCtx, err := base.NewMessageContextBuilder().
 		WithChatSession(sessionID, "slack", "", sessionCtx.ChatBotUserID, channelID, threadTS).
@@ -278,12 +282,12 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 		Build()
 
 	if err != nil {
-		a.Logger().Debug("Failed to build message context", "error", err)
+		a.Logger().Warn("Failed to build message context", "error", err)
 		return
 	}
 
 	if err := a.storePlugin.OnBotResponse(ctx, msgCtx); err != nil {
-		a.Logger().Debug("Failed to store bot response", "error", err)
+		a.Logger().Warn("Failed to store bot response", "error", err)
 	}
 }
 
@@ -294,9 +298,9 @@ func (a *Adapter) GetThreadHistory(ctx context.Context, channelID, threadTS stri
 		return nil, fmt.Errorf("storage not enabled")
 	}
 
-	// Generate session ID for this thread
-	sessionMgr := session.NewSessionManager("hotplex")
-	sessionID := sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
+	// Use stored session manager for consistent session ID generation
+	// Empty userID for thread-based session (matches storeUserMessage/storeBotResponse)
+	sessionID := a.sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
 
 	// Query messages
 	if limit <= 0 {

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -5,8 +5,10 @@ package slack
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/hrygo/hotplex/chatapps/base"
@@ -283,6 +285,62 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 	if err := a.storePlugin.OnBotResponse(ctx, msgCtx); err != nil {
 		a.Logger().Debug("Failed to store bot response", "error", err)
 	}
+}
+
+// GetThreadHistory retrieves message history for a thread session
+// Returns messages in chronological order (oldest first)
+func (a *Adapter) GetThreadHistory(ctx context.Context, channelID, threadTS string, limit int) ([]*storage.ChatAppMessage, error) {
+	if a.storePlugin == nil {
+		return nil, fmt.Errorf("storage not enabled")
+	}
+
+	// Generate session ID for this thread
+	sessionMgr := session.NewSessionManager("hotplex")
+	sessionID := sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
+
+	// Query messages
+	if limit <= 0 {
+		limit = 100
+	}
+	query := &storage.MessageQuery{
+		ChatSessionID: sessionID,
+		Limit:         limit,
+		Ascending:     true, // Oldest first for conversation context
+	}
+
+	messages, err := a.storePlugin.ListMessages(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list messages: %w", err)
+	}
+
+	return messages, nil
+}
+
+// GetThreadHistoryAsString returns thread history as a formatted string
+// Useful for providing context to AI models
+func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threadTS string, limit int) (string, error) {
+	messages, err := a.GetThreadHistory(ctx, channelID, threadTS, limit)
+	if err != nil {
+		return "", err
+	}
+
+	if len(messages) == 0 {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	for _, msg := range messages {
+		timestamp := msg.CreatedAt.Format("2006-01-02 15:04:05")
+		var role string
+		if msg.MessageType == types.MessageTypeUserInput {
+			role = "User"
+		} else {
+			role = "Assistant"
+		}
+		sb.WriteString(fmt.Sprintf("[%s] %s: %s\n", timestamp, role, msg.Content))
+	}
+
+	return sb.String(), nil
 }
 
 // Start starts the adapter

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -124,7 +124,8 @@ func NewAdapter(config *Config, logger *slog.Logger, opts ...base.AdapterOption)
 	// Initialize message storage plugin if enabled
 	if config.Storage != nil && config.Storage.Enabled {
 		if err := a.initStoragePlugin(config.Storage, logger); err != nil {
-			logger.Error("Failed to initialize storage plugin", "error", err)
+			logger.Error("Failed to initialize storage plugin, continuing without persistence",
+				"error", err, "type", config.Storage.Type)
 		} else {
 			logger.Info("Message storage plugin initialized", "type", config.Storage.Type)
 		}
@@ -146,6 +147,12 @@ func (a *Adapter) initStoragePlugin(cfg *StorageConfig, logger *slog.Logger) err
 			pluginConfig["path"] = cfg.SQLitePath
 		} else {
 			pluginConfig["path"] = "data/slack_messages.db"
+		}
+	case "postgresql":
+		if cfg.PostgreSQLURL != "" {
+			pluginConfig["url"] = cfg.PostgreSQLURL
+		} else {
+			return fmt.Errorf("postgresql storage requires PostgreSQLURL config")
 		}
 	case "memory":
 		// No additional config needed
@@ -320,16 +327,10 @@ func (a *Adapter) GetThreadHistory(ctx context.Context, channelID, threadTS stri
 	return messages, nil
 }
 
-// GetThreadHistoryAsString returns thread history as a formatted string
-// Useful for providing context to AI models
-func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threadTS string, limit int) (string, error) {
-	messages, err := a.GetThreadHistory(ctx, channelID, threadTS, limit)
-	if err != nil {
-		return "", err
-	}
-
+// formatMessagesAsString formats messages as a human-readable string
+func formatMessagesAsString(messages []*storage.ChatAppMessage) string {
 	if len(messages) == 0 {
-		return "", nil
+		return ""
 	}
 
 	var sb strings.Builder
@@ -344,7 +345,17 @@ func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threa
 		fmt.Fprintf(&sb, "[%s] %s: %s\n", timestamp, role, msg.Content)
 	}
 
-	return sb.String(), nil
+	return sb.String()
+}
+
+// GetThreadHistoryAsString returns thread history as a formatted string
+// Useful for providing context to AI models
+func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threadTS string, limit int) (string, error) {
+	messages, err := a.GetThreadHistory(ctx, channelID, threadTS, limit)
+	if err != nil {
+		return "", err
+	}
+	return formatMessagesAsString(messages), nil
 }
 
 // GetThreadHistoryByUser retrieves message history for a thread session, filtered by user ID
@@ -382,24 +393,7 @@ func (a *Adapter) GetThreadHistoryByUserAsString(ctx context.Context, channelID,
 	if err != nil {
 		return "", err
 	}
-
-	if len(messages) == 0 {
-		return "", nil
-	}
-
-	var sb strings.Builder
-	for _, msg := range messages {
-		timestamp := msg.CreatedAt.Format("2006-01-02 15:04:05")
-		var role string
-		if msg.MessageType == types.MessageTypeUserInput {
-			role = "User"
-		} else {
-			role = "Assistant"
-		}
-		fmt.Fprintf(&sb, "[%s] %s: %s\n", timestamp, role, msg.Content)
-	}
-
-	return sb.String(), nil
+	return formatMessagesAsString(messages), nil
 }
 
 // Start starts the adapter

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -347,6 +347,61 @@ func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threa
 	return sb.String(), nil
 }
 
+// GetThreadHistoryByUser retrieves message history for a thread session, filtered by user ID
+// This provides database-level filtering by ChatUserID for efficient queries
+func (a *Adapter) GetThreadHistoryByUser(ctx context.Context, channelID, threadTS, userID string, limit int) ([]*storage.ChatAppMessage, error) {
+	if a.storePlugin == nil {
+		return nil, fmt.Errorf("storage not enabled")
+	}
+
+	// Use stored session manager for consistent session ID generation
+	sessionID := a.sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
+
+	// Query messages with ChatUserID filter
+	if limit <= 0 {
+		limit = 100
+	}
+	query := &storage.MessageQuery{
+		ChatSessionID: sessionID,
+		ChatUserID:    userID, // Filter by actual user ID at database level
+		Limit:         limit,
+		Ascending:     true,
+	}
+
+	messages, err := a.storePlugin.ListMessages(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list messages: %w", err)
+	}
+
+	return messages, nil
+}
+
+// GetThreadHistoryByUserAsString returns user-filtered thread history as a formatted string
+func (a *Adapter) GetThreadHistoryByUserAsString(ctx context.Context, channelID, threadTS, userID string, limit int) (string, error) {
+	messages, err := a.GetThreadHistoryByUser(ctx, channelID, threadTS, userID, limit)
+	if err != nil {
+		return "", err
+	}
+
+	if len(messages) == 0 {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	for _, msg := range messages {
+		timestamp := msg.CreatedAt.Format("2006-01-02 15:04:05")
+		var role string
+		if msg.MessageType == types.MessageTypeUserInput {
+			role = "User"
+		} else {
+			role = "Assistant"
+		}
+		fmt.Fprintf(&sb, "[%s] %s: %s\n", timestamp, role, msg.Content)
+	}
+
+	return sb.String(), nil
+}
+
 // Start starts the adapter
 func (a *Adapter) Start(ctx context.Context) error {
 	// Start Socket Mode if enabled (preferred mode)

--- a/chatapps/slack/adapter.go
+++ b/chatapps/slack/adapter.go
@@ -134,7 +134,17 @@ func NewAdapter(config *Config, logger *slog.Logger, opts ...base.AdapterOption)
 	return a
 }
 
-// initStoragePlugin initializes the message storage plugin
+// initStoragePlugin initializes the message storage plugin based on config.
+//
+// Supported Storage Types:
+//   - "memory": In-memory storage (default, no persistence)
+//   - "sqlite": SQLite file storage (requires CGO)
+//   - "postgresql": PostgreSQL storage (requires PostgreSQLURL)
+//
+// Graceful Degradation:
+//   - Unknown types fall back to "memory"
+//   - Initialization failure is logged but doesn't prevent adapter startup
+//   - storePlugin remains nil if initialization fails
 func (a *Adapter) initStoragePlugin(cfg *StorageConfig, logger *slog.Logger) error {
 	// Create storage backend using factory
 	registry := storage.GlobalRegistry()
@@ -170,12 +180,12 @@ func (a *Adapter) initStoragePlugin(cfg *StorageConfig, logger *slog.Logger) err
 		store, _ = registry.Get("memory", nil)
 	}
 
-	// Initialize storage
+	// Initialize storage backend (creates tables if needed)
 	if err := store.Initialize(context.Background()); err != nil {
 		return err
 	}
 
-	// Create session manager
+	// Create session manager for consistent session ID generation
 	sessionMgr := session.NewSessionManager("hotplex")
 
 	// Create message store plugin
@@ -240,7 +250,13 @@ func (a *Adapter) Stop() error {
 	return a.Adapter.Stop()
 }
 
-// storeUserMessage stores user message if storage is enabled
+// storeUserMessage stores a user message to the persistent storage if enabled.
+//
+// Session ID Design:
+//   - SessionID is derived from (platform, botUserID, channelID, threadTS) - NOT userID
+//   - This ensures all messages in a thread share the same session, regardless of sender
+//   - ChatUserID in MessageContext is set to msg.UserID to identify the actual sender
+//   - This enables: (1) thread-based history retrieval, (2) user-filtered queries
 func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 	if a.storePlugin == nil {
 		return
@@ -249,8 +265,7 @@ func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 	channelID, _ := msg.Metadata["channel_id"].(string)
 	threadTS, _ := msg.Metadata["thread_ts"].(string)
 
-	// Use stored session manager for consistent session ID generation
-	// Note: sessionID is thread-based (empty userID) to ensure user and bot messages share the same session
+	// Generate session context with empty userID - session is thread-based, not user-based
 	sessionCtx := a.sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
 
 	msgCtx, err := base.NewMessageContextBuilder().
@@ -271,14 +286,18 @@ func (a *Adapter) storeUserMessage(ctx context.Context, msg *base.ChatMessage) {
 	}
 }
 
-// storeBotResponse stores bot response if storage is enabled
+// storeBotResponse stores a bot response to the persistent storage if enabled.
+//
+// Session ID Design (same as storeUserMessage):
+//   - SessionID is derived from (platform, botUserID, channelID, threadTS) - NOT userID
+//   - Empty ChatUserID in MessageContext indicates bot as sender
+//   - This ensures bot responses are grouped with user messages in the same thread session
 func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, threadTS, content string) {
 	if a.storePlugin == nil {
 		return
 	}
 
-	// Use stored session manager for consistent session ID generation
-	// Note: userID is empty for bot responses, matching sessionID generation in GetThreadHistory
+	// Generate session context with empty userID for consistent session ID
 	sessionCtx := a.sessionMgr.CreateSessionContext("slack", "", a.config.BotUserID, channelID, threadTS, "claude")
 
 	msgCtx, err := base.NewMessageContextBuilder().
@@ -298,18 +317,21 @@ func (a *Adapter) storeBotResponse(ctx context.Context, sessionID, channelID, th
 	}
 }
 
-// GetThreadHistory retrieves message history for a thread session
-// Returns messages in chronological order (oldest first)
+// GetThreadHistory retrieves message history for a thread session.
+// Returns messages in chronological order (oldest first) for AI context building.
+//
+// Query Design:
+//   - SessionID is generated with empty userID to match how messages are stored
+//   - This retrieves ALL messages in the thread (both user and bot)
+//   - Use GetThreadHistoryByUser for user-filtered queries
 func (a *Adapter) GetThreadHistory(ctx context.Context, channelID, threadTS string, limit int) ([]*storage.ChatAppMessage, error) {
 	if a.storePlugin == nil {
 		return nil, fmt.Errorf("storage not enabled")
 	}
 
-	// Use stored session manager for consistent session ID generation
-	// Empty userID for thread-based session (matches storeUserMessage/storeBotResponse)
+	// Generate session ID with empty userID - must match storeUserMessage/storeBotResponse
 	sessionID := a.sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
 
-	// Query messages
 	if limit <= 0 {
 		limit = 100
 	}
@@ -358,23 +380,29 @@ func (a *Adapter) GetThreadHistoryAsString(ctx context.Context, channelID, threa
 	return formatMessagesAsString(messages), nil
 }
 
-// GetThreadHistoryByUser retrieves message history for a thread session, filtered by user ID
-// This provides database-level filtering by ChatUserID for efficient queries
+// GetThreadHistoryByUser retrieves message history filtered by a specific user ID.
+//
+// Use Case:
+//   - Query messages from a specific user in a multi-user thread
+//   - Database-level filtering for better performance than in-memory filtering
+//
+// Design:
+//   - SessionID matches GetThreadHistory (thread-based, empty userID)
+//   - ChatUserID filter is applied at database level for efficiency
 func (a *Adapter) GetThreadHistoryByUser(ctx context.Context, channelID, threadTS, userID string, limit int) ([]*storage.ChatAppMessage, error) {
 	if a.storePlugin == nil {
 		return nil, fmt.Errorf("storage not enabled")
 	}
 
-	// Use stored session manager for consistent session ID generation
+	// Generate session ID with empty userID for thread-level session
 	sessionID := a.sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
 
-	// Query messages with ChatUserID filter
 	if limit <= 0 {
 		limit = 100
 	}
 	query := &storage.MessageQuery{
 		ChatSessionID: sessionID,
-		ChatUserID:    userID, // Filter by actual user ID at database level
+		ChatUserID:    userID, // Database-level filter by actual sender
 		Limit:         limit,
 		Ascending:     true,
 	}

--- a/chatapps/slack/config.go
+++ b/chatapps/slack/config.go
@@ -72,6 +72,8 @@ type StorageConfig struct {
 	Type string
 	// SQLite specific config
 	SQLitePath string
+	// PostgreSQL connection URL (e.g., "postgres://user:pass@localhost:5432/hotplex")
+	PostgreSQLURL string
 	// StreamEnabled enables streaming message buffering
 	StreamEnabled bool
 	// StreamTimeout is the timeout for streaming buffer (default 5min)

--- a/chatapps/slack/config.go
+++ b/chatapps/slack/config.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 )
 
 // pairingState holds runtime pairing state with thread-safe access
@@ -58,6 +59,23 @@ type Config struct {
 	// BroadcastResponder generates responses for broadcast messages (no @ mention).
 	// If nil, uses DefaultBroadcastResponse.
 	BroadcastResponder BroadcastResponder
+
+	// Storage configuration for message persistence
+	Storage *StorageConfig
+}
+
+// StorageConfig holds message storage configuration for Slack adapter
+type StorageConfig struct {
+	// Enabled enables message storage
+	Enabled bool
+	// Type: "memory", "sqlite", "postgresql"
+	Type string
+	// SQLite specific config
+	SQLitePath string
+	// StreamEnabled enables streaming message buffering
+	StreamEnabled bool
+	// StreamTimeout is the timeout for streaming buffer (default 5min)
+	StreamTimeout time.Duration
 }
 
 // Token format patterns - supports both legacy 3-part and new 4-part Slack token formats

--- a/chatapps/slack/config.go
+++ b/chatapps/slack/config.go
@@ -60,19 +60,34 @@ type Config struct {
 	// If nil, uses DefaultBroadcastResponse.
 	BroadcastResponder BroadcastResponder
 
-	// Storage configuration for message persistence
+	// Storage configuration for message persistence (optional)
+	// When enabled, stores user messages and bot responses for history retrieval
 	Storage *StorageConfig
 }
 
-// StorageConfig holds message storage configuration for Slack adapter
+// StorageConfig holds message storage configuration for Slack adapter.
+//
+// Storage Architecture:
+//   - Session ID is derived from (platform, botUserID, channelID, threadTS)
+//   - Messages are grouped by thread, enabling conversation history retrieval
+//   - ChatUserID field distinguishes message sender for user-filtered queries
+//
+// Example Usage:
+//
+//	&StorageConfig{
+//	    Enabled:   true,
+//	    Type:      "sqlite",
+//	    SQLitePath: "data/slack_messages.db",
+//	}
 type StorageConfig struct {
 	// Enabled enables message storage
 	Enabled bool
-	// Type: "memory", "sqlite", "postgresql"
+	// Type: "memory" (default), "sqlite", "postgresql"
 	Type string
-	// SQLite specific config
+	// SQLitePath: Path to SQLite database file (only for type="sqlite")
 	SQLitePath string
-	// PostgreSQL connection URL (e.g., "postgres://user:pass@localhost:5432/hotplex")
+	// PostgreSQLURL: Connection URL for PostgreSQL (only for type="postgresql")
+	// Format: "postgres://user:pass@host:port/dbname"
 	PostgreSQLURL string
 	// StreamEnabled enables streaming message buffering
 	StreamEnabled bool

--- a/chatapps/slack/events.go
+++ b/chatapps/slack/events.go
@@ -217,6 +217,9 @@ func (a *Adapter) handleEventCallback(ctx context.Context, teamID string, eventD
 		msg.Metadata[k] = v
 	}
 
+	// Store user message if storage is enabled
+	a.storeUserMessage(ctx, msg)
+
 	a.webhook.Run(ctx, a.Handler(), msg)
 }
 

--- a/chatapps/slack/messages.go
+++ b/chatapps/slack/messages.go
@@ -498,6 +498,17 @@ func (a *Adapter) StopStream(ctx context.Context, channelID, messageTS string) e
 
 // NewStreamWriter creates a platform-specific streaming writer
 // Returns StreamWriter interface for platform-agnostic abstraction
+// The writer automatically stores the final response when closed (if storage is enabled)
 func (a *Adapter) NewStreamWriter(ctx context.Context, channelID, threadTS string) base.StreamWriter {
-	return NewNativeStreamingWriter(ctx, a, channelID, threadTS, nil)
+	writer := NewNativeStreamingWriter(ctx, a, channelID, threadTS, nil)
+
+	// Set up storage callback to persist the final response when stream closes
+	if a.storePlugin != nil && a.sessionMgr != nil {
+		sessionID := a.sessionMgr.GetChatSessionID("slack", "", a.config.BotUserID, channelID, threadTS)
+		writer.SetStoreCallback(func(content string) {
+			a.storeBotResponse(ctx, sessionID, channelID, threadTS, content)
+		})
+	}
+
+	return writer
 }

--- a/chatapps/slack/messages.go
+++ b/chatapps/slack/messages.go
@@ -116,8 +116,8 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 
 	// Store bot response for plain text messages
 	err := a.SendToChannelSDK(ctx, channelID, msg.Content, threadTS)
-	if err == nil {
-		// For plain text messages without explicit type, store as final response
+	if err == nil && types.MessageType(msg.Type).IsStorable() {
+		// Only store if message type is storable (user_input or final_response)
 		a.storeBotResponse(ctx, sessionID, channelID, threadTS, msg.Content)
 	}
 	return err

--- a/chatapps/slack/messages.go
+++ b/chatapps/slack/messages.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/types"
 	"github.com/slack-go/slack"
 )
 
@@ -86,6 +87,10 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 			if messageTS != "" {
 				err := a.UpdateMessageSDK(ctx, channelID, messageTS, blocks, fallbackText)
 				if err == nil {
+					// Store bot response for final responses
+					if types.MessageType(msg.Type).IsStorable() {
+						a.storeBotResponse(ctx, sessionID, channelID, threadTS, fallbackText)
+					}
 					return nil
 				}
 
@@ -100,11 +105,22 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 			if ts != "" && msg.Metadata != nil {
 				msg.Metadata["message_ts"] = ts
 			}
+
+			// Store bot response for final responses
+			if types.MessageType(msg.Type).IsStorable() {
+				a.storeBotResponse(ctx, sessionID, channelID, threadTS, fallbackText)
+			}
 			return nil
 		}
 	}
 
-	return a.SendToChannelSDK(ctx, channelID, msg.Content, threadTS)
+	// Store bot response for plain text messages
+	err := a.SendToChannelSDK(ctx, channelID, msg.Content, threadTS)
+	if err == nil {
+		// For plain text messages without explicit type, store as final response
+		a.storeBotResponse(ctx, sessionID, channelID, threadTS, msg.Content)
+	}
+	return err
 }
 
 // SendAttachment sends an attachment to a Slack channel using the Slack SDK

--- a/chatapps/slack/socketmode.go
+++ b/chatapps/slack/socketmode.go
@@ -154,6 +154,9 @@ func (a *Adapter) handleAppMentionEvent(teamID string, ev *slackevents.AppMentio
 		}
 	}
 
+	// Store user message if storage is enabled
+	a.storeUserMessage(a.socketModeCtx, msg)
+
 	a.webhook.Run(a.socketModeCtx, a.Handler(), msg)
 }
 
@@ -285,6 +288,9 @@ func (a *Adapter) handleSocketModeMessageEvent(teamID string, ev *slackevents.Me
 			a.channelToUser.Store(ev.Channel, ev.User)
 		}
 	}
+
+	// Store user message if storage is enabled
+	a.storeUserMessage(a.socketModeCtx, msg)
 
 	a.webhook.Run(a.socketModeCtx, a.Handler(), msg)
 }

--- a/chatapps/slack/storage_test.go
+++ b/chatapps/slack/storage_test.go
@@ -346,3 +346,272 @@ func TestAdapter_StoreBotResponse_StorageDisabled(t *testing.T) {
 	adapter.storeBotResponse(context.Background(), "session-id", "C123", "1234567890.123456", "Hello")
 	// No assertion needed - just checking it doesn't panic
 }
+
+// =============================================================================
+// Round-Trip Tests (Store + Retrieve)
+// =============================================================================
+
+func TestAdapter_StoreAndRetrieve_RoundTrip(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		BotUserID:     "B123",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+	defer func() { _ = adapter.Stop() }()
+
+	ctx := context.Background()
+	channelID := "C12345"
+	threadTS := "1234567890.123456"
+
+	// Store user message
+	userMsg := &base.ChatMessage{
+		UserID:  "U456",
+		Content: "Hello from user",
+		Metadata: map[string]any{
+			"channel_id": channelID,
+			"thread_ts":  threadTS,
+		},
+	}
+	adapter.storeUserMessage(ctx, userMsg)
+
+	// Store bot response
+	adapter.storeBotResponse(ctx, "test-session", channelID, threadTS, "Hello from bot")
+
+	// Retrieve messages
+	messages, err := adapter.GetThreadHistory(ctx, channelID, threadTS, 100)
+	if err != nil {
+		t.Fatalf("GetThreadHistory failed: %v", err)
+	}
+
+	// Verify round-trip data integrity
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d", len(messages))
+	}
+
+	// Find user and bot messages (order may vary due to storage implementation)
+	var userMessage, botMessage *storage.ChatAppMessage
+	for _, msg := range messages {
+		switch msg.MessageType {
+		case types.MessageTypeUserInput:
+			userMessage = msg
+		case types.MessageTypeFinalResponse:
+			botMessage = msg
+		}
+	}
+
+	// Verify user message
+	if userMessage == nil {
+		t.Fatal("User message not found in results")
+	}
+	if userMessage.Content != "Hello from user" {
+		t.Errorf("Expected user content 'Hello from user', got %q", userMessage.Content)
+	}
+	if userMessage.ChatUserID != "U456" {
+		t.Errorf("Expected ChatUserID 'U456', got %q", userMessage.ChatUserID)
+	}
+
+	// Verify bot response
+	if botMessage == nil {
+		t.Fatal("Bot message not found in results")
+	}
+	if botMessage.Content != "Hello from bot" {
+		t.Errorf("Expected bot content 'Hello from bot', got %q", botMessage.Content)
+	}
+}
+
+func TestAdapter_StoreAndRetrieveByUser_RoundTrip(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		BotUserID:     "B123",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+	defer func() { _ = adapter.Stop() }()
+
+	ctx := context.Background()
+	channelID := "C789"
+	threadTS := "9876543210.654321"
+	userID1 := "U111"
+	userID2 := "U222"
+
+	// Store messages from two users
+	adapter.storeUserMessage(ctx, &base.ChatMessage{
+		UserID:  userID1,
+		Content: "Message from user 1",
+		Metadata: map[string]any{
+			"channel_id": channelID,
+			"thread_ts":  threadTS,
+		},
+	})
+
+	adapter.storeUserMessage(ctx, &base.ChatMessage{
+		UserID:  userID2,
+		Content: "Message from user 2",
+		Metadata: map[string]any{
+			"channel_id": channelID,
+			"thread_ts":  threadTS,
+		},
+	})
+
+	adapter.storeBotResponse(ctx, "test-session", channelID, threadTS, "Bot response")
+
+	// Retrieve all messages - should have 3
+	allMessages, err := adapter.GetThreadHistory(ctx, channelID, threadTS, 100)
+	if err != nil {
+		t.Fatalf("GetThreadHistory failed: %v", err)
+	}
+	if len(allMessages) != 3 {
+		t.Fatalf("Expected 3 total messages, got %d", len(allMessages))
+	}
+
+	// Retrieve messages filtered by user1 - should have 1
+	user1Messages, err := adapter.GetThreadHistoryByUser(ctx, channelID, threadTS, userID1, 100)
+	if err != nil {
+		t.Fatalf("GetThreadHistoryByUser failed: %v", err)
+	}
+	if len(user1Messages) != 1 {
+		t.Fatalf("Expected 1 message for user1, got %d", len(user1Messages))
+	}
+	if user1Messages[0].Content != "Message from user 1" {
+		t.Errorf("Expected 'Message from user 1', got %q", user1Messages[0].Content)
+	}
+	if user1Messages[0].ChatUserID != userID1 {
+		t.Errorf("Expected ChatUserID %q, got %q", userID1, user1Messages[0].ChatUserID)
+	}
+
+	// Retrieve messages filtered by user2 - should have 1
+	user2Messages, err := adapter.GetThreadHistoryByUser(ctx, channelID, threadTS, userID2, 100)
+	if err != nil {
+		t.Fatalf("GetThreadHistoryByUser for user2 failed: %v", err)
+	}
+	if len(user2Messages) != 1 {
+		t.Fatalf("Expected 1 message for user2, got %d", len(user2Messages))
+	}
+	if user2Messages[0].Content != "Message from user 2" {
+		t.Errorf("Expected 'Message from user 2', got %q", user2Messages[0].Content)
+	}
+
+	// Retrieve messages for non-existent user - should have 0
+	noMessages, err := adapter.GetThreadHistoryByUser(ctx, channelID, threadTS, "U999", 100)
+	if err != nil {
+		t.Fatalf("GetThreadHistoryByUser for non-existent user failed: %v", err)
+	}
+	if len(noMessages) != 0 {
+		t.Errorf("Expected 0 messages for non-existent user, got %d", len(noMessages))
+	}
+}
+
+// =============================================================================
+// GetThreadHistoryByUser Tests
+// =============================================================================
+
+func TestAdapter_GetThreadHistoryByUser_StorageDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage:       nil,
+	}, logger, base.WithoutServer())
+
+	ctx := context.Background()
+	_, err := adapter.GetThreadHistoryByUser(ctx, "C123", "1234567890.123456", "U456", 10)
+	if err == nil {
+		t.Error("Expected error when storage is disabled")
+	}
+	if err.Error() != "storage not enabled" {
+		t.Errorf("Expected 'storage not enabled' error, got: %v", err)
+	}
+}
+
+func TestAdapter_GetThreadHistoryByUser_EmptyResult(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+
+	ctx := context.Background()
+	messages, err := adapter.GetThreadHistoryByUser(ctx, "C123", "1234567890.123456", "U456", 10)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Errorf("Expected empty messages, got %d", len(messages))
+	}
+
+	// Clean up
+	_ = adapter.Stop()
+}
+
+func TestAdapter_GetThreadHistoryByUserAsString(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		BotUserID:     "B123",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+	defer func() { _ = adapter.Stop() }()
+
+	ctx := context.Background()
+	channelID := "C123"
+	threadTS := "1234567890.123456"
+
+	// Store a message
+	adapter.storeUserMessage(ctx, &base.ChatMessage{
+		UserID:  "U456",
+		Content: "Test message",
+		Metadata: map[string]any{
+			"channel_id": channelID,
+			"thread_ts":  threadTS,
+		},
+	})
+
+	// Retrieve as string
+	result, err := adapter.GetThreadHistoryByUserAsString(ctx, channelID, threadTS, "U456", 10)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Error("Expected non-empty string result")
+	}
+	if !containsString(result, "Test message") {
+		t.Errorf("Expected result to contain 'Test message', got: %q", result)
+	}
+}
+
+// Helper function
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/chatapps/slack/storage_test.go
+++ b/chatapps/slack/storage_test.go
@@ -1,0 +1,348 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/plugins/storage"
+	"github.com/hrygo/hotplex/types"
+)
+
+// =============================================================================
+// Storage Config Tests
+// =============================================================================
+
+func TestStorageConfig_Defaults(t *testing.T) {
+	cfg := &StorageConfig{}
+	if cfg.Enabled {
+		t.Error("Expected Enabled to be false by default")
+	}
+	if cfg.Type != "" {
+		t.Error("Expected Type to be empty by default")
+	}
+}
+
+func TestStorageConfig_PostgreSQL(t *testing.T) {
+	cfg := &StorageConfig{
+		Enabled:       true,
+		Type:          "postgresql",
+		PostgreSQLURL: "postgres://user:pass@localhost:5432/test",
+	}
+	if !cfg.Enabled {
+		t.Error("Expected Enabled to be true")
+	}
+	if cfg.Type != "postgresql" {
+		t.Error("Expected Type to be postgresql")
+	}
+	if cfg.PostgreSQLURL != "postgres://user:pass@localhost:5432/test" {
+		t.Error("PostgreSQLURL mismatch")
+	}
+}
+
+// =============================================================================
+// initStoragePlugin Tests
+// =============================================================================
+
+func TestAdapter_StorageDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage:       nil, // No storage config
+	}, logger, base.WithoutServer())
+
+	if adapter.storePlugin != nil {
+		t.Error("Expected storePlugin to be nil when storage is disabled")
+	}
+}
+
+func TestAdapter_StorageEnabled_Memory(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+
+	if adapter.storePlugin == nil {
+		t.Error("Expected storePlugin to be initialized")
+	}
+
+	// Clean up
+	if err := adapter.Stop(); err != nil {
+		t.Logf("Warning: failed to stop adapter: %v", err)
+	}
+}
+
+func TestAdapter_Storage_SQLite(t *testing.T) {
+	// Skip if CGO is not enabled (sqlite3 requires CGO)
+	if testing.Short() {
+		t.Skip("Skipping SQLite test in short mode")
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled:   true,
+			Type:      "sqlite",
+			SQLitePath: t.TempDir() + "/test.db",
+		},
+	}, logger, base.WithoutServer())
+
+	// SQLite may fail if CGO is not enabled, which is acceptable in CI
+	if adapter.storePlugin == nil {
+		t.Skip("SQLite storage not available (likely CGO disabled)")
+	}
+
+	// Clean up
+	if err := adapter.Stop(); err != nil {
+		t.Logf("Warning: failed to stop adapter: %v", err)
+	}
+}
+
+func TestAdapter_Storage_PostgreSQL_MissingURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled:       true,
+			Type:          "postgresql",
+			PostgreSQLURL: "", // Missing URL
+		},
+	}, logger, base.WithoutServer())
+
+	// Should fail gracefully and not initialize storage
+	if adapter.storePlugin != nil {
+		t.Error("Expected storePlugin to be nil when PostgreSQLURL is missing")
+	}
+}
+
+func TestAdapter_Storage_UnknownType(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "unknown",
+		},
+	}, logger, base.WithoutServer())
+
+	// Should fall back to memory storage
+	if adapter.storePlugin == nil {
+		t.Error("Expected storePlugin to fall back to memory for unknown type")
+	}
+
+	// Clean up
+	if err := adapter.Stop(); err != nil {
+		t.Logf("Warning: failed to stop adapter: %v", err)
+	}
+}
+
+// =============================================================================
+// GetThreadHistory Tests (with memory storage)
+// =============================================================================
+
+func TestAdapter_GetThreadHistory_StorageDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage:       nil,
+	}, logger, base.WithoutServer())
+
+	ctx := context.Background()
+	_, err := adapter.GetThreadHistory(ctx, "C123", "1234567890.123456", 10)
+	if err == nil {
+		t.Error("Expected error when storage is disabled")
+	}
+	if err.Error() != "storage not enabled" {
+		t.Errorf("Expected 'storage not enabled' error, got: %v", err)
+	}
+}
+
+func TestAdapter_GetThreadHistory_EmptyResult(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+
+	ctx := context.Background()
+	messages, err := adapter.GetThreadHistory(ctx, "C123", "1234567890.123456", 10)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Errorf("Expected empty messages, got %d", len(messages))
+	}
+
+	// Clean up
+	_ = adapter.Stop()
+}
+
+func TestAdapter_GetThreadHistoryAsString_EmptyResult(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage: &StorageConfig{
+			Enabled: true,
+			Type:    "memory",
+		},
+	}, logger, base.WithoutServer())
+
+	ctx := context.Background()
+	result, err := adapter.GetThreadHistoryAsString(ctx, "C123", "1234567890.123456", 10)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if result != "" {
+		t.Errorf("Expected empty string, got: %q", result)
+	}
+
+	// Clean up
+	_ = adapter.Stop()
+}
+
+// =============================================================================
+// formatMessagesAsString Tests
+// =============================================================================
+
+func TestFormatMessagesAsString_Empty(t *testing.T) {
+	result := formatMessagesAsString(nil)
+	if result != "" {
+		t.Errorf("Expected empty string for nil, got: %q", result)
+	}
+
+	result = formatMessagesAsString([]*storage.ChatAppMessage{})
+	if result != "" {
+		t.Errorf("Expected empty string for empty slice, got: %q", result)
+	}
+}
+
+func TestFormatMessagesAsString_UserMessage(t *testing.T) {
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	messages := []*storage.ChatAppMessage{
+		{
+			MessageType: types.MessageTypeUserInput,
+			Content:     "Hello, world!",
+			CreatedAt:   now,
+		},
+	}
+
+	result := formatMessagesAsString(messages)
+	expected := "[2024-01-15 10:30:00] User: Hello, world!\n"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestFormatMessagesAsString_BotResponse(t *testing.T) {
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	messages := []*storage.ChatAppMessage{
+		{
+			MessageType: types.MessageTypeFinalResponse,
+			Content:     "Hi there!",
+			CreatedAt:   now,
+		},
+	}
+
+	result := formatMessagesAsString(messages)
+	expected := "[2024-01-15 10:30:00] Assistant: Hi there!\n"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestFormatMessagesAsString_Multiple(t *testing.T) {
+	baseTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	messages := []*storage.ChatAppMessage{
+		{
+			MessageType: types.MessageTypeUserInput,
+			Content:     "Hello",
+			CreatedAt:   baseTime,
+		},
+		{
+			MessageType: types.MessageTypeFinalResponse,
+			Content:     "Hi there!",
+			CreatedAt:   baseTime.Add(5 * time.Second),
+		},
+		{
+			MessageType: types.MessageTypeUserInput,
+			Content:     "How are you?",
+			CreatedAt:   baseTime.Add(10 * time.Second),
+		},
+	}
+
+	result := formatMessagesAsString(messages)
+	expected := `[2024-01-15 10:30:00] User: Hello
+[2024-01-15 10:30:05] Assistant: Hi there!
+[2024-01-15 10:30:10] User: How are you?
+`
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+// =============================================================================
+// storeUserMessage / storeBotResponse Tests
+// =============================================================================
+
+func TestAdapter_StoreUserMessage_StorageDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage:       nil,
+	}, logger, base.WithoutServer())
+
+	// Should not panic when storage is disabled
+	msg := &base.ChatMessage{
+		UserID:  "U123",
+		Content: "Hello",
+		Metadata: map[string]any{
+			"channel_id": "C123",
+			"thread_ts":  "1234567890.123456",
+		},
+	}
+	adapter.storeUserMessage(context.Background(), msg)
+	// No assertion needed - just checking it doesn't panic
+}
+
+func TestAdapter_StoreBotResponse_StorageDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	adapter := NewAdapter(&Config{
+		BotToken:      "xoxb-test-bot-token-123456789012-abcdef",
+		SigningSecret: "test-signing-secret-123456789012345",
+		Mode:          "http",
+		Storage:       nil,
+	}, logger, base.WithoutServer())
+
+	// Should not panic when storage is disabled
+	adapter.storeBotResponse(context.Background(), "session-id", "C123", "1234567890.123456", "Hello")
+	// No assertion needed - just checking it doesn't panic
+}

--- a/chatapps/slack/streaming_writer.go
+++ b/chatapps/slack/streaming_writer.go
@@ -36,6 +36,12 @@ type NativeStreamingWriter struct {
 	flushTrigger chan struct{}
 	closeChan    chan struct{}
 	wg           sync.WaitGroup
+
+	// 完整内容累积（用于存储）
+	fullContent bytes.Buffer
+
+	// 存储回调（可选）
+	storeCallback func(content string)
 }
 
 // NewNativeStreamingWriter 创建新的原生流式写入器
@@ -59,6 +65,14 @@ func NewNativeStreamingWriter(
 	go w.flushLoop()
 
 	return w
+}
+
+// SetStoreCallback sets the callback to store the complete message content
+// when the stream is closed. This enables persistent storage of streaming responses.
+func (w *NativeStreamingWriter) SetStoreCallback(callback func(content string)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.storeCallback = callback
 }
 
 func (w *NativeStreamingWriter) flushLoop() {
@@ -135,6 +149,7 @@ func (w *NativeStreamingWriter) Write(p []byte) (n int, err error) {
 	}
 
 	w.buf.Write(p)
+	w.fullContent.Write(p) // 累积完整内容用于存储
 
 	// 如果超过 rune 阈值，立即触发一次 flush
 	if utf8.RuneCount(w.buf.Bytes()) >= flushSize {
@@ -157,6 +172,8 @@ func (w *NativeStreamingWriter) Close() error {
 
 	w.closed = true
 	started := w.started
+	fullContent := w.fullContent.String()
+	storeCallback := w.storeCallback
 	w.mu.Unlock()
 
 	// 停止处理并等待残留缓冲区发送完成
@@ -173,6 +190,11 @@ func (w *NativeStreamingWriter) Close() error {
 	// 调用完成回调
 	if w.onComplete != nil {
 		w.onComplete(w.messageTS)
+	}
+
+	// 存储完整内容（如果有存储回调）
+	if storeCallback != nil && fullContent != "" {
+		storeCallback(fullContent)
 	}
 
 	if stopErr != nil {

--- a/plugins/storage/interface.go
+++ b/plugins/storage/interface.go
@@ -36,6 +36,7 @@ type ChatAppMessage struct {
 // MessageQuery 消息查询条件
 type MessageQuery struct {
 	ChatSessionID     string
+	ChatUserID        string         // 按用户ID过滤
 	EngineSessionID   uuid.UUID
 	ProviderType      string
 	ProviderSessionID string

--- a/plugins/storage/memory.go
+++ b/plugins/storage/memory.go
@@ -61,6 +61,9 @@ func (m *MemoryStorage) List(ctx context.Context, query *MessageQuery) ([]*ChatA
 		if query.ChatSessionID != "" && msg.ChatSessionID != query.ChatSessionID {
 			continue
 		}
+		if query.ChatUserID != "" && msg.ChatUserID != query.ChatUserID {
+			continue
+		}
 		results = append(results, msg)
 	}
 	return results, nil
@@ -75,6 +78,9 @@ func (m *MemoryStorage) Count(ctx context.Context, query *MessageQuery) (int64, 
 			continue
 		}
 		if query.ChatSessionID != "" && msg.ChatSessionID != query.ChatSessionID {
+			continue
+		}
+		if query.ChatUserID != "" && msg.ChatUserID != query.ChatUserID {
 			continue
 		}
 		count++

--- a/plugins/storage/postgres.go
+++ b/plugins/storage/postgres.go
@@ -362,6 +362,11 @@ func (p *PostgreStorage) buildListQuery(query *MessageQuery) (string, []interfac
 		args = append(args, query.ChatSessionID)
 		argNum++
 	}
+	if query.ChatUserID != "" {
+		conditions = append(conditions, fmt.Sprintf("chat_user_id = $%d", argNum))
+		args = append(args, query.ChatUserID)
+		argNum++
+	}
 	if query.EngineSessionID != uuid.Nil {
 		conditions = append(conditions, fmt.Sprintf("engine_session_id = $%d", argNum))
 		args = append(args, query.EngineSessionID)
@@ -427,10 +432,17 @@ func (p *PostgreStorage) buildListQuery(query *MessageQuery) (string, []interfac
 func (p *PostgreStorage) buildCountQuery(query *MessageQuery) (string, []interface{}) {
 	conditions := []string{}
 	var args []interface{}
+	argNum := 1
 
 	if query.ChatSessionID != "" {
-		conditions = append(conditions, fmt.Sprintf("chat_session_id = $%d", 1))
+		conditions = append(conditions, fmt.Sprintf("chat_session_id = $%d", argNum))
 		args = append(args, query.ChatSessionID)
+		argNum++
+	}
+	if query.ChatUserID != "" {
+		conditions = append(conditions, fmt.Sprintf("chat_user_id = $%d", argNum))
+		args = append(args, query.ChatUserID)
+		argNum++
 	}
 	if !query.IncludeDeleted {
 		conditions = append(conditions, "(deleted = FALSE OR deleted IS NULL)")

--- a/plugins/storage/postgres.go
+++ b/plugins/storage/postgres.go
@@ -442,7 +442,6 @@ func (p *PostgreStorage) buildCountQuery(query *MessageQuery) (string, []interfa
 	if query.ChatUserID != "" {
 		conditions = append(conditions, fmt.Sprintf("chat_user_id = $%d", argNum))
 		args = append(args, query.ChatUserID)
-		argNum++
 	}
 	if !query.IncludeDeleted {
 		conditions = append(conditions, "(deleted = FALSE OR deleted IS NULL)")

--- a/plugins/storage/sqlite.go
+++ b/plugins/storage/sqlite.go
@@ -101,6 +101,10 @@ func (s *SQLiteStorage) List(ctx context.Context, query *MessageQuery) ([]*ChatA
 		sqlQuery += " AND chat_session_id = ?"
 		args = append(args, query.ChatSessionID)
 	}
+	if query.ChatUserID != "" {
+		sqlQuery += " AND chat_user_id = ?"
+		args = append(args, query.ChatUserID)
+	}
 	rows, err := s.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, err
@@ -121,6 +125,10 @@ func (s *SQLiteStorage) Count(ctx context.Context, query *MessageQuery) (int64, 
 	if query.ChatSessionID != "" {
 		sqlQuery += " AND chat_session_id = ?"
 		args = append(args, query.ChatSessionID)
+	}
+	if query.ChatUserID != "" {
+		sqlQuery += " AND chat_user_id = ?"
+		args = append(args, query.ChatUserID)
 	}
 	var count int64
 	err := s.db.QueryRowContext(ctx, sqlQuery, args...).Scan(&count)


### PR DESCRIPTION
## Summary
- Add StorageConfig to Slack adapter config for message persistence settings
- Initialize MessageStorePlugin in adapter with configurable storage backend
- Store user messages in HTTP and Socket Mode event handlers
- Store bot responses in message sender using IsStorable() whitelist
- Support SQLite, PostgreSQL, and Memory storage backends

## Changes
- adapter.go: Add storePlugin field, initialization, and helper methods
- config.go: Add StorageConfig struct with storage settings
- events.go: Add storeUserMessage() call in HTTP event handler
- socketmode.go: Add storeUserMessage() call in Socket Mode handlers
- messages.go: Add storeBotResponse() call in message sender

## Test Plan
- go build ./... passes
- go test ./... passes
- All existing Slack adapter tests pass

Resolves #195