### PR TITLE
fix: session stats token format and cache billing

### DIFF
--- a/chatapps/engine_handler.go
+++ b/chatapps/engine_handler.go
@@ -111,9 +111,14 @@ func (w *engineWrapper) GetSessionStats(sessionID string) *SessionStats {
 		return nil
 	}
 	return &SessionStats{
-		SessionID:     stats.SessionID,
-		Status:        stats.SessionID,
-		TotalTokens:   int64(stats.InputTokens + stats.OutputTokens + stats.CacheReadTokens + stats.CacheWriteTokens),
+		SessionID: stats.SessionID,
+		Status:    stats.SessionID,
+		// Token billing formula:
+		// input_tokens already includes cache_read_tokens
+		// output_tokens already includes cache_write_tokens
+		// Billable = input + output - cache_read*0.9 - cache_write*0.9
+		// (cache is charged at 10%, so we subtract 90% of cache tokens)
+		TotalTokens:   int64(stats.InputTokens) + int64(stats.OutputTokens) - int64(float64(stats.CacheReadTokens)*0.9) - int64(float64(stats.CacheWriteTokens)*0.9),
 		InputTokens:   int64(stats.InputTokens),
 		OutputTokens:  int64(stats.OutputTokens),
 		CacheRead:     int64(stats.CacheReadTokens),

--- a/chatapps/feishu/card_builder.go
+++ b/chatapps/feishu/card_builder.go
@@ -242,12 +242,33 @@ func (b *CardBuilder) BuildErrorCard(errorMsg string) (string, error) {
 	return b.marshalCard(card)
 }
 
+// formatTokenCount formats token count in compact form (1.2K, 1.00M)
+// Uses proper threshold: K for < 1M, M for >= 1M
+func formatTokenCount(count int) string {
+	if count >= 1000000 {
+		return fmt.Sprintf("%.2fM", float64(count)/1000000)
+	}
+	if count >= 1000 {
+		kValue := float64(count) / 1000
+		// If k value >= 999.5, show M to avoid rounding issues
+		if kValue >= 999.5 {
+			return fmt.Sprintf("%.2fM", float64(count)/1000000)
+		}
+		// Use integer for >= 100K
+		if kValue >= 100 {
+			return fmt.Sprintf("%.0fK", kValue)
+		}
+		return fmt.Sprintf("%.1fK", kValue)
+	}
+	return fmt.Sprintf("%d", count)
+}
+
 // BuildSessionStatsCard builds a session statistics card
 // Event: session_stats - Gray note with stats
 func (b *CardBuilder) BuildSessionStatsCard(duration string, tokenUsage int, otherStats map[string]string) (string, error) {
-	// Build stats text
+	// Build stats text with formatted token count
 	var statsBuilder strings.Builder
-	_, _ = fmt.Fprintf(&statsBuilder, "⏱️ %s • ⚡ %d tokens", duration, tokenUsage)
+	_, _ = fmt.Fprintf(&statsBuilder, "⏱️ %s • ⚡ %s tokens", duration, formatTokenCount(tokenUsage))
 
 	// Add additional stats if provided
 	for key, value := range otherStats {

--- a/chatapps/feishu/card_builder_test.go
+++ b/chatapps/feishu/card_builder_test.go
@@ -264,7 +264,7 @@ func TestBuildSessionStatsCard(t *testing.T) {
 	if !strings.Contains(statsContent, "⏱️ 2.3s") {
 		t.Errorf("Expected duration in stats, got %s", statsContent)
 	}
-	if !strings.Contains(statsContent, "⚡ 1200 tokens") {
+	if !strings.Contains(statsContent, "⚡ 1.2K tokens") {
 		t.Errorf("Expected token usage in stats, got %s", statsContent)
 	}
 	if !strings.Contains(statsContent, "步骤") || !strings.Contains(statsContent, "3/5") {

--- a/chatapps/slack/builder_stats.go
+++ b/chatapps/slack/builder_stats.go
@@ -32,11 +32,21 @@ func (b *StatsMessageBuilder) BuildSessionStatsMessage(msg *base.ChatMessage) []
 			stats = append(stats, "⏱️ "+FormatDuration(duration))
 		}
 
-		// Tokens (show in/out separately) - using input_tokens/output_tokens from SessionStats.ToSummary
+		// Tokens (show in/out separately with cache info)
+		// input_tokens/output_tokens already include cache tokens from API
 		tokensIn := extractInt64(msg.Metadata, "input_tokens")
 		tokensOut := extractInt64(msg.Metadata, "output_tokens")
+		cacheRead := extractInt64(msg.Metadata, "cache_read_tokens")
+		cacheWrite := extractInt64(msg.Metadata, "cache_write_tokens")
 		if tokensIn > 0 || tokensOut > 0 {
-			stats = append(stats, fmt.Sprintf("⚡ %s/%s", formatTokenCount(tokensIn), formatTokenCount(tokensOut)))
+			// Show cache info if available: "⚡ 100K/50K (cache: 10K/5K)"
+			if cacheRead > 0 || cacheWrite > 0 {
+				stats = append(stats, fmt.Sprintf("⚡ %s/%s (cache: %s/%s)",
+					formatTokenCount(tokensIn), formatTokenCount(tokensOut),
+					formatTokenCount(cacheRead), formatTokenCount(cacheWrite)))
+			} else {
+				stats = append(stats, fmt.Sprintf("⚡ %s/%s", formatTokenCount(tokensIn), formatTokenCount(tokensOut)))
+			}
 		}
 
 		// Files modified
@@ -70,12 +80,23 @@ func extractInt64(metadata map[string]any, key string) int64 {
 }
 
 // formatTokenCount formats token count in compact form (1.2K)
+// formatTokenCount formats token count in compact form (1.2K, 1.00M)
+// Uses proper threshold: K for < 1M, M for >= 1M
 func formatTokenCount(count int64) string {
 	if count >= 1000000 {
-		return fmt.Sprintf("%.1fM", float64(count)/1000000)
+		return fmt.Sprintf("%.2fM", float64(count)/1000000)
 	}
 	if count >= 1000 {
-		return fmt.Sprintf("%.1fK", float64(count)/1000)
+		kValue := float64(count) / 1000
+		// If k value >= 999.5, show M to avoid rounding issues (999.9K -> 1000.0K)
+		if kValue >= 999.5 {
+			return fmt.Sprintf("%.2fM", float64(count)/1000000)
+		}
+		// Use integer for >= 100K
+		if kValue >= 100 {
+			return fmt.Sprintf("%.0fK", kValue)
+		}
+		return fmt.Sprintf("%.1fK", kValue)
 	}
 	return fmt.Sprintf("%d", count)
 }

--- a/engine/runner.go
+++ b/engine/runner.go
@@ -559,21 +559,27 @@ func (r *Engine) handleNormalizedResult(pevt *provider.ProviderEvent, stats *Ses
 		// Any error in handleSessionStats (like fallback failure) must bubble up
 		// to the Engine so that Execute() returns an error.
 		if err := callback("session_stats", &event.SessionStatsData{
-			SessionID:       cfg.SessionID,
-			StartTime:       stats.StartTime.Unix(),
-			EndTime:         time.Now().Unix(),
-			TotalDurationMs: stats.TotalDurationMs,
-			InputTokens:     stats.InputTokens,
-			OutputTokens:    stats.OutputTokens,
-			TotalTokens:     stats.InputTokens + stats.OutputTokens,
-			ToolCallCount:   stats.ToolCallCount,
-			ToolsUsed:       toolsUsed,
-			FilesModified:   stats.FilesModified,
-			FilePaths:       filePaths,
-			ModelUsed:       r.provider.Name(),
-			TotalCostUSD:    costUSD,
-			IsError:         pevt.IsError,
-			ErrorMessage:    pevt.Error,
+			SessionID:        cfg.SessionID,
+			StartTime:        stats.StartTime.Unix(),
+			EndTime:          time.Now().Unix(),
+			TotalDurationMs:  stats.TotalDurationMs,
+			InputTokens:      stats.InputTokens,
+			OutputTokens:     stats.OutputTokens,
+			CacheReadTokens:  stats.CacheReadTokens,
+			CacheWriteTokens: stats.CacheWriteTokens,
+			// Token billing formula:
+			// input_tokens already includes cache_read_tokens
+			// output_tokens already includes cache_write_tokens
+			// Billable = input + output - cache_read*0.9 - cache_write*0.9
+			TotalTokens:   stats.InputTokens + stats.OutputTokens - int32(float64(stats.CacheReadTokens)*0.9) - int32(float64(stats.CacheWriteTokens)*0.9),
+			ToolCallCount: stats.ToolCallCount,
+			ToolsUsed:     toolsUsed,
+			FilesModified: stats.FilesModified,
+			FilePaths:     filePaths,
+			ModelUsed:     r.provider.Name(),
+			TotalCostUSD:  costUSD,
+			IsError:       pevt.IsError,
+			ErrorMessage:  pevt.Error,
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
## 修复内容

### 问题
1. **单位转换 bug**: 999.5K 后应切换到 M 单位
2. **Cache Token 计费**: input/output 已包含 cache，需要正确计算计费

### 修复
- Token 数量显示：999.5K 后正确切换到 M 单位
- Token 计费公式：`input + output - cache_read*0.9 - cache_write*0.9`
- Slack 展示优化：有 cache 时显示 `100K/50K (cache: 10K/5K)`
- 飞书卡片添加 formatTokenCount 函数

### 改动文件
- chatapps/engine_handler.go
- chatapps/feishu/card_builder.go  
- chatapps/slack/builder_stats.go
- engine/runner.go

---

Resolves: #268