### PR TITLE
chore(release): bump version to v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG.md
 
+## [v0.28.1] - 2026-03-15
+
+### Fixed
+- **Docker Entrypoint Mount** - Resolved remote image entrypoint override issues:
+  - Fixed `runuser` HOME environment variable for Debian 12 compatibility
+  - Corrected entrypoint mount relative path
+  - Removed temporary entrypoint mount (remote image now rebuilt with fix)
+
+---
+
 ## [v0.28.0] - 2026-03-15
 
 ### Added

--- a/hotplex.go
+++ b/hotplex.go
@@ -10,10 +10,10 @@ import (
 
 var (
 	// Version can be overridden via ldflags: -X github.com/hrygo/hotplex.Version=1.2.3
-	Version      = "0.28.0"
+	Version      = "0.28.1"
 	VersionMajor = 0
 	VersionMinor = 28
-	VersionPatch = 0
+	VersionPatch = 1
 )
 
 // Compile-time interface verification


### PR DESCRIPTION
## Summary
- Bump version from v0.28.0 to v0.28.1
- Update CHANGELOG with Docker entrypoint fix details

## Changes
### Fixed
- Docker Entrypoint Mount - Resolved remote image entrypoint override issues:
  - Fixed `runuser` HOME environment variable for Debian 12 compatibility
  - Corrected entrypoint mount relative path
  - Removed temporary entrypoint mount (remote image now rebuilt with fix)

## Test plan
- [x] Version number updated correctly
- [x] CHANGELOG updated with release notes
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)