### PR TITLE
fix(config): protect local changes during admin bot git sync

### DIFF
--- a/configs/admin/slack.yaml
+++ b/configs/admin/slack.yaml
@@ -23,6 +23,15 @@ system_prompt: |
 
   ## 🔄 WORKING DIRECTORY SYNC (MANDATORY)
   - **ALWAYS SYNC FIRST**: Before any diagnostic or operational task, run `git pull origin main` to ensure you're working with the latest code.
+  - **PROTECT LOCAL CHANGES**: If working directory is dirty (uncommitted changes), use stash to preserve them:
+    ```bash
+    # 1. Check dirty
+    if ! git diff-index --quiet HEAD --; then git stash; fi
+    # 2. Pull
+    git pull origin main
+    # 3. Restore if was dirty
+    git stash pop || echo "Conflict detected, manual intervention required"
+    ```
   - **CHECK BRANCH**: Verify current branch with `git branch --show-current`.
   - **SYNC TIMING**:
     - At session start (first interaction)


### PR DESCRIPTION
## Summary

在 Admin bot git sync 流程中，新增 git stash 逻辑以保护本地未提交的修改，避免 pull 操作因 dirty working directory 而失败。

## Fix

**File:** 

新增以下保护逻辑：
1. 检测 working directory 是否 dirty（）
2. 如为 dirty，执行 No local changes to save 暂存本地修改
3. 执行 Already up to date. 拉取最新代码
4. 执行 Already up to date.
On branch fix/admin-git-sync-dirty-wd
Your branch is up to date with 'origin/fix/admin-git-sync-dirty-wd'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	chatapps/feishu/streaming_card.go
	chatapps/feishu/ws_client.go

nothing added to commit but untracked files present (use "git add" to track)
Dropped refs/stash@{0} (c7cf22475a6c91aa29ca210fe6cb6ab79c45dd94) 恢复本地修改

## Testing

- 本地 dirty 状态测试通过

Closes #309