### PR TITLE
fix(slack): prevent duplicate message sends from multiple fallback triggers

### DIFF
--- a/chatapps/base/types.go
+++ b/chatapps/base/types.go
@@ -179,6 +179,9 @@ type StreamWriter interface {
 	io.Closer
 	// MessageTS returns the message timestamp after stream starts
 	MessageTS() string
+	// FallbackUsed returns true if the stream used fallback mechanism
+	// This prevents duplicate message sends from multiple fallback triggers
+	FallbackUsed() bool
 }
 
 // StatusType defines AI working states

--- a/chatapps/engine_handler.go
+++ b/chatapps/engine_handler.go
@@ -895,6 +895,13 @@ func (c *StreamCallback) handleAnswer(data any) error {
 				return fmt.Errorf("streaming failed: %w, fallback failed: %v", err, sendErr)
 			}
 
+			// CRITICAL: Mark fallback as used to prevent duplicate sends from handleSessionStats
+			// This coordinates with the Close() fallback mechanism
+			c.mu.Lock()
+			c.streamWriterActive = false
+			c.accumulatedContent.Reset() // Clear accumulated content to prevent re-sending
+			c.mu.Unlock()
+
 			c.logger.Info("Fallback to non-streaming succeeded", "content_runes", len([]rune(fullContent)))
 			return nil
 		}
@@ -1045,6 +1052,10 @@ func (c *StreamCallback) handleSessionStats(data any) error {
 	}
 	c.mu.Unlock()
 
+	// Check if Close() already triggered its fallback mechanism
+	// This prevents duplicate sends when both Close() and handleSessionStats could trigger
+	streamUsedFallback := streamWriter != nil && streamWriter.FallbackUsed()
+
 	// Fallback mechanism: if streaming was never active but we have accumulated content,
 	// send the content via direct message.
 	//
@@ -1052,8 +1063,10 @@ func (c *StreamCallback) handleSessionStats(data any) error {
 	// The NativeStreamingWriter.Close() handles a DIFFERENT case: when streaming was active but
 	// failed mid-stream (integrity check failure or StopStream error). These two fallbacks are
 	// MUTUALLY EXCLUSIVE - this one triggers when !streamWasActive, Close() triggers when started.
+	// Additionally, we check FallbackUsed() to handle the edge case where handleAnswer already
+	// sent a fallback message before the stream was properly initialized.
 	// This prevents duplicate message sends.
-	if !streamWasActive && len(accumulatedContent) > 0 {
+	if !streamWasActive && !streamUsedFallback && len(accumulatedContent) > 0 {
 		c.logger.Info("Streaming was inactive, sending accumulated content via fallback",
 			"content_len", len(accumulatedContent))
 

--- a/chatapps/slack/streaming_writer.go
+++ b/chatapps/slack/streaming_writer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -17,6 +18,10 @@ const (
 	flushSize        = 20 // rune count threshold for immediate flush
 	maxAppendRetries = 3  // max retry attempts for AppendStream
 	retryDelay       = 50 * time.Millisecond
+
+	// StreamTTL is the maximum duration a Slack stream can live (~5 min TTL)
+	// We use 4 minutes to leave a safety buffer before the actual timeout
+	StreamTTL = 4 * time.Minute
 )
 
 // NativeStreamingWriter 实现 io.Writer 接口，封装 Slack 原生流式消息的生命周期管理
@@ -47,6 +52,10 @@ type NativeStreamingWriter struct {
 	bytesWritten      int64    // 成功写入的总字节数
 	bytesFlushed      int64    // 成功 flush 的总字节数
 	failedFlushChunks []string // 失败的 flush 块（用于潜在恢复）
+
+	// TTL 监控：检测流超时
+	streamStartTime time.Time // 流启动时间
+	streamExpired   bool      // 流是否已超时
 
 	// 存储回调（可选）
 	storeCallback func(content string)
@@ -116,10 +125,27 @@ func (w *NativeStreamingWriter) flushBuffer() {
 	contentLen := len(content)
 	w.buf.Reset()
 	started := w.started
+	streamExpired := w.streamExpired
+	streamStartTime := w.streamStartTime
 	w.mu.Unlock()
 
 	// 理论上只要有内容必然 started，前置拦截防空指针
 	if !started {
+		return
+	}
+
+	// TTL 检测：如果流已超时，不再尝试 AppendStream，直接记录失败
+	if streamExpired || time.Since(streamStartTime) > StreamTTL {
+		w.adapter.Logger().Warn("Stream TTL exceeded, marking as expired",
+			"channel_id", w.channelID,
+			"message_ts", w.messageTS,
+			"stream_age", time.Since(streamStartTime),
+			"ttl", StreamTTL)
+
+		w.mu.Lock()
+		w.streamExpired = true
+		w.failedFlushChunks = append(w.failedFlushChunks, content)
+		w.mu.Unlock()
 		return
 	}
 
@@ -128,6 +154,22 @@ func (w *NativeStreamingWriter) flushBuffer() {
 	for attempt := 1; attempt <= maxAppendRetries; attempt++ {
 		if err := w.adapter.AppendStream(w.ctx, w.channelID, w.messageTS, content); err != nil {
 			lastErr = err
+
+			// 检测流状态错误：如果是 message_not_in_streaming_state，立即停止重试
+			// 这表示流已经超时或被服务端关闭
+			if isStreamStateError(err) {
+				w.adapter.Logger().Warn("Stream state error detected, marking stream as expired",
+					"channel_id", w.channelID,
+					"message_ts", w.messageTS,
+					"error", err)
+
+				w.mu.Lock()
+				w.streamExpired = true
+				w.failedFlushChunks = append(w.failedFlushChunks, content)
+				w.mu.Unlock()
+				return
+			}
+
 			w.adapter.Logger().Warn("AppendStream failed, will retry",
 				"channel_id", w.channelID,
 				"message_ts", w.messageTS,
@@ -159,6 +201,17 @@ func (w *NativeStreamingWriter) flushBuffer() {
 		"error", lastErr)
 }
 
+// isStreamStateError checks if the error indicates the stream is no longer in streaming state
+func isStreamStateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "message_not_in_streaming_state") ||
+		strings.Contains(errStr, "streaming_state") ||
+		strings.Contains(errStr, "not_in_streaming")
+}
+
 // Write 实现 io.Writer 接口
 // 首次调用执行 StartStream 获取 TS；后续调用将内容追加到缓冲区并触发异步 AppendStream
 func (w *NativeStreamingWriter) Write(p []byte) (n int, err error) {
@@ -181,6 +234,7 @@ func (w *NativeStreamingWriter) Write(p []byte) (n int, err error) {
 		}
 		w.messageTS = messageTS
 		w.started = true
+		w.streamStartTime = time.Now() // 记录流启动时间用于 TTL 检测
 	}
 
 	w.buf.Write(p)
@@ -213,6 +267,7 @@ func (w *NativeStreamingWriter) Close() error {
 	bytesWritten := w.bytesWritten
 	bytesFlushed := w.bytesFlushed
 	failedChunks := w.failedFlushChunks
+	streamExpired := w.streamExpired
 	storeCallback := w.storeCallback
 	w.mu.Unlock()
 
@@ -225,14 +280,16 @@ func (w *NativeStreamingWriter) Close() error {
 	}
 
 	// 完整性校验：检查是否有失败的内容块
-	integrityOK := len(failedChunks) == 0 && bytesWritten == bytesFlushed
+	// 改进：即使 bytesWritten == bytesFlushed，如果有失败的 chunk 或流超时，也认为不完整
+	integrityOK := len(failedChunks) == 0 && bytesWritten == bytesFlushed && !streamExpired
 
 	if !integrityOK {
 		w.adapter.Logger().Warn("Stream integrity check failed",
 			"channel_id", w.channelID,
 			"bytes_written", bytesWritten,
 			"bytes_flushed", bytesFlushed,
-			"failed_chunks", len(failedChunks))
+			"failed_chunks", len(failedChunks),
+			"stream_expired", streamExpired)
 	}
 
 	// 结束远端流
@@ -353,7 +410,7 @@ func (w *NativeStreamingWriter) GetStats() StreamWriterStats {
 		BytesWritten:     w.bytesWritten,
 		BytesFlushed:     w.bytesFlushed,
 		FailedChunkCount: len(w.failedFlushChunks),
-		IntegrityOK:      len(w.failedFlushChunks) == 0 && w.bytesWritten == w.bytesFlushed,
+		IntegrityOK:      len(w.failedFlushChunks) == 0 && w.bytesWritten == w.bytesFlushed && !w.streamExpired,
 		FallbackUsed:     w.fallbackUsed,
 		ContentLength:    w.accumulatedContent.Len(),
 	}


### PR DESCRIPTION
## Summary

- Fixed duplicate Slack message sends caused by uncoordinated fallback mechanisms
- Added stream TTL monitoring to prevent content loss on stream timeout

## Changes

### Issue 235: Duplicate Message Prevention
- Added `FallbackUsed() bool` to `StreamWriter` interface for coordination
- Updated `handleAnswer` to mark state after fallback success (`streamWriterActive=false`, clear `accumulatedContent`)
- Updated `handleSessionStats` to check `FallbackUsed()` before sending fallback

### Issue 237: Stream TTL Monitoring
- Added `StreamTTL` (4 min) constant for proactive timeout detection
- Track `streamStartTime` in `Write()` for TTL monitoring
- Check TTL in `flushBuffer()` before attempting `AppendStream`
- Detect `message_not_in_streaming_state` error and mark stream expired immediately
- Improved integrity check to consider `streamExpired` flag
- Log detailed info when stream expires or state errors occur

## Root Causes

### Issue 235
Three fallback mechanisms could independently send messages:
1. `handleAnswer` - when `writer.Write()` fails
2. `NativeStreamingWriter.Close()` - on integrity check failure
3. `handleSessionStats` - when streaming was never active

### Issue 237
Slack native streaming messages have ~5 min TTL. After timeout:
- `AppendStream` calls fail with `message_not_in_streaming_state`
- Content written during invalid stream period was lost
- No proactive detection of stream expiration

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all tests)
- [x] Existing streaming writer tests pass

Resolves #235
Resolves #237
