### PR TITLE
docs(internal): add package-level README files for internal subpackages

### DIFF
--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -1,0 +1,60 @@
+# Config Package (`internal/config`)
+
+Server configuration loading and hot-reload support.
+
+## Overview
+
+This package handles YAML-based configuration for the `hotplexd` server, including engine settings, server options, and security configuration.
+
+## Key Types
+
+```go
+type ServerConfig struct {
+    Engine   EngineConfig
+    Server   ServerSettings
+    Security SecurityConfig
+}
+
+type EngineConfig struct {
+    Timeout         time.Duration
+    IdleTimeout     time.Duration
+    WorkDir         string
+    SystemPrompt    string
+    AllowedTools    []string
+    DisallowedTools []string
+}
+```
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/config"
+
+// Load server config
+loader, err := config.NewServerLoader("configs/server.yaml", logger)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Get current config
+cfg := loader.Get()
+
+// Hot-reload support
+loader.Watch(ctx, func(newCfg *ServerConfig) {
+    log.Info("Config reloaded")
+})
+```
+
+## Features
+
+- **YAML Parsing**: Uses `gopkg.in/yaml.v3`
+- **Hot-Reload**: Watch for config file changes
+- **Thread-Safe**: Safe concurrent access via `sync.RWMutex`
+- **Validation**: Validates configuration values on load
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `server_config.go` | Server configuration types and loader |
+| `hotreload_yaml.go` | YAML file watcher for hot-reload |

--- a/internal/engine/README.md
+++ b/internal/engine/README.md
@@ -1,0 +1,64 @@
+# Engine Package (`internal/engine`)
+
+Core session management and process pool implementation for HotPlex.
+
+## Overview
+
+This package implements the **Hot-Multiplexing** pattern, maintaining persistent CLI agent processes that can be reused across multiple execution turns. This eliminates the cold-start latency of spawning heavy Node.js processes for each request.
+
+## Key Components
+
+| Component | Description |
+|-----------|-------------|
+| `SessionPool` | Thread-safe process pool with idle GC |
+| `Session` | Individual CLI process wrapper with full-duplex I/O |
+| `SessionManager` | Interface for process lifecycle management |
+
+## Architecture
+
+```
+SessionPool
+    ├── sessions map[string]*Session  (active sessions)
+    ├── mu sync.RWMutex               (thread-safe access)
+    ├── markerStore                   (session persistence)
+    └── cleanupLoop()                 (idle session GC)
+```
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/engine"
+
+// Create session pool
+pool := engine.NewSessionPool(
+    logger,
+    30*time.Minute,  // idle timeout
+    opts,            // engine options
+    cliPath,         // CLI binary path
+    provider,        // CLI provider
+)
+
+// Get or create session
+session, created, err := pool.GetOrCreateSession(ctx, sessionID, cfg, prompt)
+
+// Execute command
+err := session.Execute(ctx, prompt, callback)
+
+// Shutdown pool (graceful)
+pool.Shutdown(ctx)
+```
+
+## Design Principles
+
+- **PGID Isolation**: Each session runs in its own process group for clean termination
+- **Idle GC**: Inactive sessions are garbage collected after timeout
+- **Thread Safety**: All operations are protected by `sync.RWMutex`
+- **Graceful Shutdown**: Respects context cancellation
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `pool.go` | SessionPool implementation |
+| `session.go` | Session lifecycle and I/O handling |
+| `types.go` | Type definitions and interfaces |

--- a/internal/panicx/README.md
+++ b/internal/panicx/README.md
@@ -1,0 +1,58 @@
+# PanicX Package (`internal/panicx`)
+
+Panic recovery utilities for goroutine safety.
+
+## Overview
+
+This package ensures that panics in spawned goroutines are caught and logged rather than crashing the entire process.
+
+## Recovery Policies
+
+| Policy | Behavior |
+|--------|----------|
+| `PolicyLogAndContinue` | Log panic, continue operation (default) |
+| `PolicyLogAndRestart` | Log panic, signal for restart |
+| `PolicyLogAndShutdown` | Log panic, trigger graceful shutdown |
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/panicx"
+
+// Safe goroutine launch
+panicx.SafeGo(logger, func() {
+    // This panic will be caught and logged
+    panic("something went wrong")
+})
+
+// With context
+panicx.SafeGoWithContext(ctx, logger, func(ctx context.Context) {
+    // Context-aware goroutine
+    select {
+    case <-ctx.Done():
+        return
+    case result := <-ch:
+        process(result)
+    }
+})
+
+// With recovery policy
+panicx.SafeGoWithPolicy(logger, panicx.PolicyLogAndShutdown, "critical-worker", func() {
+    // Critical goroutine - shutdown on panic
+})
+```
+
+## Functions
+
+| Function | Purpose |
+|----------|---------|
+| `SafeGo` | Launch goroutine with panic recovery |
+| `SafeGoWithContext` | Context-aware goroutine with recovery |
+| `SafeGoWithPolicy` | Goroutine with specific recovery policy |
+| `Recover` | Low-level recovery function |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `goroutine.go` | Panic recovery utilities |

--- a/internal/persistence/README.md
+++ b/internal/persistence/README.md
@@ -1,0 +1,62 @@
+# Persistence Package (`internal/persistence`)
+
+Session marker storage abstractions.
+
+## Overview
+
+This package provides session marker persistence, decoupling session management from filesystem operations. This improves testability and enables alternative storage backends.
+
+## Purpose
+
+Session markers track whether a CLI session can be resumed (e.g., Claude Code's `--resume` functionality).
+
+## Interface
+
+```go
+type SessionMarkerStore interface {
+    // Exists checks if a session marker exists
+    Exists(sessionID string) bool
+
+    // Create creates a session marker
+    Create(sessionID string) error
+
+    // Delete removes the session marker
+    Delete(sessionID string) error
+
+    // Dir returns the base directory
+    Dir() string
+}
+```
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/persistence"
+
+// Create file-based marker store
+store, err := persistence.NewFileMarkerStore("/var/lib/hotplex/markers")
+
+// Check if session can be resumed
+if store.Exists(sessionID) {
+    // Resume session
+}
+
+// Create marker for new session
+err := store.Create(sessionID)
+
+// Clean up after session ends
+err := store.Delete(sessionID)
+```
+
+## Implementation
+
+| Type | Description |
+|------|-------------|
+| `FileMarkerStore` | Filesystem-based storage (default) |
+| `SessionMarkerStore` | Interface for custom backends |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `markers.go` | Marker store interface and file implementation |

--- a/internal/security/README.md
+++ b/internal/security/README.md
@@ -1,0 +1,57 @@
+# Security Package (`internal/security`)
+
+Regex-based WAF and danger detection for HotPlex.
+
+## Overview
+
+This package implements the core security engine with a **Danger Detector** that uses high-performance regex matching to prevent dangerous commands before execution.
+
+## Key Features
+
+- **Pattern Matching**: Regex-based detection of dangerous commands
+- **Rule Sources**: Extensible rule loading interface
+- **Audit Logging**: All security decisions are logged
+- **Severity Levels**: Warning vs. Block actions
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/security"
+
+// Create detector
+detector := security.NewDangerDetector(logger)
+
+// Check input
+result := detector.CheckInput(ctx, userInput)
+if result.Blocked {
+    log.Warn("Dangerous input blocked", "pattern", result.MatchedPattern)
+    return ErrSecurityBlock
+}
+```
+
+## Detection Rules
+
+The detector blocks patterns like:
+- `rm -rf /` - Recursive root deletion
+- Credential exfiltration attempts
+- Shell injection patterns
+- Sensitive file access
+
+## Architecture
+
+```
+RuleSource interface
+    ├── LoadRules(ctx) ([]SecurityRule, error)
+    └── Name() string
+
+SecurityRule
+    ├── Pattern *regexp.Regexp
+    ├── Severity SeverityLevel
+    └── Description string
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `detector.go` | Core detection engine and interfaces |

--- a/internal/server/README.md
+++ b/internal/server/README.md
@@ -1,0 +1,58 @@
+# Server Package (`internal/server`)
+
+HTTP/WebSocket transport layer for HotPlex.
+
+## Overview
+
+This package provides the core HTTP and WebSocket handlers that bridge web clients to the HotPlex Engine. It implements OpenCode-compatible HTTP endpoints and native WebSocket protocol.
+
+## Key Components
+
+| Component | Description |
+|-----------|-------------|
+| `ExecutionController` | Main execution orchestration |
+| `HotPlexWebSocket` | Native WebSocket handler |
+| `OpenCodeHTTP` | OpenCode-compatible HTTP endpoints |
+| `Observability` | Metrics and health endpoints |
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/server"
+
+// Create execution controller
+ctrl := server.NewExecutionController(engine, logger)
+
+// Execute request
+err := ctrl.Execute(ctx, server.ExecutionRequest{
+    SessionID:    "session-123",
+    Prompt:       "Write a hello world program",
+    WorkDir:      "/tmp/sandbox",
+    Timeout:      15 * time.Minute,
+}, callback)
+```
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/ws` | WebSocket | Native HotPlex WebSocket |
+| `/v1/execute` | POST | OpenCode-compatible execution |
+| `/health` | GET | Health check |
+| `/metrics` | GET | Prometheus metrics |
+
+## Security
+
+- **Path Validation**: Prevents directory traversal attacks
+- **Timeout Enforcement**: All requests have configurable timeouts
+- **Input Sanitization**: WorkDir paths are validated
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `controller.go` | Execution orchestration |
+| `hotplex_ws.go` | WebSocket handler |
+| `opencode_http.go` | OpenCode HTTP compatibility |
+| `observability.go` | Metrics and health |
+| `security.go` | Security utilities |

--- a/internal/strutil/README.md
+++ b/internal/strutil/README.md
@@ -1,0 +1,32 @@
+# StrUtil Package (`internal/strutil`)
+
+High-performance string utilities.
+
+## Overview
+
+This package provides optimized string manipulation functions used throughout HotPlex, particularly in security-critical paths like regex scanning.
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/strutil"
+
+// Truncate string with ellipsis
+short := strutil.Truncate("very long string...", 10)
+// Result: "very lo..."
+
+// Safe substring (handles Unicode)
+sub := strutil.SafeSubstring("Hello 世界", 0, 8)
+```
+
+## Design Goals
+
+- **Zero Allocation**: Critical paths minimize garbage collection
+- **Unicode Safe**: Proper handling of multi-byte characters
+- **Security Focused**: Used in WAF pattern matching
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `strutil.go` | String utility functions |

--- a/internal/sys/README.md
+++ b/internal/sys/README.md
@@ -1,0 +1,39 @@
+# Sys Package (`internal/sys`)
+
+Cross-platform process management utilities.
+
+## Overview
+
+This package handles low-level OS-specific operations for process group management, signal handling, and process lifecycle control. It abstracts the differences between Unix (PGID-based) and Windows (taskkill-based) process termination strategies.
+
+## Primary Purpose
+
+Ensure proper cleanup of CLI processes and their children, preventing zombie processes and resource leaks.
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/sys"
+
+// Kill process group (Unix: PGID, Windows: taskkill)
+err := sys.KillProcessGroup(pid)
+
+// Find process by name
+pids, err := sys.FindProcessByName("claude")
+```
+
+## Platform Differences
+
+| Platform | Kill Strategy |
+|----------|---------------|
+| Unix/Linux | `kill(-pgid, SIGKILL)` |
+| Windows | `taskkill /F /T /PID` |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `doc.go` | Package documentation |
+| `proc_unix.go` | Unix process management |
+| `proc_windows.go` | Windows process management |
+| `path.go` | Path utilities |

--- a/internal/telemetry/README.md
+++ b/internal/telemetry/README.md
@@ -1,0 +1,55 @@
+# Telemetry Package (`internal/telemetry`)
+
+Observability and metrics collection for HotPlex.
+
+## Overview
+
+This package manages Prometheus metrics and internal tracing. It tracks session duration, token usage, and security blocks globally.
+
+## Metrics Tracked
+
+| Metric | Description |
+|--------|-------------|
+| `sessions_active` | Currently active sessions |
+| `sessions_total` | Total sessions created |
+| `sessions_errors` | Failed sessions |
+| `tools_invoked` | Tool invocations count |
+| `dangers_blocked` | Security blocks count |
+| `slack_permission_*` | Slack permission decisions |
+
+## Usage
+
+```go
+import "github.com/hrygo/hotplex/internal/telemetry"
+
+// Initialize global metrics
+telemetry.InitMetrics(logger)
+
+// Get metrics instance
+m := telemetry.GetMetrics()
+
+// Record events
+m.IncSessionsActive()
+m.IncToolsInvoked()
+m.IncDangersBlocked()
+
+// Get snapshot
+snapshot := m.Snapshot()
+fmt.Printf("Active sessions: %d\n", snapshot.SessionsActive)
+```
+
+## Health Check
+
+```go
+// Health endpoint handler
+handler := telemetry.NewHealthHandler(engine)
+// GET /health returns {"status": "ok"}
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `metrics.go` | Metrics collection and snapshots |
+| `tracer.go` | Distributed tracing support |
+| `health.go` | Health check handler |


### PR DESCRIPTION
## Summary

- Add comprehensive README documentation for all 9 internal subpackages
- Each README includes: overview, key components, usage examples, file structure

### Packages Added

| Package | Description |
|---------|-------------|
| `internal/config` | Server configuration and hot-reload |
| `internal/engine` | Session pool and process management |
| `internal/panicx` | Panic recovery utilities |
| `internal/persistence` | Session marker storage |
| `internal/security` | Regex WAF and danger detection |
| `internal/server` | HTTP/WebSocket transport layer |
| `internal/strutil` | String utilities |
| `internal/sys` | Cross-platform process management |
| `internal/telemetry` | Metrics and observability |

### Review Notes

- Reviewed existing READMEs (brain, engine, provider, chatapps, types, event) - all are fresh
- Only internal subpackages were missing README files
- 9 new README files created (485 lines total)

Resolves #280

## Test Plan

- [x] Verify all README files render correctly
- [x] Check code examples are syntactically correct
- [x] Confirm file structure tables match actual files

🤖 Generated with [Claude Code](https://claude.com/claude-code)