### PR TITLE
feat(slack): implement App Home Capability Center

### DIFF
--- a/chatapps/slack/apphome/apphome_test.go
+++ b/chatapps/slack/apphome/apphome_test.go
@@ -1,0 +1,265 @@
+package apphome
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapability_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cap     Capability
+		wantErr bool
+	}{
+		{
+			name: "valid capability",
+			cap: Capability{
+				ID:             "test_cap",
+				Name:           "Test Capability",
+				Icon:           ":test:",
+				Description:    "A test capability",
+				Category:       "test",
+				PromptTemplate: "Test prompt: {{.input}}",
+				Enabled:        true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing ID",
+			cap: Capability{
+				Name:           "Test",
+				PromptTemplate: "Test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing name",
+			cap: Capability{
+				ID:             "test",
+				PromptTemplate: "Test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing prompt template",
+			cap: Capability{
+				ID:   "test",
+				Name: "Test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid parameter type",
+			cap: Capability{
+				ID:             "test",
+				Name:           "Test",
+				PromptTemplate: "Test",
+				Parameters: []Parameter{
+					{ID: "p1", Label: "P1", Type: "invalid"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "select without options",
+			cap: Capability{
+				ID:             "test",
+				Name:           "Test",
+				PromptTemplate: "Test",
+				Parameters: []Parameter{
+					{ID: "p1", Label: "P1", Type: "select"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "select with options",
+			cap: Capability{
+				ID:             "test",
+				Name:           "Test",
+				PromptTemplate: "Test: {{.p1}}",
+				Parameters: []Parameter{
+					{ID: "p1", Label: "P1", Type: "select", Options: []string{"a", "b"}},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cap.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRegistry_LoadFromBytes(t *testing.T) {
+	yamlData := `
+capabilities:
+  - id: test_cap
+    name: Test Capability
+    icon: ":test:"
+    description: A test
+    category: test
+    enabled: true
+    prompt_template: "Test: {{.input}}"
+    parameters:
+      - id: input
+        label: Input
+        type: text
+        required: true
+  - id: disabled_cap
+    name: Disabled
+    icon: ":x:"
+    description: Disabled
+    category: test
+    enabled: false
+    prompt_template: "Disabled"
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromBytes([]byte(yamlData))
+	require.NoError(t, err)
+
+	// Should have 1 capability (disabled one skipped)
+	assert.Equal(t, 1, registry.Count())
+
+	cap, ok := registry.Get("test_cap")
+	require.True(t, ok)
+	assert.Equal(t, "Test Capability", cap.Name)
+	assert.Len(t, cap.Parameters, 1)
+}
+
+func TestRegistry_GetByCategory(t *testing.T) {
+	registry := NewRegistry()
+
+	// Register test capabilities
+	require.NoError(t, registry.Register(Capability{
+		ID:             "code1",
+		Name:           "Code 1",
+		Category:       "code",
+		PromptTemplate: "Test",
+	}))
+	require.NoError(t, registry.Register(Capability{
+		ID:             "code2",
+		Name:           "Code 2",
+		Category:       "code",
+		PromptTemplate: "Test",
+	}))
+	require.NoError(t, registry.Register(Capability{
+		ID:             "debug1",
+		Name:           "Debug 1",
+		Category:       "debug",
+		PromptTemplate: "Test",
+	}))
+
+	codeCaps := registry.GetByCategory("code")
+	assert.Len(t, codeCaps, 2)
+
+	debugCaps := registry.GetByCategory("debug")
+	assert.Len(t, debugCaps, 1)
+
+	gitCaps := registry.GetByCategory("git")
+	assert.Len(t, gitCaps, 0)
+}
+
+func TestFormBuilder_BuildModal(t *testing.T) {
+	fb := NewFormBuilder()
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test Capability",
+		Description:    "Test description",
+		PromptTemplate: "Test: {{.input}}",
+		Parameters: []Parameter{
+			{
+				ID:          "input",
+				Label:       "Input",
+				Type:        "text",
+				Required:    true,
+				Placeholder: "Enter input",
+			},
+			{
+				ID:          "select_field",
+				Label:       "Select",
+				Type:        "select",
+				Options:     []string{"a", "b", "c"},
+				Placeholder: "Choose",
+			},
+		},
+	}
+
+	modal := fb.BuildModal(cap)
+	require.NotNil(t, modal)
+	assert.Equal(t, slack.VTModal, modal.Type)
+	assert.Equal(t, "test", modal.PrivateMetadata)
+	assert.NotEmpty(t, modal.Blocks.BlockSet)
+}
+
+func TestFormBuilder_ValidateParams(t *testing.T) {
+	fb := NewFormBuilder()
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test",
+		PromptTemplate: "Test",
+		Parameters: []Parameter{
+			{ID: "required_field", Label: "Required", Type: "text", Required: true},
+			{ID: "optional_field", Label: "Optional", Type: "text", Required: false},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		errors int
+	}{
+		{
+			name:   "all required provided",
+			params: map[string]string{"required_field": "value"},
+			errors: 0,
+		},
+		{
+			name:   "missing required",
+			params: map[string]string{},
+			errors: 1,
+		},
+		{
+			name:   "all provided",
+			params: map[string]string{"required_field": "value", "optional_field": "opt"},
+			errors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := fb.ValidateParams(cap, tt.params)
+			assert.Len(t, errors, tt.errors)
+		})
+	}
+}
+
+func TestBuilder_BuildFullHomeView(t *testing.T) {
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(Capability{
+		ID:             "code1",
+		Name:           "Code Review",
+		Icon:           ":mag:",
+		Description:    "Review code",
+		Category:       "code",
+		PromptTemplate: "Review: {{.code}}",
+	}))
+
+	builder := NewBuilder(registry)
+	view := builder.BuildFullHomeView()
+
+	require.NotNil(t, view)
+	assert.Equal(t, slack.VTHomeTab, view.Type)
+	assert.NotEmpty(t, view.Blocks.BlockSet)
+}

--- a/chatapps/slack/apphome/apphome_test.go
+++ b/chatapps/slack/apphome/apphome_test.go
@@ -1,6 +1,9 @@
 package apphome
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/slack-go/slack"
@@ -262,4 +265,206 @@ func TestBuilder_BuildFullHomeView(t *testing.T) {
 	require.NotNil(t, view)
 	assert.Equal(t, slack.VTHomeTab, view.Type)
 	assert.NotEmpty(t, view.Blocks.BlockSet)
+}
+
+func TestIsCapabilityAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		actionID string
+		want     bool
+	}{
+		{
+			name:     "capability action",
+			actionID: "cap_click:test_cap",
+			want:     true,
+		},
+		{
+			name:     "non-capability action",
+			actionID: "other_action",
+			want:     false,
+		},
+		{
+			name:     "empty action",
+			actionID: "",
+			want:     false,
+		},
+		{
+			name:     "prefix only",
+			actionID: ActionIDPrefix,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCapabilityAction(tt.actionID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractCapabilityID(t *testing.T) {
+	tests := []struct {
+		name     string
+		actionID string
+		want     string
+	}{
+		{
+			name:     "extract capability ID",
+			actionID: "cap_click:code_review",
+			want:     "code_review",
+		},
+		{
+			name:     "no prefix",
+			actionID: "other",
+			want:     "other",
+		},
+		{
+			name:     "empty",
+			actionID: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractCapabilityID(tt.actionID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExecutor_RenderPrompt(t *testing.T) {
+	executor := NewExecutor()
+
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test",
+		PromptTemplate: "Hello {{.name}}, your score is {{.score}}",
+	}
+
+	prompt, err := executor.renderPrompt(cap, map[string]string{
+		"name":  "Alice",
+		"score": "100",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello Alice, your score is 100", prompt)
+}
+
+func TestExecutor_RenderPrompt_InvalidTemplate(t *testing.T) {
+	executor := NewExecutor()
+
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test",
+		PromptTemplate: "Hello {{.name}",
+	}
+
+	_, err := executor.renderPrompt(cap, map[string]string{"name": "Alice"})
+	assert.Error(t, err)
+}
+
+func TestExecutor_RenderPrompt_MissingParam(t *testing.T) {
+	executor := NewExecutor()
+
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test",
+		PromptTemplate: "Hello {{.name}}",
+	}
+
+	prompt, err := executor.renderPrompt(cap, map[string]string{})
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "Hello")
+}
+
+func TestBrainIntegration_PreparePrompt_NoBrain(t *testing.T) {
+	bi := &BrainIntegration{brain: nil}
+
+	prompt, err := bi.PreparePrompt(context.Background(), Capability{}, map[string]string{}, "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "test prompt", prompt)
+}
+
+func TestBrainIntegration_CompressContext_NoBrain(t *testing.T) {
+	bi := &BrainIntegration{brain: nil}
+
+	compressed, err := bi.compressContext(context.Background(), "long prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "long prompt", compressed)
+}
+
+func TestBrainIntegration_EnhancePrompt_NoBrain(t *testing.T) {
+	bi := &BrainIntegration{brain: nil}
+
+	enhanced, err := bi.EnhancePrompt(context.Background(), "original", "context")
+	require.NoError(t, err)
+	assert.Equal(t, "original", enhanced)
+}
+
+func TestBrainIntegration_ConfirmIntent_NoBrain(t *testing.T) {
+	bi := &BrainIntegration{brain: nil}
+
+	confirmed, err := bi.confirmIntent(context.Background(), "test prompt")
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+}
+
+func TestLoadDefaultCapabilities(t *testing.T) {
+	registry := NewRegistry()
+	err := LoadDefaultCapabilities(registry)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, registry.Count())
+
+	cap, ok := registry.Get("code_review")
+	require.True(t, ok)
+	assert.Equal(t, "代码审查", cap.Name)
+	assert.Equal(t, "code", cap.Category)
+	assert.Len(t, cap.Parameters, 1)
+}
+
+func TestSetup_Disabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler, registry, executor := Setup(nil, nil, Config{Enabled: false}, logger)
+	assert.Nil(t, handler)
+	assert.Nil(t, registry)
+	assert.Nil(t, executor)
+}
+
+func TestDefaultCategories(t *testing.T) {
+	categories := DefaultCategories()
+	assert.Len(t, categories, 6)
+
+	// Check some expected categories
+	catMap := make(map[string]CategoryInfo)
+	for _, c := range categories {
+		catMap[c.ID] = c
+	}
+
+	assert.Equal(t, "代码", catMap["code"].Name)
+	assert.Equal(t, ":computer:", catMap["code"].Icon)
+	assert.Equal(t, "调试", catMap["debug"].Name)
+	assert.Equal(t, ":bug:", catMap["debug"].Icon)
+}
+
+func TestCapability_BrainOptions(t *testing.T) {
+	cap := Capability{
+		ID:             "test",
+		Name:           "Test",
+		PromptTemplate: "Test",
+		BrainOpts: BrainOptions{
+			IntentConfirm:   true,
+			CompressContext: true,
+			PreferredModel:  "claude-3",
+		},
+	}
+
+	err := cap.Validate()
+	assert.NoError(t, err)
+	assert.True(t, cap.BrainOpts.IntentConfirm)
+	assert.True(t, cap.BrainOpts.CompressContext)
+	assert.Equal(t, "claude-3", cap.BrainOpts.PreferredModel)
 }

--- a/chatapps/slack/apphome/brain_integration.go
+++ b/chatapps/slack/apphome/brain_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/hrygo/hotplex/brain"
 )
@@ -79,9 +80,9 @@ func (bi *BrainIntegration) confirmIntent(ctx context.Context, prompt string) (b
 		return false, fmt.Errorf("brain chat: %w", err)
 	}
 
-	// Parse response
+	// Parse response (case-insensitive match)
 	bi.logger.Debug("Intent confirmation response", "response", response)
-	return response == "yes" || response == "Yes" || response == "YES", nil
+	return strings.EqualFold(strings.TrimSpace(response), "yes"), nil
 }
 
 // compressContext uses Brain to compress the context.

--- a/chatapps/slack/apphome/brain_integration.go
+++ b/chatapps/slack/apphome/brain_integration.go
@@ -1,0 +1,132 @@
+package apphome
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/hrygo/hotplex/brain"
+)
+
+// ErrIntentNotConfirmed is returned when the user doesn't confirm the intent.
+var ErrIntentNotConfirmed = fmt.Errorf("intent not confirmed")
+
+// BrainIntegration provides Native Brain integration for capabilities.
+type BrainIntegration struct {
+	brain  brain.Brain
+	logger *slog.Logger
+}
+
+// NewBrainIntegration creates a new Brain integration.
+func NewBrainIntegration(b brain.Brain) *BrainIntegration {
+	return &BrainIntegration{
+		brain:  b,
+		logger: slog.Default(),
+	}
+}
+
+// PreparePrompt prepares the final prompt with Brain preprocessing.
+func (bi *BrainIntegration) PreparePrompt(
+	ctx context.Context,
+	cap Capability,
+	params map[string]string,
+	basePrompt string,
+) (string, error) {
+	prompt := basePrompt
+
+	// Step 1: Intent confirmation (optional)
+	if cap.BrainOpts.IntentConfirm {
+		confirmed, err := bi.confirmIntent(ctx, prompt)
+		if err != nil {
+			bi.logger.Warn("Intent confirmation failed",
+				"capability", cap.ID,
+				"error", err)
+			// Non-fatal: continue without confirmation
+		} else if !confirmed {
+			return "", ErrIntentNotConfirmed
+		}
+	}
+
+	// Step 2: Context compression (optional)
+	if cap.BrainOpts.CompressContext {
+		compressed, err := bi.compressContext(ctx, prompt)
+		if err != nil {
+			bi.logger.Warn("Context compression failed",
+				"capability", cap.ID,
+				"error", err)
+			// Non-fatal: continue with original prompt
+		} else {
+			prompt = compressed
+		}
+	}
+
+	return prompt, nil
+}
+
+// confirmIntent uses Brain to confirm the user's intent.
+func (bi *BrainIntegration) confirmIntent(ctx context.Context, prompt string) (bool, error) {
+	if bi.brain == nil {
+		return true, nil // No brain, assume confirmed
+	}
+
+	// Ask Brain to confirm the intent
+	confirmPrompt := fmt.Sprintf(
+		"Analyze the following prompt and determine if it is clear and safe to execute. "+
+			"Respond with only 'yes' or 'no'.\n\nPrompt:\n%s", prompt)
+
+	response, err := bi.brain.Chat(ctx, confirmPrompt)
+	if err != nil {
+		return false, fmt.Errorf("brain chat: %w", err)
+	}
+
+	// Parse response
+	bi.logger.Debug("Intent confirmation response", "response", response)
+	return response == "yes" || response == "Yes" || response == "YES", nil
+}
+
+// compressContext uses Brain to compress the context.
+func (bi *BrainIntegration) compressContext(ctx context.Context, prompt string) (string, error) {
+	if bi.brain == nil {
+		return prompt, nil // No brain, return original
+	}
+
+	// Ask Brain to compress the prompt
+	compressPrompt := fmt.Sprintf(
+		"Compress the following prompt while preserving all essential information. "+
+			"Remove redundancy but keep the key instructions.\n\nPrompt:\n%s", prompt)
+
+	compressed, err := bi.brain.Chat(ctx, compressPrompt)
+	if err != nil {
+		return "", fmt.Errorf("brain chat: %w", err)
+	}
+
+	bi.logger.Debug("Context compressed",
+		"original_length", len(prompt),
+		"compressed_length", len(compressed))
+
+	return compressed, nil
+}
+
+// EnhancePrompt uses Brain to enhance a prompt with additional context.
+func (bi *BrainIntegration) EnhancePrompt(ctx context.Context, prompt string, context string) (string, error) {
+	if bi.brain == nil {
+		return prompt, nil
+	}
+
+	enhancePrompt := fmt.Sprintf(
+		"Enhance the following prompt with the given context. "+
+			"Keep the original intent but add relevant context.\n\nOriginal prompt:\n%s\n\nContext:\n%s",
+		prompt, context)
+
+	enhanced, err := bi.brain.Chat(ctx, enhancePrompt)
+	if err != nil {
+		return "", fmt.Errorf("brain chat: %w", err)
+	}
+
+	return enhanced, nil
+}
+
+// SetLogger sets the logger.
+func (bi *BrainIntegration) SetLogger(logger *slog.Logger) {
+	bi.logger = logger
+}

--- a/chatapps/slack/apphome/builder.go
+++ b/chatapps/slack/apphome/builder.go
@@ -1,0 +1,204 @@
+package apphome
+
+import (
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+const (
+	// ActionIDPrefix is the prefix for capability button action IDs.
+	ActionIDPrefix = "cap_click:"
+
+	// HomeTitle is the title displayed in the App Home.
+	HomeTitle = "🔥 HotPlex 能力中心"
+
+	// MaxCapabilitiesPerRow is the maximum number of capability cards per row.
+	MaxCapabilitiesPerRow = 3
+)
+
+// Builder constructs Slack App Home Tab views.
+type Builder struct {
+	registry *Registry
+}
+
+// NewBuilder creates a new App Home builder.
+func NewBuilder(registry *Registry) *Builder {
+	return &Builder{
+		registry: registry,
+	}
+}
+
+// BuildHomeTab constructs the complete Home Tab view.
+func (b *Builder) BuildHomeTab() *slack.HomeTabViewRequest {
+	blocks := b.BuildBlocks()
+	return &slack.HomeTabViewRequest{
+		Type:   slack.VTHomeTab,
+		Blocks: slack.Blocks{BlockSet: blocks},
+	}
+}
+
+// BuildBlocks constructs the block set for the Home Tab.
+func (b *Builder) BuildBlocks() []slack.Block {
+	var blocks []slack.Block
+
+	// Header
+	blocks = append(blocks, b.buildHeader())
+
+	// Group capabilities by category
+	categories := b.registry.GetCategories()
+	capabilities := b.registry.GetAll()
+
+	// Build capability map by category
+	capByCategory := make(map[string][]Capability)
+	for _, cap := range capabilities {
+		capByCategory[cap.Category] = append(capByCategory[cap.Category], cap)
+	}
+
+	// Build each category section
+	for _, cat := range categories {
+		caps, ok := capByCategory[cat.ID]
+		if !ok || len(caps) == 0 {
+			continue
+		}
+
+		// Category header
+		blocks = append(blocks, b.buildCategoryHeader(cat))
+
+		// Capability cards (grouped in rows)
+		for i := 0; i < len(caps); i += MaxCapabilitiesPerRow {
+			end := i + MaxCapabilitiesPerRow
+			if end > len(caps) {
+				end = len(caps)
+			}
+			row := caps[i:end]
+			blocks = append(blocks, b.buildCapabilityRow(row))
+		}
+
+		// Spacer between categories
+		blocks = append(blocks, slack.NewDividerBlock())
+	}
+
+	// Footer with help text
+	blocks = append(blocks, b.buildFooter())
+
+	return blocks
+}
+
+// buildHeader creates the main header block.
+func (b *Builder) buildHeader() slack.Block {
+	headerText := slack.NewTextBlockObject(slack.PlainTextType, HomeTitle, false, false)
+	return slack.NewHeaderBlock(headerText)
+}
+
+// buildCategoryHeader creates a category section header.
+func (b *Builder) buildCategoryHeader(cat CategoryInfo) slack.Block {
+	text := fmt.Sprintf("%s *%s*", cat.Icon, cat.Name)
+	headerText := slack.NewTextBlockObject(slack.MarkdownType, text, false, false)
+	return slack.NewSectionBlock(headerText, nil, nil)
+}
+
+// buildCapabilityRow creates a row of capability cards.
+// Note: This returns a section with fields. Individual capabilities should use BuildCapabilitySection.
+func (b *Builder) buildCapabilityRow(caps []Capability) slack.Block {
+	if len(caps) == 0 {
+		return nil
+	}
+
+	// For Slack, we use section blocks with fields for multi-column layout
+	var fields []*slack.TextBlockObject
+	for _, cap := range caps {
+		text := fmt.Sprintf("%s *%s*\n_%s_", cap.Icon, cap.Name, cap.Description)
+		fields = append(fields, slack.NewTextBlockObject(slack.MarkdownType, text, false, false))
+	}
+
+	// Use fields for multi-column layout
+	return slack.NewSectionBlock(nil, fields, nil)
+}
+
+// BuildCapabilitySection creates a section block for a single capability with a button.
+func (b *Builder) BuildCapabilitySection(cap Capability) slack.Block {
+	// Main text
+	text := fmt.Sprintf("%s *%s*\n_%s_", cap.Icon, cap.Name, cap.Description)
+	mainText := slack.NewTextBlockObject(slack.MarkdownType, text, false, false)
+
+	// Execute button
+	btn := slack.NewButtonBlockElement(
+		ActionIDPrefix+cap.ID,
+		cap.ID,
+		slack.NewTextBlockObject(slack.PlainTextType, "执行", false, false),
+	)
+
+	return slack.NewSectionBlock(mainText, nil, slack.NewAccessory(btn))
+}
+
+// buildFooter creates a footer with help text.
+func (b *Builder) buildFooter() slack.Block {
+	helpText := slack.NewTextBlockObject(
+		slack.MarkdownType,
+		"_点击能力卡片上的「执行」按钮开始使用。_\n_能力中心由 Native Brain 智能驱动。_",
+		false, false,
+	)
+	return slack.NewContextBlock("", helpText)
+}
+
+// BuildCapabilityBlocks builds all capability blocks organized by category.
+func (b *Builder) BuildCapabilityBlocks() []slack.Block {
+	var blocks []slack.Block
+
+	categories := b.registry.GetCategories()
+	capabilities := b.registry.GetAll()
+
+	// Build capability map by category
+	capByCategory := make(map[string][]Capability)
+	for _, cap := range capabilities {
+		capByCategory[cap.Category] = append(capByCategory[cap.Category], cap)
+	}
+
+	// Build each category section
+	for _, cat := range categories {
+		caps, ok := capByCategory[cat.ID]
+		if !ok || len(caps) == 0 {
+			continue
+		}
+
+		// Category header
+		blocks = append(blocks, b.buildCategoryHeader(cat))
+
+		// Each capability as a section with button
+		for _, cap := range caps {
+			blocks = append(blocks, b.BuildCapabilitySection(cap))
+		}
+	}
+
+	return blocks
+}
+
+// BuildFullHomeView builds the complete Home Tab with proper block structure.
+func (b *Builder) BuildFullHomeView() *slack.HomeTabViewRequest {
+	var blocks []slack.Block
+
+	// Header
+	blocks = append(blocks, b.buildHeader())
+
+	// Introduction
+	introText := slack.NewTextBlockObject(
+		slack.MarkdownType,
+		"欢迎使用 HotPlex 能力中心！选择一个能力开始工作。",
+		false, false,
+	)
+	blocks = append(blocks, slack.NewSectionBlock(introText, nil, nil))
+	blocks = append(blocks, slack.NewDividerBlock())
+
+	// Capabilities by category
+	blocks = append(blocks, b.BuildCapabilityBlocks()...)
+
+	// Footer
+	blocks = append(blocks, slack.NewDividerBlock())
+	blocks = append(blocks, b.buildFooter())
+
+	return &slack.HomeTabViewRequest{
+		Type:   slack.VTHomeTab,
+		Blocks: slack.Blocks{BlockSet: blocks},
+	}
+}

--- a/chatapps/slack/apphome/capabilities.yaml
+++ b/chatapps/slack/apphome/capabilities.yaml
@@ -1,0 +1,384 @@
+# HotPlex Capability Center - Predefined Capabilities
+# Issue: #215
+
+capabilities:
+  # ========== Phase 1: MVP Capabilities ==========
+
+  - id: code_review
+    name: 代码审查
+    icon: ":mag:"
+    description: 对指定文件进行安全/性能/风格审查
+    category: code
+    enabled: true
+    parameters:
+      - id: target
+        label: 审查目标
+        type: text
+        required: true
+        placeholder: "例如: src/main.go 或具体代码片段"
+      - id: focus
+        label: 审查重点
+        type: select
+        required: false
+        default: "all"
+        options:
+          - all
+          - security
+          - performance
+          - style
+          - maintainability
+        placeholder: "选择审查重点"
+      - id: context
+        label: 额外说明
+        type: multiline
+        required: false
+        placeholder: "可选：提供额外上下文或特定要求"
+    prompt_template: |
+      请对以下内容进行代码审查:
+      目标: {{.target}}
+      重点关注: {{.focus}}
+      {{if .context}}额外说明: {{.context}}{{end}}
+
+      请从以下角度进行分析:
+      1. 安全性 - 是否存在安全漏洞
+      2. 性能 - 是否有性能优化空间
+      3. 代码风格 - 是否符合最佳实践
+      4. 可维护性 - 代码是否易于理解和维护
+
+      请提供具体的改进建议。
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+      preferred_model: claude-sonnet-4-6
+
+  - id: explain_code
+    name: 代码解释
+    icon: ":book:"
+    description: 解释代码片段的工作原理
+    category: code
+    enabled: true
+    parameters:
+      - id: code
+        label: 代码片段
+        type: multiline
+        required: true
+        placeholder: "粘贴需要解释的代码"
+      - id: detail_level
+        label: 详细程度
+        type: select
+        required: false
+        default: "normal"
+        options:
+          - brief
+          - normal
+          - detailed
+        placeholder: "选择解释详细程度"
+    prompt_template: |
+      请解释以下代码的工作原理:
+      ```
+      {{.code}}
+      ```
+
+      详细程度: {{.detail_level}}
+
+      请包括:
+      1. 代码的整体目的
+      2. 关键逻辑和流程
+      3. 使用的算法或数据结构
+      4. 潜在的边界情况
+    brain_opts:
+      intent_confirm: false
+      compress_context: false
+      preferred_model: claude-sonnet-4-6
+
+  - id: debug_error
+    name: 错误诊断
+    icon: ":bug:"
+    description: 分析错误信息并给出修复方案
+    category: debug
+    enabled: true
+    parameters:
+      - id: error_message
+        label: 错误信息
+        type: multiline
+        required: true
+        placeholder: "粘贴完整的错误信息"
+      - id: code_context
+        label: 相关代码
+        type: multiline
+        required: false
+        placeholder: "可选：提供相关代码上下文"
+      - id: environment
+        label: 运行环境
+        type: text
+        required: false
+        placeholder: "例如: Go 1.22, Node.js 20, Python 3.12"
+    prompt_template: |
+      请分析以下错误并提供修复方案:
+
+      错误信息:
+      ```
+      {{.error_message}}
+      ```
+
+      {{if .code_context}}相关代码:
+      ```
+      {{.code_context}}
+      ```
+      {{end}}
+      {{if .environment}}运行环境: {{.environment}}{{end}}
+
+      请提供:
+      1. 错误根本原因分析
+      2. 具体的修复步骤
+      3. 预防类似错误的建议
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+      preferred_model: claude-sonnet-4-6
+
+  # ========== Phase 2: Brain Integration Capabilities ==========
+
+  - id: git_commit
+    name: Commit 生成
+    icon: ":package:"
+    description: 生成 Conventional Commit 消息
+    category: git
+    enabled: true
+    parameters:
+      - id: changes
+        label: 变更说明
+        type: multiline
+        required: true
+        placeholder: "描述你的代码变更"
+      - id: type
+        label: 提交类型
+        type: select
+        required: false
+        default: "feat"
+        options:
+          - feat
+          - fix
+          - refactor
+          - docs
+          - test
+          - chore
+          - style
+          - perf
+          - ci
+        placeholder: "选择提交类型"
+      - id: scope
+        label: 作用域
+        type: text
+        required: false
+        placeholder: "可选：模块或组件名称"
+    prompt_template: |
+      请根据以下变更生成 Conventional Commit 消息:
+
+      变更说明:
+      {{.changes}}
+
+      类型: {{.type}}
+      {{if .scope}}作用域: {{.scope}}{{end}}
+
+      请生成:
+      1. 符合 Conventional Commits 规范的标题行
+      2. 详细的 body 说明（如果需要）
+      3. 相关的 footer（如 Breaking Changes）
+
+      格式要求:
+      <type>(<scope>): <description>
+
+      [optional body]
+
+      [optional footer(s)]
+    brain_opts:
+      intent_confirm: true
+      compress_context: false
+      preferred_model: claude-sonnet-4-6
+
+  - id: pr_review
+    name: PR 审查
+    icon: ":twisted_rightwards_arrows:"
+    description: 审查 PR 变更并给出建议
+    category: code
+    enabled: true
+    parameters:
+      - id: pr_description
+        label: PR 描述
+        type: multiline
+        required: true
+        placeholder: "粘贴 PR 描述或变更摘要"
+      - id: diff
+        label: 代码变更
+        type: multiline
+        required: false
+        placeholder: "可选：粘贴 git diff 输出"
+      - id: focus
+        label: 审查重点
+        type: select
+        required: false
+        default: "all"
+        options:
+          - all
+          - logic
+          - security
+          - performance
+          - tests
+    prompt_template: |
+      请审查以下 Pull Request:
+
+      PR 描述:
+      {{.pr_description}}
+
+      {{if .diff}}代码变更:
+      ```diff
+      {{.diff}}
+      ```
+      {{end}}
+
+      审查重点: {{.focus}}
+
+      请提供:
+      1. 总体评价
+      2. 发现的问题（按严重程度分类）
+      3. 具体的改进建议
+      4. 测试覆盖建议
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+      preferred_model: claude-sonnet-4-6
+
+  - id: refactor
+    name: 重构建议
+    icon: ":recycle:"
+    description: 分析代码并提供重构建议
+    category: code
+    enabled: true
+    parameters:
+      - id: code
+        label: 代码片段
+        type: multiline
+        required: true
+        placeholder: "粘贴需要重构的代码"
+      - id: goals
+        label: 重构目标
+        type: select
+        required: false
+        default: "readability"
+        options:
+          - readability
+          - performance
+          - maintainability
+          - testability
+          - modularity
+        placeholder: "选择重构目标"
+      - id: constraints
+        label: 约束条件
+        type: multiline
+        required: false
+        placeholder: "可选：说明任何约束条件"
+    prompt_template: |
+      请分析以下代码并提供重构建议:
+
+      ```go
+      {{.code}}
+      ```
+
+      重构目标: {{.goals}}
+      {{if .constraints}}约束条件: {{.constraints}}{{end}}
+
+      请提供:
+      1. 当前代码的问题分析
+      2. 重构后的代码示例
+      3. 重构带来的具体改进
+      4. 重构步骤（如果复杂）
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+      preferred_model: claude-sonnet-4-6
+
+  # ========== Phase 3: Extended Capabilities ==========
+
+  - id: test_gen
+    name: 测试生成
+    icon: ":white_check_mark:"
+    description: 为代码生成单元测试
+    category: code
+    enabled: true
+    parameters:
+      - id: code
+        label: 代码片段
+        type: multiline
+        required: true
+        placeholder: "粘贴需要测试的代码"
+      - id: framework
+        label: 测试框架
+        type: select
+        required: false
+        default: "native"
+        options:
+          - native
+          - testify
+          - ginkgo
+        placeholder: "选择测试框架"
+    prompt_template: |
+      请为以下代码生成单元测试:
+
+      ```go
+      {{.code}}
+      ```
+
+      测试框架: {{.framework}}
+
+      请生成:
+      1. 测试用例覆盖正常路径
+      2. 测试用例覆盖边界情况
+      3. 测试用例覆盖错误情况
+      4. 必要的 mock 和 setup 代码
+    brain_opts:
+      intent_confirm: false
+      compress_context: false
+      preferred_model: claude-sonnet-4-6
+
+  - id: doc_gen
+    name: 文档生成
+    icon: ":memo:"
+    description: 生成代码文档
+    category: docs
+    enabled: true
+    parameters:
+      - id: code
+        label: 代码片段
+        type: multiline
+        required: true
+        placeholder: "粘贴需要文档化的代码"
+      - id: format
+        label: 文档格式
+        type: select
+        required: false
+        default: "godoc"
+        options:
+          - godoc
+          - markdown
+          - openapi
+        placeholder: "选择文档格式"
+    prompt_template: |
+      请为以下代码生成文档:
+
+      ```go
+      {{.code}}
+      ```
+
+      文档格式: {{.format}}
+
+      请生成:
+      1. 函数/方法说明
+      2. 参数描述
+      3. 返回值描述
+      4. 使用示例
+      5. 注意事项（如有）
+    brain_opts:
+      intent_confirm: false
+      compress_context: false
+      preferred_model: claude-sonnet-4-6

--- a/chatapps/slack/apphome/capability.go
+++ b/chatapps/slack/apphome/capability.go
@@ -1,0 +1,126 @@
+// Package apphome provides Slack App Home capability center functionality.
+// It enables users to trigger predefined, parameterizable task templates
+// through the App Home tab interface.
+package apphome
+
+import (
+	"fmt"
+)
+
+// Capability represents a predefined, parameterizable task template.
+type Capability struct {
+	// ID is the unique identifier for the capability.
+	ID string `yaml:"id" json:"id"`
+
+	// Name is the display name shown in the UI.
+	Name string `yaml:"name" json:"name"`
+
+	// Icon is the emoji icon for the capability (e.g., ":mag:").
+	Icon string `yaml:"icon" json:"icon"`
+
+	// Description is a brief description of what the capability does.
+	Description string `yaml:"description" json:"description"`
+
+	// Category is the grouping category (e.g., "code", "debug", "git").
+	Category string `yaml:"category" json:"category"`
+
+	// Parameters are the input parameters for the capability.
+	Parameters []Parameter `yaml:"parameters" json:"parameters"`
+
+	// PromptTemplate is the Go template for rendering the final prompt.
+	// Uses standard text/template syntax with {{.param_id}} placeholders.
+	PromptTemplate string `yaml:"prompt_template" json:"prompt_template"`
+
+	// BrainOpts configures Native Brain integration options.
+	BrainOpts BrainOptions `yaml:"brain_opts" json:"brain_opts"`
+
+	// Enabled indicates whether the capability is active.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+// Parameter represents an input parameter for a capability.
+type Parameter struct {
+	// ID is the unique identifier for the parameter.
+	ID string `yaml:"id" json:"id"`
+
+	// Label is the display label shown in the UI.
+	Label string `yaml:"label" json:"label"`
+
+	// Type is the input type: "text", "select", or "multiline".
+	Type string `yaml:"type" json:"type"`
+
+	// Required indicates whether the parameter must be filled.
+	Required bool `yaml:"required" json:"required"`
+
+	// Default is the default value for the parameter.
+	Default string `yaml:"default" json:"default"`
+
+	// Options are the available options for "select" type parameters.
+	Options []string `yaml:"options" json:"options"`
+
+	// Placeholder is the placeholder text shown in the input field.
+	Placeholder string `yaml:"placeholder" json:"placeholder"`
+}
+
+// BrainOptions configures Native Brain integration for a capability.
+type BrainOptions struct {
+	// IntentConfirm enables intent confirmation before execution.
+	IntentConfirm bool `yaml:"intent_confirm" json:"intent_confirm"`
+
+	// CompressContext enables context compression to save tokens.
+	CompressContext bool `yaml:"compress_context" json:"compress_context"`
+
+	// PreferredModel is the preferred model for this capability.
+	PreferredModel string `yaml:"preferred_model" json:"preferred_model"`
+}
+
+// Validate validates the capability configuration.
+func (c *Capability) Validate() error {
+	if c.ID == "" {
+		return fmt.Errorf("capability ID is required")
+	}
+	if c.Name == "" {
+		return fmt.Errorf("capability name is required")
+	}
+	if c.PromptTemplate == "" {
+		return fmt.Errorf("prompt_template is required for capability %s", c.ID)
+	}
+
+	// Validate parameters
+	for i, p := range c.Parameters {
+		if p.ID == "" {
+			return fmt.Errorf("parameter %d: ID is required", i)
+		}
+		if p.Label == "" {
+			return fmt.Errorf("parameter %s: label is required", p.ID)
+		}
+		if p.Type != "text" && p.Type != "select" && p.Type != "multiline" {
+			return fmt.Errorf("parameter %s: invalid type %q, must be text, select, or multiline", p.ID, p.Type)
+		}
+		if p.Type == "select" && len(p.Options) == 0 {
+			return fmt.Errorf("parameter %s: select type requires options", p.ID)
+		}
+	}
+
+	return nil
+}
+
+// CategoryInfo contains display information for a capability category.
+type CategoryInfo struct {
+	ID          string
+	Name        string
+	Icon        string
+	Description string
+}
+
+// DefaultCategories returns the default capability categories.
+func DefaultCategories() []CategoryInfo {
+	return []CategoryInfo{
+		{ID: "code", Name: "代码", Icon: ":computer:", Description: "代码相关能力"},
+		{ID: "debug", Name: "调试", Icon: ":bug:", Description: "调试和错误诊断"},
+		{ID: "git", Name: "Git", Icon: ":twisted_rightwards_arrows:", Description: "Git 和版本控制"},
+		{ID: "docs", Name: "文档", Icon: ":book:", Description: "文档生成"},
+		{ID: "db", Name: "数据库", Icon: ":card_file_box:", Description: "数据库相关"},
+		{ID: "design", Name: "设计", Icon: ":art:", Description: "API 和系统设计"},
+	}
+}

--- a/chatapps/slack/apphome/executor.go
+++ b/chatapps/slack/apphome/executor.go
@@ -1,0 +1,183 @@
+package apphome
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"text/template"
+	"time"
+
+	"github.com/hrygo/hotplex/brain"
+	"github.com/slack-go/slack"
+)
+
+// Executor executes capabilities with the given parameters.
+type Executor struct {
+	client         *slack.Client
+	brain          brain.Brain
+	brainIntegration *BrainIntegration
+	logger         *slog.Logger
+
+	// MessageHandler is called to trigger engine execution.
+	// This is a callback to avoid circular dependencies with the adapter.
+	MessageHandler func(ctx context.Context, userID, channelID, message string) error
+}
+
+// ExecutorOption configures an Executor.
+type ExecutorOption func(*Executor)
+
+// WithExecutorClient sets the Slack client.
+func WithExecutorClient(client *slack.Client) ExecutorOption {
+	return func(e *Executor) {
+		e.client = client
+	}
+}
+
+// WithBrain sets the Brain instance.
+func WithBrain(b brain.Brain) ExecutorOption {
+	return func(e *Executor) {
+		e.brain = b
+		e.brainIntegration = NewBrainIntegration(b)
+	}
+}
+
+// WithMessageHandler sets the message handler callback.
+func WithMessageHandler(handler func(ctx context.Context, userID, channelID, message string) error) ExecutorOption {
+	return func(e *Executor) {
+		e.MessageHandler = handler
+	}
+}
+
+// WithExecutorLogger sets the logger.
+func WithExecutorLogger(logger *slog.Logger) ExecutorOption {
+	return func(e *Executor) {
+		e.logger = logger
+	}
+}
+
+// NewExecutor creates a new capability executor.
+func NewExecutor(opts ...ExecutorOption) *Executor {
+	e := &Executor{
+		logger: slog.Default(),
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// Execute executes a capability with the given parameters.
+func (e *Executor) Execute(ctx context.Context, userID string, cap Capability, params map[string]string) error {
+	startTime := time.Now()
+
+	e.logger.Info("Executing capability",
+		"user", userID,
+		"capability", cap.ID,
+		"params", params)
+
+	// Step 1: Render the prompt template
+	prompt, err := e.renderPrompt(cap, params)
+	if err != nil {
+		return fmt.Errorf("render prompt: %w", err)
+	}
+
+	e.logger.Debug("Rendered prompt", "prompt_length", len(prompt))
+
+	// Step 2: Apply Brain preprocessing if available
+	if e.brainIntegration != nil {
+		processedPrompt, err := e.brainIntegration.PreparePrompt(ctx, cap, params, prompt)
+		if err != nil {
+			e.logger.Warn("Brain preprocessing failed, using original prompt",
+				"error", err)
+		} else {
+			prompt = processedPrompt
+		}
+	}
+
+	// Step 3: Get or create DM channel
+	dmChannel, err := e.getOrCreateDMChannel(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("get DM channel: %w", err)
+	}
+
+	// Step 4: Send header message to DM
+	header := fmt.Sprintf("🎯 *%s* — 执行能力任务", cap.Name)
+	if _, _, err := e.client.PostMessageContext(
+		ctx,
+		dmChannel,
+		slack.MsgOptionText(header, false),
+	); err != nil {
+		e.logger.Error("Failed to send header message", "error", err)
+	}
+
+	// Step 5: Send the rendered prompt to DM
+	if _, _, err := e.client.PostMessageContext(
+		ctx,
+		dmChannel,
+		slack.MsgOptionText(prompt, false),
+	); err != nil {
+		return fmt.Errorf("send prompt to DM: %w", err)
+	}
+
+	// Step 6: Trigger engine execution via callback
+	if e.MessageHandler != nil {
+		if err := e.MessageHandler(ctx, userID, dmChannel, prompt); err != nil {
+			e.logger.Error("Message handler failed", "error", err)
+			// Don't fail the execution, the prompt was already sent
+		}
+	}
+
+	duration := time.Since(startTime)
+	e.logger.Info("Capability execution completed",
+		"user", userID,
+		"capability", cap.ID,
+		"duration", duration)
+
+	return nil
+}
+
+// renderPrompt renders the capability's prompt template with the given parameters.
+func (e *Executor) renderPrompt(cap Capability, params map[string]string) (string, error) {
+	tmpl, err := template.New(cap.ID).Parse(cap.PromptTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, params); err != nil {
+		return "", fmt.Errorf("execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// getOrCreateDMChannel gets or creates a DM channel with the user.
+func (e *Executor) getOrCreateDMChannel(ctx context.Context, userID string) (string, error) {
+	if e.client == nil {
+		return "", fmt.Errorf("slack client not configured")
+	}
+
+	// Open or resume a DM conversation with the user
+	channel, _, _, err := e.client.OpenConversationContext(ctx, &slack.OpenConversationParameters{
+		Users: []string{userID},
+	})
+	if err != nil {
+		return "", fmt.Errorf("open conversation: %w", err)
+	}
+
+	return channel.ID, nil
+}
+
+// SetClient sets the Slack client (for late initialization).
+func (e *Executor) SetClient(client *slack.Client) {
+	e.client = client
+}
+
+// SetBrain sets the Brain instance (for late initialization).
+func (e *Executor) SetBrain(b brain.Brain) {
+	e.brain = b
+	e.brainIntegration = NewBrainIntegration(b)
+}

--- a/chatapps/slack/apphome/form.go
+++ b/chatapps/slack/apphome/form.go
@@ -1,0 +1,216 @@
+package apphome
+
+import (
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+const (
+	// BlockIDPrefix is the prefix for input block IDs.
+	BlockIDPrefix = "input_"
+
+	// ActionIDInputSuffix is the suffix for input action IDs.
+	ActionIDInputSuffix = "_value"
+)
+
+// FormBuilder constructs dynamic Modal forms based on Capability definitions.
+type FormBuilder struct{}
+
+// NewFormBuilder creates a new form builder.
+func NewFormBuilder() *FormBuilder {
+	return &FormBuilder{}
+}
+
+// BuildModal creates a Modal view for a capability.
+func (f *FormBuilder) BuildModal(cap Capability) *slack.ModalViewRequest {
+	blocks := f.BuildBlocks(cap)
+
+	return &slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		Title:           slack.NewTextBlockObject(slack.PlainTextType, truncate(cap.Name, 24), false, false),
+		Submit:          slack.NewTextBlockObject(slack.PlainTextType, "执行", false, false),
+		Close:           slack.NewTextBlockObject(slack.PlainTextType, "取消", false, false),
+		Blocks:          slack.Blocks{BlockSet: blocks},
+		PrivateMetadata: cap.ID,
+	}
+}
+
+// BuildBlocks creates input blocks for each parameter.
+func (f *FormBuilder) BuildBlocks(cap Capability) []slack.Block {
+	var blocks []slack.Block
+
+	// Description header
+	if cap.Description != "" {
+		descText := slack.NewTextBlockObject(
+			slack.PlainTextType,
+			cap.Description,
+			false, false,
+		)
+		blocks = append(blocks, slack.NewHeaderBlock(descText))
+		blocks = append(blocks, slack.NewDividerBlock())
+	}
+
+	// Build input for each parameter
+	for _, param := range cap.Parameters {
+		block := f.buildInputBlock(param)
+		if block != nil {
+			blocks = append(blocks, block)
+		}
+	}
+
+	return blocks
+}
+
+// buildInputBlock creates an input block based on parameter type.
+func (f *FormBuilder) buildInputBlock(param Parameter) slack.Block {
+	blockID := BlockIDPrefix + param.ID
+	actionID := param.ID + ActionIDInputSuffix
+
+	switch param.Type {
+	case "text":
+		return f.buildTextInput(param, blockID, actionID)
+	case "multiline":
+		return f.buildTextarea(param, blockID, actionID)
+	case "select":
+		return f.buildSelect(param, blockID, actionID)
+	default:
+		// Default to text input
+		return f.buildTextInput(param, blockID, actionID)
+	}
+}
+
+// buildTextInput creates a plain text input block.
+func (f *FormBuilder) buildTextInput(param Parameter, blockID, actionID string) slack.Block {
+	placeholder := slack.NewTextBlockObject(slack.PlainTextType, param.Placeholder, false, false)
+	label := slack.NewTextBlockObject(slack.PlainTextType, buildLabel(param), false, false)
+
+	textInput := slack.NewPlainTextInputBlockElement(
+		placeholder,
+		actionID,
+	)
+
+	return slack.NewInputBlock(
+		blockID,
+		label,
+		nil,
+		textInput,
+	)
+}
+
+// buildTextarea creates a multiline text input block.
+func (f *FormBuilder) buildTextarea(param Parameter, blockID, actionID string) slack.Block {
+	placeholder := slack.NewTextBlockObject(slack.PlainTextType, param.Placeholder, false, false)
+	label := slack.NewTextBlockObject(slack.PlainTextType, buildLabel(param), false, false)
+
+	textInput := slack.NewPlainTextInputBlockElement(
+		placeholder,
+		actionID,
+	)
+	// Enable multiline
+	textInput.Multiline = true
+
+	return slack.NewInputBlock(
+		blockID,
+		label,
+		nil,
+		textInput,
+	)
+}
+
+// buildSelect creates a static select input block.
+func (f *FormBuilder) buildSelect(param Parameter, blockID, actionID string) slack.Block {
+	label := slack.NewTextBlockObject(slack.PlainTextType, buildLabel(param), false, false)
+
+	// Build options
+	var options []*slack.OptionBlockObject
+	for _, opt := range param.Options {
+		text := slack.NewTextBlockObject(slack.PlainTextType, opt, false, false)
+		value := opt
+		options = append(options, slack.NewOptionBlockObject(value, text, nil))
+	}
+
+	// Placeholder for select
+	placeholder := slack.NewTextBlockObject(slack.PlainTextType, param.Placeholder, false, false)
+
+	selectInput := slack.NewOptionsSelectBlockElement(
+		slack.OptTypeStatic,
+		placeholder,
+		actionID,
+		options...,
+	)
+
+	return slack.NewInputBlock(
+		blockID,
+		label,
+		nil,
+		selectInput,
+	)
+}
+
+// ExtractParams extracts parameter values from a Modal submission.
+func (f *FormBuilder) ExtractParams(state *slack.ViewState, cap Capability) map[string]string {
+	params := make(map[string]string)
+
+	if state == nil || state.Values == nil {
+		return params
+	}
+
+	for _, param := range cap.Parameters {
+		blockID := BlockIDPrefix + param.ID
+		actionID := param.ID + ActionIDInputSuffix
+
+		if blockValues, ok := state.Values[blockID]; ok {
+			if actionValue, ok := blockValues[actionID]; ok {
+				// Extract value based on type
+				switch param.Type {
+				case "select":
+					// SelectedOption is a value type, check if Value is not empty
+					if actionValue.SelectedOption.Value != "" {
+						params[param.ID] = actionValue.SelectedOption.Value
+					}
+				default:
+					params[param.ID] = actionValue.Value
+				}
+			}
+		}
+
+		// Apply default if empty
+		if params[param.ID] == "" && param.Default != "" {
+			params[param.ID] = param.Default
+		}
+	}
+
+	return params
+}
+
+// ValidateParams validates extracted parameters against capability definition.
+func (f *FormBuilder) ValidateParams(cap Capability, params map[string]string) map[string]string {
+	errors := make(map[string]string)
+
+	for _, param := range cap.Parameters {
+		value := params[param.ID]
+
+		if param.Required && value == "" {
+			errors[param.ID] = fmt.Sprintf("%s 是必填项", param.Label)
+		}
+	}
+
+	return errors
+}
+
+// buildLabel creates a label text with required marker.
+func buildLabel(param Parameter) string {
+	if param.Required {
+		return param.Label + " *"
+	}
+	return param.Label
+}
+
+// truncate truncates a string to maxLen characters.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/chatapps/slack/apphome/handler.go
+++ b/chatapps/slack/apphome/handler.go
@@ -1,0 +1,230 @@
+package apphome
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+// Handler handles App Home events and interactions.
+type Handler struct {
+	client   *slack.Client
+	registry *Registry
+	builder  *Builder
+	form     *FormBuilder
+	executor *Executor
+	logger   *slog.Logger
+}
+
+// HandlerOption configures a Handler.
+type HandlerOption func(*Handler)
+
+// WithSlackClient sets the Slack client.
+func WithSlackClient(client *slack.Client) HandlerOption {
+	return func(h *Handler) {
+		h.client = client
+	}
+}
+
+// WithExecutor sets the capability executor.
+func WithExecutor(executor *Executor) HandlerOption {
+	return func(h *Handler) {
+		h.executor = executor
+	}
+}
+
+// WithHandlerLogger sets the logger.
+func WithHandlerLogger(logger *slog.Logger) HandlerOption {
+	return func(h *Handler) {
+		h.logger = logger
+	}
+}
+
+// NewHandler creates a new App Home handler.
+func NewHandler(registry *Registry, opts ...HandlerOption) *Handler {
+	h := &Handler{
+		registry: registry,
+		builder:  NewBuilder(registry),
+		form:     &FormBuilder{},
+		logger:   slog.Default(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
+}
+
+// HomeOpenedEvent represents the app_home_opened event data.
+// This is a simplified version for our use case.
+type HomeOpenedEvent struct {
+	User    string
+	Channel string
+	Tab     string
+}
+
+// HandleHomeOpened handles the app_home_opened event.
+// This is called when a user opens the App Home tab.
+func (h *Handler) HandleHomeOpened(ctx context.Context, event *HomeOpenedEvent) error {
+	if h.client == nil {
+		return fmt.Errorf("slack client not configured")
+	}
+
+	h.logger.Debug("Handling app_home_opened event",
+		"user", event.User,
+		"channel", event.Channel,
+		"tab", event.Tab)
+
+	// Build the Home Tab view
+	view := h.builder.BuildFullHomeView()
+
+	// Publish the view
+	_, err := h.client.PublishViewContext(
+		ctx,
+		slack.PublishViewContextRequest{
+			UserID: event.User,
+			View:   *view,
+		},
+	)
+	if err != nil {
+		h.logger.Error("Failed to publish Home Tab view",
+			"user", event.User,
+			"error", err)
+		return fmt.Errorf("publish view: %w", err)
+	}
+
+	h.logger.Info("Published Home Tab view", "user", event.User)
+	return nil
+}
+
+// HandleCapabilityClick handles a capability card button click.
+// This opens the parameter Modal for the selected capability.
+func (h *Handler) HandleCapabilityClick(ctx context.Context, callback *slack.InteractionCallback, capID string) error {
+	if h.client == nil {
+		return fmt.Errorf("slack client not configured")
+	}
+
+	h.logger.Debug("Handling capability click",
+		"user", callback.User.ID,
+		"capability", capID)
+
+	// Get capability definition
+	cap, ok := h.registry.Get(capID)
+	if !ok {
+		return fmt.Errorf("capability not found: %s", capID)
+	}
+
+	// Build Modal view
+	modal := h.form.BuildModal(cap)
+
+	// Open the Modal
+	_, err := h.client.OpenViewContext(ctx, callback.TriggerID, *modal)
+	if err != nil {
+		h.logger.Error("Failed to open capability Modal",
+			"user", callback.User.ID,
+			"capability", capID,
+			"error", err)
+		return fmt.Errorf("open view: %w", err)
+	}
+
+	h.logger.Info("Opened capability Modal",
+		"user", callback.User.ID,
+		"capability", capID)
+	return nil
+}
+
+// HandleViewSubmission handles Modal form submission.
+// This executes the capability with the submitted parameters.
+func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.InteractionCallback) error {
+	if h.client == nil {
+		return fmt.Errorf("slack client not configured")
+	}
+
+	capID := callback.View.PrivateMetadata
+	userID := callback.User.ID
+
+	h.logger.Debug("Handling view submission",
+		"user", userID,
+		"capability", capID)
+
+	// Get capability definition
+	cap, ok := h.registry.Get(capID)
+	if !ok {
+		return fmt.Errorf("capability not found: %s", capID)
+	}
+
+	// Extract parameters
+	params := h.form.ExtractParams(callback.View.State, cap)
+
+	// Validate parameters
+	if errors := h.form.ValidateParams(cap, params); len(errors) > 0 {
+		h.logger.Warn("Parameter validation failed",
+			"user", userID,
+			"capability", capID,
+			"errors", errors)
+		// Return validation errors in response
+		return h.buildValidationResponse(callback, errors)
+	}
+
+	h.logger.Info("Executing capability",
+		"user", userID,
+		"capability", capID,
+		"params", params)
+
+	// Execute capability
+	if h.executor != nil {
+		go func() {
+			// Execute in background to avoid blocking the response
+			execCtx := context.Background()
+			if err := h.executor.Execute(execCtx, userID, cap, params); err != nil {
+				h.logger.Error("Capability execution failed",
+					"user", userID,
+					"capability", capID,
+					"error", err)
+			}
+		}()
+	} else {
+		h.logger.Warn("No executor configured, capability will not be executed",
+			"capability", capID)
+	}
+
+	// Return empty response to close the Modal
+	return nil
+}
+
+// buildValidationResponse builds an error response for validation failures.
+func (h *Handler) buildValidationResponse(callback *slack.InteractionCallback, errors map[string]string) error {
+	// Build error message
+	var errorLines []string
+	for _, errMsg := range errors {
+		errorLines = append(errorLines, fmt.Sprintf("• %s", errMsg))
+	}
+
+	// Log validation errors (actual response would need slack.ResponseAction)
+	h.logger.Warn("Validation errors", "errors", strings.Join(errorLines, "\n"))
+	return fmt.Errorf("validation failed: %s", strings.Join(errorLines, ", "))
+}
+
+// IsCapabilityAction checks if an action ID is a capability click action.
+func IsCapabilityAction(actionID string) bool {
+	return strings.HasPrefix(actionID, ActionIDPrefix)
+}
+
+// ExtractCapabilityID extracts the capability ID from an action ID.
+func ExtractCapabilityID(actionID string) string {
+	return strings.TrimPrefix(actionID, ActionIDPrefix)
+}
+
+// SetClient sets the Slack client (for late initialization).
+func (h *Handler) SetClient(client *slack.Client) {
+	h.client = client
+}
+
+// SetExecutor sets the executor (for late initialization).
+func (h *Handler) SetExecutor(executor *Executor) {
+	h.executor = executor
+}

--- a/chatapps/slack/apphome/handler.go
+++ b/chatapps/slack/apphome/handler.go
@@ -138,10 +138,11 @@ func (h *Handler) HandleCapabilityClick(ctx context.Context, callback *slack.Int
 }
 
 // HandleViewSubmission handles Modal form submission.
-// This executes the capability with the submitted parameters.
-func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.InteractionCallback) error {
+// Returns ViewSubmissionResponse for validation errors, nil for success.
+// The error return is for unexpected errors (not validation failures).
+func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.InteractionCallback) (*slack.ViewSubmissionResponse, error) {
 	if h.client == nil {
-		return fmt.Errorf("slack client not configured")
+		return nil, fmt.Errorf("slack client not configured")
 	}
 
 	capID := callback.View.PrivateMetadata
@@ -154,7 +155,7 @@ func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.Inte
 	// Get capability definition
 	cap, ok := h.registry.Get(capID)
 	if !ok {
-		return fmt.Errorf("capability not found: %s", capID)
+		return nil, fmt.Errorf("capability not found: %s", capID)
 	}
 
 	// Extract parameters
@@ -166,8 +167,8 @@ func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.Inte
 			"user", userID,
 			"capability", capID,
 			"errors", errors)
-		// Return validation errors in response
-		return h.buildValidationResponse(callback, errors)
+		// Return validation errors as Slack ViewSubmissionResponse
+		return slack.NewErrorsViewSubmissionResponse(errors), nil
 	}
 
 	h.logger.Info("Executing capability",
@@ -192,21 +193,8 @@ func (h *Handler) HandleViewSubmission(ctx context.Context, callback *slack.Inte
 			"capability", capID)
 	}
 
-	// Return empty response to close the Modal
-	return nil
-}
-
-// buildValidationResponse builds an error response for validation failures.
-func (h *Handler) buildValidationResponse(callback *slack.InteractionCallback, errors map[string]string) error {
-	// Build error message
-	var errorLines []string
-	for _, errMsg := range errors {
-		errorLines = append(errorLines, fmt.Sprintf("• %s", errMsg))
-	}
-
-	// Log validation errors (actual response would need slack.ResponseAction)
-	h.logger.Warn("Validation errors", "errors", strings.Join(errorLines, "\n"))
-	return fmt.Errorf("validation failed: %s", strings.Join(errorLines, ", "))
+	// Return nil to close the Modal successfully
+	return nil, nil
 }
 
 // IsCapabilityAction checks if an action ID is a capability click action.

--- a/chatapps/slack/apphome/registry.go
+++ b/chatapps/slack/apphome/registry.go
@@ -1,0 +1,231 @@
+package apphome
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Registry manages capability definitions with thread-safe access.
+type Registry struct {
+	mu          sync.RWMutex
+	capabilities map[string]Capability
+	categories  []CategoryInfo
+	configPath  string
+	logger      *slog.Logger
+}
+
+// RegistryOption configures a Registry.
+type RegistryOption func(*Registry)
+
+// WithLogger sets the logger for the registry.
+func WithLogger(logger *slog.Logger) RegistryOption {
+	return func(r *Registry) {
+		r.logger = logger
+	}
+}
+
+// WithConfigPath sets the path to the capabilities config file.
+func WithConfigPath(path string) RegistryOption {
+	return func(r *Registry) {
+		r.configPath = path
+	}
+}
+
+// WithCategories sets custom categories.
+func WithCategories(categories []CategoryInfo) RegistryOption {
+	return func(r *Registry) {
+		r.categories = categories
+	}
+}
+
+// NewRegistry creates a new capability registry.
+func NewRegistry(opts ...RegistryOption) *Registry {
+	r := &Registry{
+		capabilities: make(map[string]Capability),
+		categories:   DefaultCategories(),
+		logger:       slog.Default(),
+		configPath:   "",
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Load loads capabilities from the configured YAML file.
+func (r *Registry) Load() error {
+	if r.configPath == "" {
+		r.logger.Debug("No config path specified, skipping load")
+		return nil
+	}
+
+	data, err := os.ReadFile(r.configPath)
+	if err != nil {
+		return fmt.Errorf("read config file: %w", err)
+	}
+
+	var cfg struct {
+		Capabilities []Capability `yaml:"capabilities"`
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse config file: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Clear existing capabilities
+	r.capabilities = make(map[string]Capability)
+
+	// Load and validate each capability
+	for _, cap := range cfg.Capabilities {
+		if err := cap.Validate(); err != nil {
+			r.logger.Warn("Invalid capability, skipping",
+				"capability_id", cap.ID,
+				"error", err)
+			continue
+		}
+
+		// Skip disabled capabilities
+		if !cap.Enabled {
+			r.logger.Debug("Capability disabled, skipping",
+				"capability_id", cap.ID)
+			continue
+		}
+
+		r.capabilities[cap.ID] = cap
+		r.logger.Debug("Loaded capability",
+			"capability_id", cap.ID,
+			"category", cap.Category)
+	}
+
+	r.logger.Info("Capabilities loaded", "count", len(r.capabilities))
+	return nil
+}
+
+// Reload reloads capabilities from the config file.
+func (r *Registry) Reload() error {
+	r.logger.Info("Reloading capabilities")
+	return r.Load()
+}
+
+// Get retrieves a capability by ID.
+func (r *Registry) Get(id string) (Capability, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	cap, ok := r.capabilities[id]
+	return cap, ok
+}
+
+// GetAll returns all registered capabilities.
+func (r *Registry) GetAll() []Capability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Capability, 0, len(r.capabilities))
+	for _, cap := range r.capabilities {
+		result = append(result, cap)
+	}
+	return result
+}
+
+// GetByCategory returns capabilities filtered by category.
+func (r *Registry) GetByCategory(category string) []Capability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []Capability
+	for _, cap := range r.capabilities {
+		if cap.Category == category {
+			result = append(result, cap)
+		}
+	}
+	return result
+}
+
+// GetCategories returns all available categories.
+func (r *Registry) GetCategories() []CategoryInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]CategoryInfo, len(r.categories))
+	copy(result, r.categories)
+	return result
+}
+
+// Register adds a capability to the registry.
+func (r *Registry) Register(cap Capability) error {
+	if err := cap.Validate(); err != nil {
+		return fmt.Errorf("validate capability: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.capabilities[cap.ID] = cap
+	r.logger.Debug("Registered capability", "capability_id", cap.ID)
+	return nil
+}
+
+// Unregister removes a capability from the registry.
+func (r *Registry) Unregister(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.capabilities, id)
+	r.logger.Debug("Unregistered capability", "capability_id", id)
+}
+
+// ConfigPath returns the current config file path.
+func (r *Registry) ConfigPath() string {
+	return r.configPath
+}
+
+// Count returns the number of registered capabilities.
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.capabilities)
+}
+
+// LoadFromBytes loads capabilities from YAML data.
+// Useful for embedding default capabilities or testing.
+func (r *Registry) LoadFromBytes(data []byte) error {
+	var cfg struct {
+		Capabilities []Capability `yaml:"capabilities"`
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, cap := range cfg.Capabilities {
+		if err := cap.Validate(); err != nil {
+			r.logger.Warn("Invalid capability, skipping",
+				"capability_id", cap.ID,
+				"error", err)
+			continue
+		}
+
+		if !cap.Enabled {
+			continue
+		}
+
+		r.capabilities[cap.ID] = cap
+	}
+
+	r.logger.Info("Capabilities loaded from bytes", "count", len(r.capabilities))
+	return nil
+}

--- a/chatapps/slack/apphome/setup.go
+++ b/chatapps/slack/apphome/setup.go
@@ -1,0 +1,92 @@
+package apphome
+
+import (
+	"log/slog"
+
+	"github.com/hrygo/hotplex/brain"
+	"github.com/slack-go/slack"
+)
+
+// Config holds configuration for the AppHome capability center.
+type Config struct {
+	// Enabled determines if the capability center is active.
+	Enabled bool
+
+	// CapabilitiesPath is the path to the capabilities YAML file.
+	CapabilitiesPath string
+}
+
+// Setup initializes the AppHome capability center with all components.
+// This is the main entry point for integrating AppHome into the Slack adapter.
+func Setup(client *slack.Client, b brain.Brain, config Config, logger *slog.Logger) (*Handler, *Registry, *Executor) {
+	if !config.Enabled {
+		logger.Info("AppHome capability center is disabled")
+		return nil, nil, nil
+	}
+
+	// Create registry and load capabilities
+	registry := NewRegistry(
+		WithConfigPath(config.CapabilitiesPath),
+		WithLogger(logger),
+	)
+
+	// Load capabilities from file
+	if config.CapabilitiesPath != "" {
+		if err := registry.Load(); err != nil {
+			logger.Error("Failed to load capabilities", "error", err)
+		}
+	} else {
+		// Load embedded defaults
+		if err := LoadDefaultCapabilities(registry); err != nil {
+			logger.Warn("Failed to load default capabilities", "error", err)
+		}
+	}
+
+	// Create executor
+	executor := NewExecutor(
+		WithExecutorClient(client),
+		WithExecutorLogger(logger),
+	)
+	if b != nil {
+		executor.SetBrain(b)
+	}
+
+	// Create handler
+	handler := NewHandler(
+		registry,
+		WithSlackClient(client),
+		WithExecutor(executor),
+		WithHandlerLogger(logger),
+	)
+
+	logger.Info("AppHome capability center initialized",
+		"capabilities", registry.Count())
+
+	return handler, registry, executor
+}
+
+// LoadDefaultCapabilities loads the embedded default capabilities.
+func LoadDefaultCapabilities(registry *Registry) error {
+	defaultYAML := `capabilities:
+  - id: code_review
+    name: 代码审查
+    icon: ":mag:"
+    description: 对指定文件进行安全/性能/风格审查
+    category: code
+    enabled: true
+    parameters:
+      - id: target
+        label: 审查目标
+        type: text
+        required: true
+        placeholder: "例如: src/main.go"
+    prompt_template: |
+      请对以下内容进行代码审查:
+      目标: {{.target}}
+      请提供具体的改进建议。
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+`
+	return registry.LoadFromBytes([]byte(defaultYAML))
+}

--- a/docs/prd-apphome-capability-center.md
+++ b/docs/prd-apphome-capability-center.md
@@ -1,0 +1,554 @@
+# PRD: Slack App Home 智能能力中心
+
+**Issue**: [#215](https://github.com/hrygo/hotplex/issues/215)
+**Version**: 1.0.0
+**Status**: Draft
+**Created**: 2026-03-08
+
+---
+
+## 1. 背景与问题陈述
+
+### 1.1 现状痛点
+
+| 痛点 | 描述 |
+|------|------|
+| **重复输入** | 用户每次需手动输入完整 prompt，效率低下 |
+| **静态推荐局限** | 预设提示词无法参数化，灵活性差 |
+| **动态推荐偏差** | 基于上下文推断可能偏离用户真实意图 |
+| **最佳实践分散** | 新人难以快速掌握高效使用方式 |
+
+### 1.2 目标用户
+
+- **开发者**: 日常代码审查、调试、重构
+- **团队新人**: 需要标准化最佳实践引导
+- **高频用户**: 重复执行相似任务
+
+### 1.3 成功指标
+
+| 指标 | 目标值 | 衡量方式 |
+|------|--------|----------|
+| 能力使用率 | >30% 请求通过能力中心触发 | 日志统计 |
+| 完成率 | >90% 提交的能力任务完成 | Modal → 最终响应 |
+| 用户满意度 | NPS > 7 | 可选反馈收集 |
+
+---
+
+## 2. 解决方案概览
+
+### 2.1 核心概念
+
+**能力 (Capability)**: 预定义的可参数化任务模板，用户通过 App Home 一键触发。
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                      App Home Tab                             │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐           │
+│  │ 🔍 代码审查  │  │ 📝 代码解释  │  │ 🐛 错误诊断  │           │
+│  └─────────────┘  └─────────────┘  └─────────────┘           │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐           │
+│  │ 📦 Commit   │  │ 🔀 PR 审查   │  │ ♻️ 重构建议  │           │
+│  └─────────────┘  └─────────────┘  └─────────────┘           │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ 点击能力卡片
+┌──────────────────────────────────────────────────────────────┐
+│                     Parameter Modal                            │
+│  ┌──────────────────────────────────────────────────────────┐│
+│  │ 文件路径: [________________________] (必填)               ││
+│  │ 审查重点: [安全 ▼] [性能 ▼] [风格 ▼] (多选)              ││
+│  │ 额外说明: [________________________] (可选)               ││
+│  │                                          [取消] [执行]    ││
+│  └──────────────────────────────────────────────────────────┘│
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 与现有系统集成
+
+```
+                    ┌─────────────────┐
+                    │   App Home      │
+                    │  能力中心 UI    │
+                    └────────┬────────┘
+                             │ 用户选择能力
+                             ▼
+                    ┌─────────────────┐
+                    │  Native Brain   │◀─────────────────────────┐
+                    │  - 意图确认      │                          │
+                    │  - 智能路由      │                          │
+                    │  - 上下文压缩    │                          │
+                    └────────┬────────┘                          │
+                             │ 渲染 Prompt                       │
+                             ▼                                   │
+                    ┌─────────────────┐                          │
+                    │   DM Channel    │                          │
+                    │   Engine 执行   │                          │
+                    └────────┬────────┘                          │
+                             │ 结果响应                          │
+                             └──────────────────────────────────┘
+```
+
+---
+
+## 3. 功能需求
+
+### 3.1 能力定义系统
+
+#### 3.1.1 Capability 数据结构
+
+```go
+// chatapps/slack/apphome/capability.go
+
+type Capability struct {
+    ID             string         `yaml:"id" json:"id"`
+    Name           string         `yaml:"name" json:"name"`
+    Icon           string         `yaml:"icon" json:"icon"`
+    Description    string         `yaml:"description" json:"description"`
+    Category       string         `yaml:"category" json:"category"`
+    Parameters     []Parameter    `yaml:"parameters" json:"parameters"`
+    PromptTemplate string         `yaml:"prompt_template" json:"prompt_template"`
+    BrainOpts      BrainOptions   `yaml:"brain_opts" json:"brain_opts"`
+    Enabled        bool           `yaml:"enabled" json:"enabled"`
+}
+
+type Parameter struct {
+    ID          string   `yaml:"id" json:"id"`
+    Label       string   `yaml:"label" json:"label"`
+    Type        string   `yaml:"type" json:"type"` // text, select, multiline
+    Required    bool     `yaml:"required" json:"required"`
+    Default     string   `yaml:"default" json:"default"`
+    Options     []string `yaml:"options" json:"options"`
+    Placeholder string   `yaml:"placeholder" json:"placeholder"`
+}
+
+type BrainOptions struct {
+    IntentConfirm   bool   `yaml:"intent_confirm"`   // 是否需要意图确认
+    CompressContext bool   `yaml:"compress_context"` // 是否压缩历史上下文
+    PreferredModel  string `yaml:"preferred_model"`  // 偏好模型
+}
+```
+
+#### 3.1.2 YAML 配置格式
+
+```yaml
+# capabilities.yaml
+capabilities:
+  - id: code_review
+    name: 代码审查
+    icon: ":mag:"
+    description: 对指定文件进行安全/性能/风格审查
+    category: code
+    enabled: true
+    parameters:
+      - id: file_path
+        label: 文件路径
+        type: text
+        required: true
+        placeholder: 例如: src/main.go
+      - id: focus
+        label: 审查重点
+        type: select
+        required: false
+        options:
+          - security
+          - performance
+          - style
+          - maintainability
+    prompt_template: |
+      请对以下文件进行代码审查:
+      文件: {{.file_path}}
+      重点关注: {{.focus}}
+
+      请从以下角度进行分析:
+      1. 安全性
+      2. 性能
+      3. 代码风格
+      4. 可维护性
+    brain_opts:
+      intent_confirm: false
+      compress_context: true
+      preferred_model: claude-sonnet-4-6
+```
+
+### 3.2 App Home 页面构建
+
+#### 3.2.1 Home Tab 结构
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ 🔥 HotPlex 能力中心                                         │
+│                                                            │
+│ 💻 代码                                                    │
+│ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐        │
+│ │🔍 代码审查    │ │📝 代码解释    │ │♻️ 重构建议    │        │
+│ │安全/性能审查  │ │解释工作原理   │ │优化建议      │        │
+│ └──────────────┘ └──────────────┘ └──────────────┘        │
+│                                                            │
+│ 🐛 调试                                                    │
+│ ┌──────────────┐                                          │
+│ │🐛 错误诊断    │                                          │
+│ │分析错误信息   │                                          │
+│ └──────────────┘                                          │
+│                                                            │
+│ 🔀 Git                                                    │
+│ ┌──────────────┐ ┌──────────────┐                         │
+│ │📦 Commit生成  │ │🔀 PR审查     │                         │
+│ │Conventional   │ │审查变更建议   │                         │
+│ └──────────────┘ └──────────────┘                         │
+└────────────────────────────────────────────────────────────┘
+```
+
+#### 3.2.2 事件处理
+
+需要处理的新事件类型:
+
+| 事件类型 | 触发条件 | 处理动作 |
+|----------|----------|----------|
+| `app_home_opened` | 用户点击 App Home Tab | 构建 Home 页面 |
+| `block_actions` | 点击能力卡片 | 打开参数 Modal |
+| `view_submission` | Modal 表单提交 | 执行能力任务 |
+
+### 3.3 参数 Modal 构建
+
+#### 3.3.1 动态表单生成
+
+根据 Capability 定义动态构建 Modal:
+
+```go
+// chatapps/slack/apphome/form.go
+
+func BuildCapabilityModal(cap Capability) *slack.ModalViewRequest {
+    blocks := []slack.Block{}
+
+    for _, param := range cap.Parameters {
+        switch param.Type {
+        case "text":
+            blocks = append(blocks, buildTextInput(param))
+        case "select":
+            blocks = append(blocks, buildSelectInput(param))
+        case "multiline":
+            blocks = append(blocks, buildTextarea(param))
+        }
+    }
+
+    return &slack.ModalViewRequest{
+        Type:       slack.VTModal,
+        Title:      slack.NewTextBlockObject("plain_text", cap.Name, false, false),
+        Submit:     slack.NewTextBlockObject("plain_text", "执行", false, false),
+        Close:      slack.NewTextBlockObject("plain_text", "取消", false, false),
+        Blocks:     slack.Blocks{BlockSet: blocks},
+        PrivateMetadata: cap.ID, // 用于回调时识别能力
+    }
+}
+```
+
+### 3.4 与 Native Brain 集成
+
+#### 3.4.1 智能路由
+
+```go
+// chatapps/slack/apphome/brain_integration.go
+
+type BrainIntegration struct {
+    brain brain.Brain
+    router *brain.IntentRouter
+}
+
+func (bi *BrainIntegration) PreparePrompt(
+    ctx context.Context,
+    cap Capability,
+    params map[string]string,
+) (string, error) {
+
+    // 1. 渲染 Prompt 模板
+    prompt := renderTemplate(cap.PromptTemplate, params)
+
+    // 2. 可选: 意图确认
+    if cap.BrainOpts.IntentConfirm {
+        confirmed, err := bi.confirmIntent(ctx, prompt)
+        if err != nil {
+            return "", err
+        }
+        if !confirmed {
+            return "", ErrIntentNotConfirmed
+        }
+    }
+
+    // 3. 可选: 上下文压缩
+    if cap.BrainOpts.CompressContext {
+        compressed, err := bi.compressContext(ctx, prompt)
+        if err != nil {
+            // 非致命错误，继续使用原始 prompt
+            log.Warn("Context compression failed", "error", err)
+        } else {
+            prompt = compressed
+        }
+    }
+
+    return prompt, nil
+}
+```
+
+### 3.5 能力执行流程
+
+```go
+// chatapps/slack/apphome/handler.go
+
+func (h *Handler) HandleCapabilitySubmit(
+    ctx context.Context,
+    callback *slack.InteractionCallback,
+) error {
+
+    // 1. 解析提交数据
+    capID := callback.View.PrivateMetadata
+    params := extractParams(callback.View.State.Values)
+
+    // 2. 加载能力定义
+    cap, err := h.registry.Get(capID)
+    if err != nil {
+        return err
+    }
+
+    // 3. 参数校验
+    if err := validateParams(cap, params); err != nil {
+        return h.showValidationErrors(callback, err)
+    }
+
+    // 4. Brain 预处理
+    prompt, err := h.brain.PreparePrompt(ctx, cap, params)
+    if err != nil {
+        return err
+    }
+
+    // 5. 获取或创建 DM 频道
+    dmChannel, err := h.getOrCreateDMChannel(ctx, callback.User.ID)
+    if err != nil {
+        return err
+    }
+
+    // 6. 发送渲染后的 Prompt 到 DM
+    if err := h.sendToDM(ctx, dmChannel, prompt); err != nil {
+        return err
+    }
+
+    // 7. 触发 Engine 执行
+    return h.triggerEngine(ctx, callback.User.ID, dmChannel, prompt)
+}
+```
+
+---
+
+## 4. 技术架构
+
+### 4.1 文件结构
+
+```
+chatapps/slack/apphome/
+├── builder.go           # Home Tab 页面构建
+├── capability.go        # Capability 数据结构定义
+├── registry.go          # 能力注册中心 (加载/缓存 YAML)
+├── handler.go           # 事件处理入口
+├── form.go              # Modal 表单动态构建
+├── brain_integration.go # Native Brain 集成
+├── executor.go          # 能力执行器
+└── capabilities.yaml    # 预定义能力配置
+```
+
+### 4.2 与现有模块集成
+
+```
+chatapps/slack/
+├── adapter.go          # 新增 AppHome Handler 注册
+├── events.go           # 扩展处理 app_home_opened
+├── interactive.go      # 扩展处理 view_submission
+└── apphome/            # 新增包
+    └── ...
+```
+
+### 4.3 依赖关系
+
+```
+apphome/
+    ├── brain/          # Native Brain 智能路由
+    ├── engine/         # Engine 触发执行
+    └── slack-go/slack  # Slack SDK
+```
+
+---
+
+## 5. API 设计
+
+### 5.1 公开接口
+
+```go
+// Registry - 能力注册中心
+type Registry interface {
+    // GetAll 返回所有已启用的能力
+    GetAll() []Capability
+
+    // GetByID 根据 ID 获取能力
+    GetByID(id string) (Capability, error)
+
+    // Reload 重新加载配置文件
+    Reload() error
+
+    // GetByCategory 按分类获取能力
+    GetByCategory(category string) []Capability
+}
+
+// Handler - App Home 事件处理器
+type Handler interface {
+    // HandleHomeOpened 处理 app_home_opened 事件
+    HandleHomeOpened(ctx context.Context, event *slack.AppHomeOpenedEvent) error
+
+    // HandleCapabilityClick 处理能力卡片点击
+    HandleCapabilityClick(ctx context.Context, callback *slack.InteractionCallback) error
+
+    // HandleCapabilitySubmit 处理 Modal 表单提交
+    HandleCapabilitySubmit(ctx context.Context, callback *slack.InteractionCallback) error
+}
+```
+
+---
+
+## 6. 预定义能力清单
+
+### 6.1 MVP 能力 (Phase 1)
+
+| ID | 名称 | 分类 | 描述 | 优先级 |
+|----|------|------|------|--------|
+| `code_review` | 代码审查 | code | 对文件进行安全/性能/风格审查 | P0 |
+| `explain_code` | 代码解释 | code | 解释代码片段工作原理 | P0 |
+| `debug_error` | 错误诊断 | debug | 分析错误信息并给出修复方案 | P0 |
+| `git_commit` | Commit 生成 | git | 生成 Conventional Commit 消息 | P1 |
+| `pr_review` | PR 审查 | code | 审查 PR 变更并给出建议 | P1 |
+| `refactor` | 重构建议 | code | 分析代码并提供重构建议 | P1 |
+
+### 6.2 扩展能力 (Phase 2+)
+
+| ID | 名称 | 分类 | 描述 |
+|----|------|------|------|
+| `test_gen` | 测试生成 | code | 为代码生成单元测试 |
+| `doc_gen` | 文档生成 | docs | 生成代码文档 |
+| `api_design` | API 设计 | design | 设计 RESTful API 规范 |
+| `sql_opt` | SQL 优化 | db | 分析并优化 SQL 查询 |
+
+---
+
+## 7. 配置与部署
+
+### 7.1 环境变量
+
+```bash
+# 能力中心开关
+HOTPLEX_APPHOME_ENABLED=true
+
+# 配置文件路径 (支持热更新)
+HOTPLEX_CAPABILITIES_PATH=/etc/hotplex/capabilities.yaml
+```
+
+### 7.2 Slack App 权限
+
+需要添加以下 OAuth Scope:
+
+- `home` - App Home Tab 访问
+- `im:write` - 发送 DM 消息
+- `im:history` - 读取 DM 历史
+- `views:write` - Modal 创建和更新
+
+### 7.3 热更新
+
+支持不重启服务更新能力定义:
+
+```bash
+# 方式 1: 修改 YAML 后触发重载
+kill -HUP <pid>
+
+# 方式 2: API 触发 (可选)
+curl -X POST http://localhost:8080/api/v1/apphome/reload
+```
+
+---
+
+## 8. 测试策略
+
+### 8.1 单元测试
+
+| 模块 | 测试重点 |
+|------|----------|
+| `registry.go` | YAML 加载、缓存、热更新 |
+| `form.go` | 动态 Modal 构建、参数提取 |
+| `executor.go` | Prompt 渲染、Engine 触发 |
+
+### 8.2 集成测试
+
+- 端到端流程: 点击卡片 → 填写表单 → 收到响应
+- Brain 集成: 意图确认、上下文压缩
+
+### 8.3 手动测试清单
+
+- [ ] 打开 App Home 显示能力网格
+- [ ] 点击卡片弹出正确参数 Modal
+- [ ] 必填参数校验
+- [ ] 提交后收到 DM 响应
+- [ ] YAML 热更新生效
+
+---
+
+## 9. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| Modal 表单复杂度高 | 用户体验差 | 限制参数数量 ≤5，提供默认值 |
+| Brain API 延迟 | 响应变慢 | 提供快速路径跳过 Brain |
+| 能力滥用 | Token 消耗过大 | 增加频率限制、确认机制 |
+| 配置文件损坏 | 功能不可用 | 验证配置格式、备份恢复 |
+
+---
+
+## 10. 里程碑
+
+### Phase 1: MVP (v0.24.0)
+
+- [ ] 基础 Capability 定义和注册
+- [ ] App Home 页面构建
+- [ ] Modal 动态表单
+- [ ] 基础能力执行 (无 Brain 集成)
+- [ ] 3 个核心能力: code_review, explain_code, debug_error
+
+### Phase 2: Brain 集成 (v0.25.0)
+
+- [ ] Native Brain 智能路由
+- [ ] 意图确认
+- [ ] 上下文压缩
+- [ ] 额外 3 个能力: git_commit, pr_review, refactor
+
+### Phase 3: 增强 (v0.26.0)
+
+- [ ] YAML 热更新
+- [ ] 自定义能力支持
+- [ ] 使用统计和反馈
+- [ ] 能力搜索/筛选
+
+---
+
+## 11. 附录
+
+### A. Slack Block Kit 参考
+
+```go
+// 能力卡片 Button Block
+slack.NewSectionBlock(
+    slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("%s *%s*", cap.Icon, cap.Name), false, false),
+    nil,
+    slack.NewAccessory(slack.NewButtonBlockElement(
+        "cap_click",
+        cap.ID,
+        slack.NewTextBlockObject("plain_text", "执行", false, false),
+    )),
+)
+```
+
+### B. 相关 Issue
+
+- #215: feat(slack): App Home 智能能力中心


### PR DESCRIPTION
## Summary
- 实现 Slack App Home 智能能力中心 (Refs #215)
- 提供预定义可参数化任务模板，用户通过 App Home 一键触发
- 包含能力注册、构建器、表单处理、执行器等核心模块

## Test plan
- [ ] 本地构建通过 `go build ./...`
- [ ] 单元测试通过 `go test ./chatapps/slack/apphome/...`
- [ ] 验证 App Home 页面正常渲染
- [ ] 验证能力触发流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)