### PR TITLE
fix(session): resolve "Session ID already in use" error (Refs #254)

### DIFF
--- a/internal/engine/pool.go
+++ b/internal/engine/pool.go
@@ -253,6 +253,11 @@ func (sm *SessionPool) startSession(ctx context.Context, sessionID string, cfg S
 		"provider_session_id", providerSessionID,
 	)
 
+	// Check if this was a resume from persistent store BEFORE building CLI args
+	// This is critical because buildCLIArgs creates a marker for new sessions,
+	// so we must check existence before that side effect
+	isResuming := sm.markerStore.Exists(providerSessionID)
+
 	args := sm.buildCLIArgs(providerSessionID, sessLog, prompt, cfg)
 	cmd := exec.CommandContext(sessCtx, sm.cliPath, args...)
 
@@ -309,9 +314,6 @@ func (sm *SessionPool) startSession(ctx context.Context, sessionID string, cfg S
 	sessLog.Info("OS Process started (Cold Start)",
 		"pid", cmd.Process.Pid,
 		"pgid", cmd.Process.Pid)
-
-	// Check if this was a resume from persistent store
-	isResuming := sm.markerStore.Exists(providerSessionID)
 
 	sess := &Session{
 		ID:                sessionID,

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -45,8 +45,9 @@ type Session struct {
 	Status       SessionStatus
 	statusChange chan SessionStatus
 
-	mu     sync.RWMutex
-	closed bool
+	mu                 sync.RWMutex
+	closed             bool
+	firstOutputReceived bool // Tracks if we've received valid stdout output
 
 	callback   Callback
 	logger     *slog.Logger
@@ -112,13 +113,14 @@ func (s *Session) GetStatusChange() <-chan SessionStatus {
 }
 
 // waitForReady monitors the session and transitions from Starting to Ready
-// when the process is confirmed alive and responsive.
+// when the process is confirmed alive, responsive, and has produced valid output.
+// This prevents false-ready states where the process starts but immediately fails.
 func (s *Session) waitForReady(ctx context.Context, timeout time.Duration) {
 	panicx.SafeGo(s.logger, func() {
 		deadlineTimer := time.NewTimer(timeout)
 		defer deadlineTimer.Stop()
 
-		ticker := time.NewTicker(500 * time.Millisecond)
+		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
 		for {
@@ -138,7 +140,9 @@ func (s *Session) waitForReady(ctx context.Context, timeout time.Duration) {
 					s.mu.Unlock()
 					return
 				}
-				if s.isAliveLocked() {
+				// Check both: process is alive AND we've received valid output
+				// This prevents false-ready when process starts but immediately fails
+				if s.isAliveLocked() && s.firstOutputReceived {
 					s.mu.Unlock()
 					s.SetStatus(SessionStatusReady)
 					return
@@ -278,6 +282,16 @@ func (s *Session) ReadStdout() {
 		if line == "" {
 			continue
 		}
+
+		// Mark that we've received valid output - session is truly ready
+		// This is used by waitForReady to distinguish between:
+		// - Process briefly starts then fails (not ready)
+		// - Process starts and is actually serving requests (ready)
+		s.mu.Lock()
+		if !s.firstOutputReceived {
+			s.firstOutputReceived = true
+		}
+		s.mu.Unlock()
 
 		cb := s.GetCallback()
 		if cb != nil {

--- a/provider/claude_provider.go
+++ b/provider/claude_provider.go
@@ -451,17 +451,29 @@ func (p *ClaudeCodeProvider) CleanupSession(providerSessionID string, workDir st
 		}
 	}
 
-	// Claude Code stores sessions in ~/.claude/projects/<workspace-key>/<providerSessionID>.jsonl
+	// Claude Code stores sessions in ~/.claude/projects/<workspace-key>/
+	// - <providerSessionID>.jsonl (conversation history)
+	// - <providerSessionID>/ (working directory with tool state, memory locks, etc.)
 	projectsDir := filepath.Join(os.Getenv("HOME"), ".claude", "projects")
 	workspaceKey := strings.ReplaceAll(cwd, "/", "-")
-	sessionPath := filepath.Join(projectsDir, workspaceKey, providerSessionID+".jsonl")
+	sessionDir := filepath.Join(projectsDir, workspaceKey)
 
-	// Best effort deletion
+	// 1. Delete session file: <providerSessionID>.jsonl
+	sessionPath := filepath.Join(sessionDir, providerSessionID+".jsonl")
 	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove Claude Code session file: %w", err)
 	}
-
 	p.logger.Debug("Cleaned up Claude Code session file", "path", sessionPath)
+
+	// 2. Delete session working directory: <providerSessionID>/
+	// This directory contains tool state, memory locks, and other artifacts
+	// that cause "Session ID is already in use" errors if not cleaned
+	sessionWorkingDir := filepath.Join(sessionDir, providerSessionID)
+	if err := os.RemoveAll(sessionWorkingDir); err != nil {
+		return fmt.Errorf("remove Claude Code session working directory: %w", err)
+	}
+	p.logger.Debug("Cleaned up Claude Code session working directory", "path", sessionWorkingDir)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
修复 "Session ID Already In Use" 错误导致历史会话无法恢复的问题。

## 根因分析
根据 issue #254/#259 的分析，问题由三个缺陷叠加导致：

1. **waitForReady Bug** - 就绪判定过早，仅检查进程存活，未验证真正就绪
2. **isResuming Bug** - Marker 判定时机错误，在 buildCLIArgs 之后检查，此时新会话已创建 Marker
3. **CleanupSession Bug** - 清理不完整，只删除 .jsonl，未清理锁目录

## 修复内容
- `session.go`: 添加 `firstOutputReceived` 标志，waitForReady 需同时验证进程存活和有效输出
- `pool.go`: 将 isResuming 检查提前到 buildCLIArgs 调用之前
- `claude_provider.go`: CleanupSession 同时删除 .jsonl 文件和工作目录

## Test plan
- [x] 编译通过
- [x] 现有测试全部通过

Refs #254
Resolves #259