### PR TITLE
fix(provider): add support for Claude Code 'think' event type

### DIFF
--- a/provider/claude_provider.go
+++ b/provider/claude_provider.go
@@ -243,7 +243,7 @@ func (p *ClaudeCodeProvider) ParseEvent(line string) ([]*ProviderEvent, error) {
 		event.Content = msg.Error
 		events = append(events, event)
 
-	case "thinking", "status":
+	case "thinking", "status", "think":
 		blocks := msg.GetContentBlocks()
 		if len(blocks) > 0 {
 			for _, block := range blocks {


### PR DESCRIPTION
## Summary

Claude Code new version uses 'think' tag instead of 'thinking'. This fix ensures think events are properly recognized as thinking instead of being incorrectly displayed in Answer.

## Changes
- Add 'think' to the event type switch case in claude_provider.go

## Test Plan
- [x] Build passes
- [ ] CI tests pass

Refs #256