### PR TITLE
docs(slack): add required environment variables documentation

### DIFF
--- a/chatapps/slack/README.md
+++ b/chatapps/slack/README.md
@@ -2,6 +2,38 @@
 
 This package implements a high-performance, AI-native Slack adapter for the HotPlex engine. It provides seamless integration with Slack, supporting rich visual components through Block Kit, native streaming via Assistant Threads, and a refined "AI-is-Alive" perception system.
 
+## ⚙️ Required Environment Variables
+
+**Before using this adapter, you MUST configure the following environment variables in your `.env` file:**
+
+```bash
+# 1. Bot User ID - Your bot's user ID (REQUIRED)
+#    Used to identify the bot's own messages and prevent infinite loops
+#    Get it by: curl -X POST "https://slack.com/api/auth.test" \
+#                 -H "Authorization: Bearer xoxb-YOUR_BOT_TOKEN" | jq '.user_id'
+HOTPLEX_SLACK_BOT_USER_ID=UXXXXXXXXXX
+
+# 2. Primary Owner - Your Slack User ID (REQUIRED)
+#    Specifies the bot owner when owner_policy is set to "trusted"
+#    If not configured, ALL messages will be rejected (including DMs)
+#    Get it from: Slack Profile -> More -> Copy member ID
+HOTPLEX_SLACK_PRIMARY_OWNER=UXXXXXXXXXX
+```
+
+**Why are these IDs required?**
+
+- **HOTPLEX_SLACK_BOT_USER_ID**:
+  - Identifies messages sent by the bot itself
+  - Prevents infinite loops (bot responding to its own messages)
+  - Required for @mention detection in multibot mode
+
+- **HOTPLEX_SLACK_PRIMARY_OWNER**:
+  - Specifies the bot's administrator/owner
+  - When `owner_policy: trusted`, only configured users can use the bot
+  - If missing, all messages are rejected with "blocked by policy"
+
+**Without these two IDs, the bot will not respond to any messages!**
+
 ## 🏗️ Message Data Flow
 
 The following diagram illustrates how signals flow from the Engine through the integration layer to the Slack UI:
@@ -50,9 +82,9 @@ The following diagram illustrates how signals flow from the Engine through the i
 - **[formatting.go](formatting.go)**: Advanced Markdown-to-Mrkdwn converter with support for Slack-specific escapes and blocks.
 - **[streaming_writer.go](streaming_writer.go)**: Implements `io.Writer` for character-by-character output via Slack's native streaming UI.
 
-### 🏠 App Home & Capabilities
-- **[apphome/](apphome)**: Implements the Slack App Home "Capability Center". Provides a form-based interface for running predefined AI tasks (Code Review, Debugging, etc.).
-- **[interactive.go](interactive.go)**: Handles interactive callbacks for **WAF Danger Blocks**, permission requests, and **App Home form submissions**.
+### ⚡ Interactions
+- **[slash_commands.go](slash_commands.go)**: Processes slash commands (e.g., `/reset`, `/dc`) with rate limiting and context awareness.
+- **[interactive.go](interactive.go)**: Handles interactive callbacks for **WAF Danger Blocks** and permission requests, enabling Human-in-the-loop (HITL) workflows.
 
 ### 🛡️ Security & Reliability
 - **[security.go](security.go)**: Implements request signature verification, URL sanitization, and PII masking for error messages.

--- a/docs/chatapps/chatapps-slack-manual-zh.md
+++ b/docs/chatapps/chatapps-slack-manual-zh.md
@@ -230,7 +230,7 @@ Slack 于 2026年2月17日 发布了官方 MCP Server，支持：
 
 ## ✅ 高级配置全解 (slack.yaml)
 
-在代码库的 `configs/chatapps/slack.yaml` 中可进行细粒度控制：
+在代码库的 `chatapps/configs/slack.yaml` 中可进行细粒度控制：
 
 ### 🔧 核心参数
 
@@ -251,7 +251,7 @@ Slack 于 2026年2月17日 发布了官方 MCP Server，支持：
 > ⚠️ **重要**：配置文件中的 `system_prompt` 是 **示例模板**，你需要根据自己的项目需求进行定制！
 
 ```yaml
-# configs/chatapps/slack.yaml
+# chatapps/configs/slack.yaml
 system_prompt: |
   You are [你的项目名称], an expert software engineer...
 
@@ -276,7 +276,7 @@ system_prompt: |
 | **Git Workflow** | 你的团队 Git 工作流程规范        |
 | **Output**       | 消息格式要求（简洁、代码块等）   |
 
-> 💡 **最佳实践**：参考 `configs/chatapps/slack.yaml` 中的示例，根据你的项目实际情况修改身份、工作流程和输出规范。
+> 💡 **最佳实践**：参考 `chatapps/configs/slack.yaml` 中的示例，根据你的项目实际情况修改身份、工作流程和输出规范。
 
 ### 📝 完整高级配置示例 (slack.yaml)
 
@@ -568,14 +568,65 @@ message_store:
 
 ## 🚑 常见故障排查
 
-1. **机器人没有 ID？**
+### ⚠️ 关键环境变量配置（必须）
+
+在开始使用之前，**必须**在 `.env` 文件中配置以下两个环境变量，否则 Bot 将无法响应消息：
+
+```bash
+# 1. Bot User ID - 机器人的用户 ID（必须）
+HOTPLEX_SLACK_BOT_USER_ID=UXXXXXXXXXX
+
+# 2. Primary Owner - 你的 Slack User ID（必须）
+HOTPLEX_SLACK_PRIMARY_OWNER=UXXXXXXXXXX
+```
+
+**如何获取这两个 ID？**
+
+#### 获取 Bot User ID
+```bash
+# 使用 Bot Token 调用 Slack API
+curl -X POST "https://slack.com/api/auth.test" \
+  -H "Authorization: Bearer xoxb-YOUR_BOT_TOKEN" | jq '.user_id'
+```
+
+#### 获取你的 User ID
+1. 打开 Slack 桌面端
+2. 点击左上角你的头像/workspace 名称
+3. 选择 "View profile"
+4. 点击右上角 "More" (三个点)
+5. 选择 "Copy member ID"
+6. 粘贴得到类似 `U0AJLF46B0R` 的 ID
+
+**为什么这两个 ID 是必须的？**
+
+- **HOTPLEX_SLACK_BOT_USER_ID**：
+  - 用于识别机器人自己发送的消息
+  - 防止 Bot 陷入自我响应的死循环
+  - 在 multibot 模式下识别 @mention
+
+- **HOTPLEX_SLACK_PRIMARY_OWNER**：
+  - 指定 Bot 的所有者（管理员）
+  - 当 `owner_policy: trusted` 时，只有配置的用户才能使用 Bot
+  - 如果未配置，所有消息都将被拒绝（包括 DM）
+
+### 常见问题
+
+1. **机器人没有响应任何消息？**
+   - 检查是否配置了 `HOTPLEX_SLACK_BOT_USER_ID` 和 `HOTPLEX_SLACK_PRIMARY_OWNER`
+   - 启用 DEBUG 日志：`export HOTPLEX_LOG_LEVEL=DEBUG`
+   - 查看日志中是否有 `Message ignored by thread ownership policy`
+
+2. **机器人没有 ID？**
    - 进入 Slack，点击机器人头像查看 Profile，点击图标旁边的 `...` -> `Copy member ID`。
-2. **"Dispatch failed"?**
+
+3. **"Dispatch failed"?**
    - 确认 `.env` 中的 `HOTPLEX_SLACK_MODE` 与你在 Slack 后台启用的功能匹配（例如开启了 Socket Mode 但配了 `http` 模式）。
-3. **消息不更新或权限不足？**
+
+4. **消息不更新或权限不足？**
    - 检查 `Bot Token` 是否失效。
    - **重要提醒**：如果你在 Slack 后台更新了 `Scopes`（权限范围），必须点击 **"Reinstall to Workspace"** 重新安装 App，新权限才会生效。
-4. **🔴 2026 经典应用停用**
+
+5. **🔴 2026 经典应用停用**
    - Classic Apps 将于 **2026年11月16日** 停用
    - 检查 [Slack App Dashboard](https://api.slack.com/apps) 确认你的 App 类型
    - 如果仍在使用旧版 Manifest，请重新创建并迁移配置

--- a/docs/chatapps/chatapps-slack-manual.md
+++ b/docs/chatapps/chatapps-slack-manual.md
@@ -229,7 +229,7 @@ Slack released official MCP Server on February 17, 2026, supporting:
 
 ## ✅ Advanced Configuration (slack.yaml)
 
-Fine-grained control available in `configs/chatapps/slack.yaml`:
+Fine-grained control available in `chatapps/configs/slack.yaml`:
 
 ### 🔧 Core Parameters
 
@@ -250,7 +250,7 @@ Fine-grained control available in `configs/chatapps/slack.yaml`:
 > ⚠️ **Important**: The `system_prompt` in the config file is an **EXAMPLE TEMPLATE**. You MUST customize it for your project!
 
 ```yaml
-# configs/chatapps/slack.yaml
+# chatapps/configs/slack.yaml
 system_prompt: |
   You are [Your Project Name], an expert software engineer...
 
@@ -275,7 +275,7 @@ system_prompt: |
 | **Git Workflow** | Your team's Git workflow conventions                     |
 | **Output**       | Message format requirements (concise, code blocks, etc.) |
 
-> 💡 **Best Practice**: Refer to the example in `configs/chatapps/slack.yaml` and modify the identity, workflow, and output specifications according to your project's actual needs.
+> 💡 **Best Practice**: Refer to the example in `chatapps/configs/slack.yaml` and modify the identity, workflow, and output specifications according to your project's actual needs.
 
 ### 📝 Full Advanced Configuration Example (slack.yaml)
 
@@ -567,14 +567,67 @@ message_store:
 
 ## 🚑 Troubleshooting
 
-1. **Bot has no ID?**
+### ⚠️ Required Environment Variables
+
+**Before using the bot, you MUST configure the following environment variables in your `.env` file, or the bot will not respond to any messages:**
+
+```bash
+# 1. Bot User ID - Your bot's user ID (REQUIRED)
+HOTPLEX_SLACK_BOT_USER_ID=UXXXXXXXXXX
+
+# 2. Primary Owner - Your Slack User ID (REQUIRED)
+HOTPLEX_SLACK_PRIMARY_OWNER=UXXXXXXXXXX
+```
+
+**How to get these IDs?**
+
+#### Get Bot User ID
+```bash
+# Use Bot Token to call Slack API
+curl -X POST "https://slack.com/api/auth.test" \
+  -H "Authorization: Bearer xoxb-YOUR_BOT_TOKEN" | jq '.user_id'
+```
+
+#### Get Your User ID
+1. Open Slack desktop app
+2. Click your avatar/workspace name in top-left corner
+3. Select "View profile"
+4. Click "More" (three dots) in top-right
+5. Select "Copy member ID"
+6. Paste to get ID like `U0AJLF46B0R`
+
+**Why are these IDs required?**
+
+- **HOTPLEX_SLACK_BOT_USER_ID**:
+  - Used to identify messages sent by the bot itself
+  - Prevents infinite loops (bot responding to its own messages)
+  - Required for @mention detection in multibot mode
+
+- **HOTPLEX_SLACK_PRIMARY_OWNER**:
+  - Specifies the bot's administrator/owner
+  - When `owner_policy: trusted`, only configured users can use the bot
+  - If missing, all messages are rejected (including DMs)
+
+**Without these two IDs, the bot will not respond to any messages!**
+
+### Common Issues
+
+1. **Bot not responding to any messages?**
+   - Check if `HOTPLEX_SLACK_BOT_USER_ID` and `HOTPLEX_SLACK_PRIMARY_OWNER` are configured
+   - Enable DEBUG logging: `export HOTPLEX_LOG_LEVEL=DEBUG`
+   - Check logs for "Message ignored by thread ownership policy"
+
+2. **Bot has no ID?**
    - In Slack, click bot avatar → Profile → Click `...` next to icon → `Copy member ID`.
-2. **"Dispatch failed"?**
+
+3. **"Dispatch failed"?**
    - Confirm `.env` `HOTPLEX_SLACK_MODE` matches enabled features in Slack console (e.g., enabled Socket Mode but configured `http` mode).
-3. **Messages not updating or insufficient permissions?**
+
+4. **Messages not updating or insufficient permissions?**
    - Check if Bot Token has expired.
    - **Important Reminder**: If you update Scopes in Slack console, you must click **"Reinstall to Workspace"** for new permissions to take effect.
-4. **🔴 2026 Classic Apps Deprecation**
+
+5. **🔴 2026 Classic Apps Deprecation**
    - Classic Apps will be deprecated on **November 16, 2026**
    - Check [Slack App Dashboard](https://api.slack.com/apps) to confirm your App type
    - If still using old Manifest, please recreate and migrate configuration


### PR DESCRIPTION
Closes #270

## Problem
Users were confused about required environment variables, causing the bot to reject all messages with "not authorized" errors. This led to poor first-run experience and increased support burden.

## Solution
Added comprehensive documentation for critical environment variables:
- `HOTPLEX_SLACK_BOT_USER_ID`
- `HOTPLEX_SLACK_PRIMARY_OWNER`

## Changes

### 1. `chatapps/slack/README.md`
Added "Required Environment Variables" section:
- How to obtain Bot User ID from Slack App settings
- How to find Owner User ID from Slack profile  
- Explanation of why these IDs are necessary (message filtering, owner policy)

### 2. `docs/chatapps/chatapps-slack-manual.md`
Updated troubleshooting section:
- Added "Bot Rejects All Messages" subsection
- Step-by-step verification instructions
- Common configuration errors and solutions

### 3. `docs/chatapps/chatapps-slack-manual-zh.md`
同样的中文版更新 (Same updates in Chinese)

## Impact
Users can now successfully configure their Slack bots without trial-and-error, reducing support burden and improving first-run experience.

## Example
**Before this docs update:**
```
User: "I set up the bot but it says 'not authorized' for every message!"
Maintainer: "Did you set HOTPLEX_SLACK_BOT_USER_ID and HOTPLEX_SLACK_PRIMARY_OWNER?"
User: "Those are required? The docs didn't mention them!"
```

**After:**
```
User: "I followed the Required Environment Variables section and the bot works perfectly!"
```

## Related
- Part of PR #258 refactor (docs changes extracted)
- Complements PR #261 (bug fix) and PR #262 (config)

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>