### PR TITLE
fix(slack): skill 工具消息应发送到动效而非频道

### DIFF
--- a/chatapps/slack/builder_subbuilders_test.go
+++ b/chatapps/slack/builder_subbuilders_test.go
@@ -57,6 +57,7 @@ func TestToolMessageBuilder_BuildToolResultMessage_SkillTool(t *testing.T) {
 	builder := NewMessageBuilder(&Config{})
 
 	// Test skill tool with "skill:" prefix - success case
+	// Skill tools should return nil blocks (no message sent to channel)
 	msg := &base.ChatMessage{
 		Type:    base.MessageTypeToolResult,
 		Content: "Skill output content here",
@@ -68,16 +69,15 @@ func TestToolMessageBuilder_BuildToolResultMessage_SkillTool(t *testing.T) {
 
 	blocks := builder.Build(msg)
 
-	assert.NotNil(t, blocks)
-	assert.Equal(t, 1, len(blocks))
-	// Verify the simplified output format (single block for skill)
-	assert.IsType(t, &slack.SectionBlock{}, blocks[0])
+	// Skill tools should return nil or empty blocks (status shown via StatusManager only)
+	assert.Nil(t, blocks)
 }
 
 func TestToolMessageBuilder_BuildToolResultMessage_SkillToolError(t *testing.T) {
 	builder := NewMessageBuilder(&Config{})
 
-	// Test skill tool with error
+	// Test skill tool with error - error case
+	// Skill tools should return nil blocks even on error (status shown via StatusManager only)
 	msg := &base.ChatMessage{
 		Type:    base.MessageTypeToolResult,
 		Content: "Error: skill failed",
@@ -89,10 +89,9 @@ func TestToolMessageBuilder_BuildToolResultMessage_SkillToolError(t *testing.T) 
 
 	blocks := builder.Build(msg)
 
-	assert.NotNil(t, blocks)
-	assert.Equal(t, 1, len(blocks))
-	// Verify single block for skill error (no preview)
-	assert.IsType(t, &slack.SectionBlock{}, blocks[0])
+	// Skill tools should return nil or empty blocks even on error
+	// Error status is shown via StatusManager
+	assert.Nil(t, blocks)
 }
 
 func TestToolMessageBuilder_BuildToolResultMessage_LongRunning(t *testing.T) {

--- a/chatapps/slack/builder_tool.go
+++ b/chatapps/slack/builder_tool.go
@@ -163,23 +163,10 @@ func (b *ToolMessageBuilder) buildSingleToolResultBlock(msg *base.ChatMessage) [
 	// Claude Code uses "skill:" prefix for skill tool invocations
 	isSkillTool := strings.HasPrefix(toolName, "skill:")
 
-	// For skill tools, show simplified output: just tool name and status
+	// For skill tools, return nil to prevent sending message to channel
+	// Skill status updates are handled by StatusManager via Assistant Status API
 	if isSkillTool {
-		icon := ":white_check_mark:"
-		if !success {
-			icon = ":warning:"
-		}
-
-		// Extract skill name from tool name (e.g., "skill:simplify" -> "simplify")
-		displayName := toolName
-		if strings.HasPrefix(toolName, "skill:") {
-			displayName = strings.TrimPrefix(toolName, "skill:")
-		}
-
-		statusText := fmt.Sprintf("%s *Skill:* `%s`", icon, displayName)
-		statusObj := slack.NewTextBlockObject("mrkdwn", statusText, false, false)
-		blocks = append(blocks, slack.NewSectionBlock(statusObj, nil, nil))
-		return blocks
+		return nil
 	}
 
 	// Original logic for non-skill tools


### PR DESCRIPTION
## 问题描述

Skills 信息被大量发送到 Slack 频道，造成消息刷屏，用户体验差。

## 修复方案

修改 `chatapps/slack/builder_tool.go` 的 `buildSingleToolResultBlock` 方法：

- 当检测到 skill 工具调用时，返回 `nil` 而非构建消息块
- 状态更新由 StatusManager 通过 Assistant Status API 处理
- 避免不必要的频道消息发送

## 技术细节

**修改前**：
```go
if isSkillTool {
    // 构建消息块并返回
    statusText := fmt.Sprintf("%s *Skill:* `%s`", icon, displayName)
    statusObj := slack.NewTextBlockObject("mrkdwn", statusText, false, false)
    blocks = append(blocks, slack.NewSectionBlock(statusObj, nil, nil))
    return blocks  // ❌ 消息发送到频道
}
```

**修改后**：
```go
if isSkillTool {
    return nil  // ✅ 消息不发送到频道，由 StatusManager 处理
}
```

## 影响范围

| 方面 | 影响 |
|------|------|
| 用户体验 | ✅ Skill 消息不再刷屏，只在动效中显示 |
| 性能 | ✅ 减少不必要的 Slack API 调用 |
| 兼容性 | ✅ 不影响其他类型的工具消息 |
| 功能 | ✅ Skill 调用仍通过 StatusManager 显示状态 |

## 测试建议

1. 调用 skill 工具（如 `skill:simplify`）
2. 验证：Slack 频道中**没有**新消息
3. 验证：线程底部动效显示 skill 状态
4. 调用非 skill 工具（如 `Bash`）
5. 验证：Slack 频道中**有**工具结果消息（原有行为保持）

Resolves #290