### PR TITLE
feat: Phase 2 platform registry + BridgeServer WebSocket gateway

### DIFF
--- a/brain/extractor_test.go
+++ b/brain/extractor_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestNewClaudeCodeExtractor tests the constructor
+func TestNewClaudeCodeExtractor(t *testing.T) {
+	extractor := NewClaudeCodeExtractor()
+	if extractor == nil {
+		t.Fatal("NewClaudeCodeExtractor() returned nil")
+	}
+	if extractor.ConfigPath == "" {
+		t.Error("ConfigPath should not be empty")
+	}
+}
+
+// TestNewOpenCodeExtractor tests the constructor
+func TestNewOpenCodeExtractor(t *testing.T) {
+	extractor := NewOpenCodeExtractor()
+	if extractor == nil {
+		t.Fatal("NewOpenCodeExtractor() returned nil")
+	}
+	// configPath may be empty if os.UserHomeDir fails, but should work in tests
+}
+
 func TestClaudeCodeExtractor_Extract(t *testing.T) {
 	// Create a temporary config file
 	tmpDir, err := os.MkdirTemp("", "claude-test")

--- a/chatapps/base/adapter.go
+++ b/chatapps/base/adapter.go
@@ -519,8 +519,9 @@ type EngineSupport interface {
 	SetEngine(eng *engine.Engine)
 }
 
-// FeishuEngineSupport defines optional interface for Feishu adapters that need
-// engine + botID injection for permission management.
-type FeishuEngineSupport interface {
-	SetEngineWithBotID(eng *engine.Engine, botID string)
+// EngineSupportWithBotID defines optional interface for adapters that need
+// both engine injection and bot identity for permission management.
+type EngineSupportWithBotID interface {
+	EngineSupport
+	SetBotID(botID string)
 }

--- a/chatapps/base/adapter_http_test.go
+++ b/chatapps/base/adapter_http_test.go
@@ -1,0 +1,170 @@
+package base
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestWebhookPath tests WebhookPath method
+func TestWebhookPath(t *testing.T) {
+	// Empty handlers
+	adapter := &Adapter{
+		httpHandlers: make(map[string]http.HandlerFunc),
+	}
+	if path := adapter.WebhookPath(); path != "" {
+		t.Errorf("WebhookPath(): got %q, want empty", path)
+	}
+
+	// With handler
+	adapter.httpHandlers["/webhook"] = func(w http.ResponseWriter, r *http.Request) {}
+	if path := adapter.WebhookPath(); path != "/webhook" {
+		t.Errorf("WebhookPath(): got %q, want /webhook", path)
+	}
+}
+
+// TestWebhookHandler tests WebhookHandler method
+func TestWebhookHandler(t *testing.T) {
+	adapter := &Adapter{
+		httpHandlers: map[string]http.HandlerFunc{
+			"/webhook": func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	}
+
+	handler := adapter.WebhookHandler()
+	if handler == nil {
+		t.Fatal("WebhookHandler(): got nil")
+	}
+
+	req := httptest.NewRequest("POST", "/webhook", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("ServeHTTP: got status %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestHandleHealth tests the health endpoint
+func TestHandleHealth(t *testing.T) {
+	adapter := &Adapter{}
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+
+	adapter.handleHealth(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("handleHealth: got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != "OK" {
+		t.Errorf("handleHealth: got body %q, want OK", rec.Body.String())
+	}
+}
+
+// TestReadBody tests ReadBody helper
+func TestReadBody(t *testing.T) {
+	// Normal case
+	body := []byte(`{"test": "data"}`)
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+
+	got, err := ReadBody(req)
+	if err != nil {
+		t.Fatalf("ReadBody: unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("ReadBody: got %q, want %q", got, body)
+	}
+}
+
+// TestRespondWithJSON tests JSON response helper
+func TestRespondWithJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	data := map[string]string{"status": "ok"}
+	err := RespondWithJSON(rec, http.StatusOK, data)
+	if err != nil {
+		t.Fatalf("RespondWithJSON: unexpected error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("RespondWithJSON: got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("RespondWithJSON: got Content-Type %q, want application/json", ct)
+	}
+	expected := `{"status":"ok"}` + "\n"
+	if rec.Body.String() != expected {
+		t.Errorf("RespondWithJSON: got body %q, want %q", rec.Body.String(), expected)
+	}
+}
+
+// TestRespondWithText tests text response helper
+func TestRespondWithText(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	RespondWithText(rec, http.StatusOK, "hello")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("RespondWithText: got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != "hello" {
+		t.Errorf("RespondWithText: got body %q, want hello", rec.Body.String())
+	}
+}
+
+// TestRespondWithError tests error response helper
+func TestRespondWithError(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	RespondWithError(rec, http.StatusBadRequest, "invalid request")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("RespondWithError: got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// TestSendMessage tests SendMessage with nil sender
+func TestSendMessage(t *testing.T) {
+	adapter := &Adapter{
+		messageSender: nil,
+	}
+
+	err := adapter.SendMessage(context.Background(), "session-1", &ChatMessage{Content: "test"})
+	if err == nil {
+		t.Error("SendMessage: got nil error, want error for nil sender")
+	}
+}
+
+// TestHandleMessage tests HandleMessage (default implementation returns nil)
+func TestHandleMessage(t *testing.T) {
+	adapter := &Adapter{}
+
+	err := adapter.HandleMessage(context.Background(), &ChatMessage{Content: "test"})
+	if err != nil {
+		t.Errorf("HandleMessage: got error %v, want nil", err)
+	}
+}
+
+// TestReadBodyError tests ReadBody with read error
+func TestReadBodyError(t *testing.T) {
+	// Create request with error reader
+	req := httptest.NewRequest("POST", "/", &errorReader{})
+
+	_, err := ReadBody(req)
+	if err == nil {
+		t.Error("ReadBody: got nil error, want error for failed read")
+	}
+}
+
+// errorReader always returns an error
+type errorReader struct{}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, io.ErrUnexpectedEOF
+}

--- a/chatapps/base/adapter_simple_test.go
+++ b/chatapps/base/adapter_simple_test.go
@@ -1,0 +1,150 @@
+package base
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/hrygo/hotplex/chatapps/session"
+)
+
+// TestAdapterOptions tests all With* option functions
+func TestAdapterOptions(t *testing.T) {
+	adapter := &Adapter{
+		config: Config{
+			SystemPrompt: "default",
+		},
+		sessions:      make(map[string]*Session),
+		httpHandlers:  make(map[string]http.HandlerFunc),
+		messageParser: func(body []byte, metadata map[string]any) (*ChatMessage, error) { return nil, nil },
+	}
+
+	// Test WithSessionTimeout
+	opt := WithSessionTimeout(5 * time.Minute)
+	opt(adapter)
+	if adapter.sessionTimeout != 5*time.Minute {
+		t.Errorf("WithSessionTimeout: got %v, want %v", adapter.sessionTimeout, 5*time.Minute)
+	}
+
+	// Test WithSessionTimeout with 0 (should not change)
+	opt = WithSessionTimeout(0)
+	opt(adapter)
+	if adapter.sessionTimeout != 5*time.Minute {
+		t.Errorf("WithSessionTimeout(0): should not change, got %v", adapter.sessionTimeout)
+	}
+
+	// Test WithCleanupInterval
+	opt = WithCleanupInterval(30 * time.Second)
+	opt(adapter)
+	if adapter.cleanupInterval != 30*time.Second {
+		t.Errorf("WithCleanupInterval: got %v, want %v", adapter.cleanupInterval, 30*time.Second)
+	}
+
+	// Test WithMetadataExtractor
+	extractor := func(update any) map[string]any { return nil }
+	opt = WithMetadataExtractor(extractor)
+	opt(adapter)
+	if adapter.metadataExtract == nil {
+		t.Error("WithMetadataExtractor: should not be nil")
+	}
+
+	// Test WithMessageParser
+	parser := func(body []byte, metadata map[string]any) (*ChatMessage, error) { return nil, nil }
+	opt = WithMessageParser(parser)
+	opt(adapter)
+	if adapter.messageParser == nil {
+		t.Error("WithMessageParser: should not be nil")
+	}
+
+	// Test WithMessageSender
+	sender := func(ctx context.Context, sessionID string, msg *ChatMessage) error { return nil }
+	opt = WithMessageSender(sender)
+	opt(adapter)
+	if adapter.messageSender == nil {
+		t.Error("WithMessageSender: should not be nil")
+	}
+
+	// Test WithHTTPHandler
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	opt = WithHTTPHandler("/test", handler)
+	opt(adapter)
+	if adapter.httpHandlers["/test"] == nil {
+		t.Error("WithHTTPHandler: should add handler")
+	}
+
+	// Test WithoutServer
+	opt = WithoutServer()
+	opt(adapter)
+	if !adapter.disableServer {
+		t.Error("WithoutServer: should set disableServer to true")
+	}
+}
+
+// TestAdapterGetterSetters tests all getter and setter methods
+func TestAdapterGetterSetters(t *testing.T) {
+	logger := slog.Default()
+	adapter := &Adapter{
+		platformName: "test-platform",
+		config: Config{
+			SystemPrompt: "test prompt",
+		},
+		sessions:     make(map[string]*Session),
+		httpHandlers: make(map[string]http.HandlerFunc),
+		logger:       logger,
+	}
+
+	// Test Platform
+	if adapter.Platform() != "test-platform" {
+		t.Errorf("Platform(): got %s, want test-platform", adapter.Platform())
+	}
+
+	// Test SystemPrompt
+	if adapter.SystemPrompt() != "test prompt" {
+		t.Errorf("SystemPrompt(): got %s, want 'test prompt'", adapter.SystemPrompt())
+	}
+
+	// Test SetHandler and Handler
+	handler := func(ctx context.Context, msg *ChatMessage) error { return nil }
+	adapter.SetHandler(handler)
+	if adapter.Handler() == nil {
+		t.Error("SetHandler/Handler: handler should not be nil")
+	}
+
+	// Test SetMessageStore
+	store := &MessageStorePlugin{}
+	adapter.SetMessageStore(store)
+	if adapter.messageStore != store {
+		t.Error("SetMessageStore: store mismatch")
+	}
+
+	// Test SetSessionManager
+	mgr := session.NewSessionManager("test")
+	adapter.SetSessionManager(mgr)
+	if adapter.sessionMgr != mgr {
+		t.Error("SetSessionManager: manager mismatch")
+	}
+
+	// Test SetProviderType
+	adapter.SetProviderType("test-provider")
+	if adapter.providerType != "test-provider" {
+		t.Errorf("SetProviderType: got %s, want test-provider", adapter.providerType)
+	}
+
+	// Test Logger
+	if adapter.Logger() != logger {
+		t.Error("Logger: logger mismatch")
+	}
+
+	// Test SetLogger
+	newLogger := slog.Default()
+	adapter.SetLogger(newLogger)
+	if adapter.Logger() != newLogger {
+		t.Error("SetLogger: logger not updated")
+	}
+
+	// Test WebhookPath (method call, not field access)
+	// Note: webhookPath is accessed via WebhookPath() method, not a field
+}

--- a/chatapps/base/chunker.go
+++ b/chatapps/base/chunker.go
@@ -117,3 +117,33 @@ func ChunkMessageSimple(text string, maxLen int) []string {
 	}
 	return chunks
 }
+
+// Chunker 将消息分块以满足平台字符限制
+type Chunker interface {
+	// ChunkText 将文本分块，每块不超过平台限制
+	ChunkText(text string, limit int) []string
+
+	// MaxChars 返回平台单条消息的最大字符数
+	MaxChars() int
+}
+
+// DefaultChunker 使用标准 Markdown 感知的分块算法，默认使用 Slack 限制
+type DefaultChunker struct {
+	maxChars int
+}
+
+// NewDefaultChunker 创建默认分块器
+func NewDefaultChunker(maxChars int) *DefaultChunker {
+	if maxChars <= 0 {
+		maxChars = DefaultChunkLimit
+	}
+	return &DefaultChunker{maxChars: maxChars}
+}
+
+// ChunkText 使用标准算法分块
+func (c *DefaultChunker) ChunkText(text string, limit int) []string {
+	return ChunkMessage(text, ChunkerConfig{MaxLen: limit, PreserveWords: true, AddNumbering: true})
+}
+
+// MaxChars 返回配置的最大字符数
+func (c *DefaultChunker) MaxChars() int { return c.maxChars }

--- a/chatapps/base/converter.go
+++ b/chatapps/base/converter.go
@@ -1,0 +1,29 @@
+package base
+
+// ContentConverter 将 Markdown 转换为平台特定格式
+type ContentConverter interface {
+	// ConvertMarkdownToPlatform 将 Markdown 文本转换为平台原生格式
+	// parseMode 为 None 时返回原文
+	ConvertMarkdownToPlatform(content string, parseMode ParseMode) string
+
+	// EscapeSpecialChars 转义平台特殊字符
+	EscapeSpecialChars(text string) string
+}
+
+// NoOpConverter is a content converter that does no conversion.
+type NoOpConverter struct{}
+
+// NewNoOpConverter creates a converter that passes text through unchanged.
+func NewNoOpConverter() *NoOpConverter {
+	return &NoOpConverter{}
+}
+
+// ConvertMarkdownToPlatform returns content unchanged.
+func (NoOpConverter) ConvertMarkdownToPlatform(content string, _ ParseMode) string {
+	return content
+}
+
+// EscapeSpecialChars returns text unchanged.
+func (NoOpConverter) EscapeSpecialChars(text string) string {
+	return text
+}

--- a/chatapps/base/metadata.go
+++ b/chatapps/base/metadata.go
@@ -1,0 +1,118 @@
+package base
+
+// Platform 元数据 Key 定义（统一命名）
+// Adapters should use these constants when setting/getting metadata to ensure
+// platform-agnostic code in engine_handler.go and processors.
+//
+// Adapter-specific keys are still stored directly (e.g., Slack uses "thread_ts"
+// internally, but should be accessible via KeyThreadID when crossing adapter boundary).
+const (
+	// KeyRoomID is the unified key for the room/channel/conversation identifier.
+	// Slack: channel_id | Feishu: chat_id | Telegram: chat_id | Discord: channel_id
+	KeyRoomID = "room_id"
+	// KeyThreadID is the unified key for thread/reply identifier.
+	// Slack: thread_ts | Feishu: message_id | Telegram: message_thread_id | Discord: thread_id
+	KeyThreadID = "thread_id"
+	// KeyUserID is the unified key for the user who sent the message.
+	// Universal across all platforms.
+	KeyUserID = "user_id"
+	// KeyBotUserID is the unified key for the bot's own user identifier.
+	KeyBotUserID = "bot_user_id"
+	// KeyPlatform is the platform identifier (slack, feishu, telegram, etc.)
+	KeyPlatform = "platform"
+)
+
+// GetMetadata extracts platform-agnostic values from metadata map.
+// Returns zero values if keys are not present.
+func GetMetadata(m map[string]any) (roomID, threadID, userID string) {
+	if m == nil {
+		return
+	}
+	roomID, _ = m[KeyRoomID].(string)
+	threadID, _ = m[KeyThreadID].(string)
+	userID, _ = m[KeyUserID].(string)
+	return
+}
+
+// SetMetadata sets platform-agnostic values in the metadata map.
+// Initializes the map if nil.
+func SetMetadata(m map[string]any, roomID, threadID, userID string) map[string]any {
+	if m == nil {
+		m = make(map[string]any)
+	}
+	if roomID != "" {
+		m[KeyRoomID] = roomID
+	}
+	if threadID != "" {
+		m[KeyThreadID] = threadID
+	}
+	if userID != "" {
+		m[KeyUserID] = userID
+	}
+	return m
+}
+
+// GetMetadataString extracts a string value from metadata safely.
+func GetMetadataString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}
+
+// SlackMetadata provides backward-compatible access to Slack-specific metadata keys.
+// Use GetMetadata for platform-agnostic access.
+func SlackMetadata(m map[string]any) (channelID, threadTS, userID string) {
+	// Unified keys (preferred)
+	channelID = GetMetadataString(m, KeyRoomID)
+	threadTS = GetMetadataString(m, KeyThreadID)
+	userID = GetMetadataString(m, KeyUserID)
+	// Fallback: Slack-specific keys (for existing adapters that haven't migrated)
+	if channelID == "" {
+		channelID = GetMetadataString(m, "channel_id")
+	}
+	if threadTS == "" {
+		threadTS = GetMetadataString(m, "thread_ts")
+	}
+	if userID == "" {
+		userID = GetMetadataString(m, "user_id")
+	}
+	return
+}
+
+// MergeMetadata merges the unified metadata keys from src into dst.
+// Unifies channel_id → KeyRoomID, thread_ts → KeyThreadID.
+// Intentionally skips message_ts as it refers to the user's message, not the bot's.
+func MergeMetadata(dst, src map[string]any) map[string]any {
+	if dst == nil {
+		dst = make(map[string]any)
+	}
+	if src == nil {
+		return dst
+	}
+
+	// Set unified keys (preferred)
+	if v := GetMetadataString(src, KeyRoomID); v != "" {
+		dst[KeyRoomID] = v
+	}
+	if v := GetMetadataString(src, KeyThreadID); v != "" {
+		dst[KeyThreadID] = v
+	}
+	if v := GetMetadataString(src, KeyUserID); v != "" {
+		dst[KeyUserID] = v
+	}
+
+	// Also migrate Slack-specific keys for backward compatibility
+	if v := GetMetadataString(src, "channel_id"); v != "" && dst[KeyRoomID] == nil {
+		dst["channel_id"] = v // Keep for adapters that still read it
+	}
+	if v := GetMetadataString(src, "thread_ts"); v != "" && dst[KeyThreadID] == nil {
+		dst["thread_ts"] = v // Keep for adapters that still read it
+	}
+
+	// Skip "message_ts" intentionally — it refers to the user's message,
+	// not the bot's. Copying it causes platform API errors (cant_update_message).
+
+	return dst
+}

--- a/chatapps/base/plugin.go
+++ b/chatapps/base/plugin.go
@@ -1,0 +1,215 @@
+package base
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/hrygo/hotplex/provider"
+)
+
+// PlatformConfig contains platform-specific configuration loaded from YAML.
+// Defined here to allow platform factories in subpackages to reference it
+// without import cycles.
+type PlatformConfig struct {
+	Inherits         string                      `yaml:"inherits"`
+	Platform         string                      `yaml:"platform"`
+	Mode             string                      `yaml:"mode"`
+	SystemPrompt     string                      `yaml:"system_prompt"`
+	TaskInstructions string                      `yaml:"task_instructions"`
+	Engine           EngineConfig                `yaml:"engine"`
+	Provider         provider.ProviderConfig     `yaml:"provider"`
+	Security         SecurityConfig              `yaml:"security"`
+	Features         FeaturesConfig              `yaml:"features"`
+	Session          SessionConfig               `yaml:"session"`
+	MessageStore     MessageStoreConfig          `yaml:"message_store,omitempty"`
+	Options          map[string]any             `yaml:"options,omitempty"`
+	SourceFile       string                      `yaml:"-"`
+}
+
+type SecurityConfig struct {
+	VerifySignature *bool             `yaml:"verify_signature"`
+	Permission      PermissionConfig  `yaml:"permission"`
+	Owner          *OwnerConfig      `yaml:"owner,omitempty"`
+}
+
+type PermissionConfig struct {
+	DMPolicy              string                 `yaml:"dm_policy"`
+	GroupPolicy           string                 `yaml:"group_policy"`
+	BotUserID             string                 `yaml:"bot_user_id"`
+	BroadcastResponse     string                 `yaml:"broadcast_response"`
+	AllowedUsers          []string               `yaml:"allowed_users"`
+	BlockedUsers          []string               `yaml:"blocked_users"`
+	SlashCommandRateLimit float64                `yaml:"slash_command_rate_limit"`
+	ThreadOwnership       *ThreadOwnershipConfig `yaml:"thread_ownership,omitempty"`
+}
+
+type FeaturesConfig struct {
+	Chunking  ChunkingConfig  `yaml:"chunking"`
+	Threading ThreadingConfig `yaml:"threading"`
+	RateLimit RateLimitConfig `yaml:"rate_limit"`
+	Markdown  MarkdownConfig  `yaml:"markdown"`
+}
+
+type ChunkingConfig struct {
+	Enabled  *bool `yaml:"enabled"`
+	MaxChars int   `yaml:"max_chars"`
+}
+
+type ThreadingConfig struct {
+	Enabled *bool `yaml:"enabled"`
+}
+
+type RateLimitConfig struct {
+	Enabled     *bool `yaml:"enabled"`
+	MaxAttempts int   `yaml:"max_attempts"`
+	BaseDelayMs int   `yaml:"base_delay_ms"`
+	MaxDelayMs  int   `yaml:"max_delay_ms"`
+}
+
+type MarkdownConfig struct {
+	Enabled *bool `yaml:"enabled"`
+}
+
+type OwnerConfig struct {
+	Primary string   `yaml:"primary"`
+	Trusted []string `yaml:"trusted_users"`
+	Policy  string   `yaml:"policy"`
+}
+
+type ThreadOwnershipConfig struct {
+	Enabled *bool        `yaml:"enabled"`
+	TTL     time.Duration `yaml:"ttl"`
+	Persist *bool        `yaml:"persist"`
+}
+
+type SessionConfig struct {
+	Timeout         time.Duration `yaml:"timeout"`
+	CleanupInterval time.Duration `yaml:"cleanup_interval"`
+}
+
+type EngineConfig struct {
+	Timeout         time.Duration `yaml:"timeout"`
+	IdleTimeout     time.Duration `yaml:"idle_timeout"`
+	WorkDir         string        `yaml:"work_dir"`
+	AllowedTools    []string      `yaml:"allowed_tools"`
+	DisallowedTools []string      `yaml:"disallowed_tools"`
+}
+
+type MessageStoreConfig struct {
+	Enabled   *bool          `yaml:"enabled"`
+	Type      string         `yaml:"type"`
+	SQLite    SQLiteConfig   `yaml:"sqlite"`
+	Postgres  PostgresConfig `yaml:"postgres"`
+	Strategy  string         `yaml:"strategy"`
+	Streaming StreamingConfig `yaml:"streaming"`
+}
+
+type SQLiteConfig struct {
+	Path      string `yaml:"path"`
+	MaxSizeMB int    `yaml:"max_size_mb"`
+}
+
+type PostgresConfig struct {
+	DSN            string `yaml:"dsn"`
+	MaxConnections int    `yaml:"max_connections"`
+	Level          int    `yaml:"level"`
+}
+
+type StreamingConfig struct {
+	Enabled       *bool        `yaml:"enabled"`
+	BufferSize    int          `yaml:"buffer_size"`
+	Timeout       time.Duration `yaml:"timeout"`
+	StoragePolicy string       `yaml:"storage_policy"`
+}
+
+// BoolValue returns the bool value if ptr is non-nil, otherwise returns defaultVal.
+func BoolValue(ptr *bool, defaultVal bool) bool {
+	if ptr == nil {
+		return defaultVal
+	}
+	return *ptr
+}
+
+// AdapterFactory defines the interface for platform adapter factories.
+type AdapterFactory interface {
+	Platform() string
+	RequiredEnvVars() []string
+	New(pc *PlatformConfig) any
+	PostSetup(ctx context.Context, adapter, setupCtx any)
+}
+
+// SetupContext holds shared context for factory PostSetup.
+type SetupContext struct {
+	Manager        any // *AdapterManager
+	Loader         any // *ConfigLoader
+	Engine         any // *engine.Engine
+	PermDir        string
+	Logger         *slog.Logger
+	WorkDirFn      func(sessionID string) string
+	Platform       string
+	PlatformConfig *PlatformConfig
+}
+
+// AdapterPluginRegistry manages adapter factory registration.
+type AdapterPluginRegistry struct {
+	mu        sync.RWMutex
+	factories map[string]AdapterFactory
+}
+
+var (
+	globalRegistry     *AdapterPluginRegistry
+	globalRegistryOnce sync.Once
+)
+
+// GlobalAdapterRegistry returns the global adapter factory registry.
+func GlobalAdapterRegistry() *AdapterPluginRegistry {
+	globalRegistryOnce.Do(func() {
+		globalRegistry = &AdapterPluginRegistry{
+			factories: make(map[string]AdapterFactory),
+		}
+	})
+	return globalRegistry
+}
+
+// Register registers a factory.
+func (r *AdapterPluginRegistry) Register(factory AdapterFactory) {
+	platform := factory.Platform()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.factories[platform]; exists {
+		panic("adapter factory already registered for platform: " + platform)
+	}
+	r.factories[platform] = factory
+}
+
+// Get returns the factory for a platform.
+func (r *AdapterPluginRegistry) Get(platform string) (AdapterFactory, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	factory, ok := r.factories[platform]
+	return factory, ok
+}
+
+// List returns all registered platform names.
+func (r *AdapterPluginRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		names = append(names, name)
+	}
+	return names
+}
+
+// HasRequiredEnvVars checks if all required environment variables are set.
+func HasRequiredEnvVars(required []string) bool {
+	for _, envVar := range required {
+		if os.Getenv(envVar) == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/chatapps/base/types.go
+++ b/chatapps/base/types.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/hrygo/hotplex/types"
 )
 
 // ErrNotSupported is returned by optional interface methods when the platform
@@ -22,55 +24,59 @@ var (
 	ErrMissingContent           = errors.New("content is required")
 )
 
-// MessageType defines the normalized message types across all chat platforms
-type MessageType string
+// MessageType is a type alias for types.MessageType, providing a unified message type
+// definition across all chat platforms. All constants are re-exported from the types
+// package to maintain backward compatibility with existing code.
+type MessageType = types.MessageType
 
+// MessageType constants — re-exported from types package for backward compatibility.
+// Code should prefer importing "github.com/hrygo/hotplex/types" directly when possible.
 const (
 	// MessageTypeThinking indicates the AI is reasoning or thinking
-	MessageTypeThinking MessageType = "thinking"
+	MessageTypeThinking MessageType = types.MessageTypeThinking
 	// MessageTypeAnswer indicates text output from the AI
-	MessageTypeAnswer MessageType = "answer"
+	MessageTypeAnswer MessageType = types.MessageTypeAnswer
 	// MessageTypeToolUse indicates a tool invocation is starting
-	MessageTypeToolUse MessageType = "tool_use"
+	MessageTypeToolUse MessageType = types.MessageTypeToolUse
 	// MessageTypeToolResult indicates a tool execution result
-	MessageTypeToolResult MessageType = "tool_result"
+	MessageTypeToolResult MessageType = types.MessageTypeToolResult
 	// MessageTypeError indicates an error occurred
-	MessageTypeError MessageType = "error"
+	MessageTypeError MessageType = types.MessageTypeError
 	// MessageTypePlanMode indicates AI is in plan mode and generating a plan
-	MessageTypePlanMode MessageType = "plan_mode"
+	MessageTypePlanMode MessageType = types.MessageTypePlanMode
 	// MessageTypeExitPlanMode indicates AI completed planning and requests user approval
-	MessageTypeExitPlanMode MessageType = "exit_plan_mode"
+	MessageTypeExitPlanMode MessageType = types.MessageTypeExitPlanMode
 	// MessageTypeAskUserQuestion indicates AI is asking a clarifying question
-	MessageTypeAskUserQuestion MessageType = "ask_user_question"
+	MessageTypeAskUserQuestion MessageType = types.MessageTypeAskUserQuestion
 	// MessageTypeDangerBlock indicates a dangerous operation confirmation block
-	MessageTypeDangerBlock MessageType = "danger_block"
+	MessageTypeDangerBlock MessageType = types.MessageTypeDangerBlock
 	// MessageTypeSessionStats indicates session statistics
-	MessageTypeSessionStats MessageType = "session_stats"
+	MessageTypeSessionStats MessageType = types.MessageTypeSessionStats
 	// MessageTypeCommandProgress indicates a slash command is executing with progress updates
-	MessageTypeCommandProgress MessageType = "command_progress"
+	MessageTypeCommandProgress MessageType = types.MessageTypeCommandProgress
 	// MessageTypeCommandComplete indicates a slash command has completed
-	MessageTypeCommandComplete MessageType = "command_complete"
+	MessageTypeCommandComplete MessageType = types.MessageTypeCommandComplete
 	// MessageTypeSystem indicates a system-level message
-	MessageTypeSystem MessageType = "system"
+	MessageTypeSystem MessageType = types.MessageTypeSystem
 	// MessageTypeUser indicates a user message reflection
-	MessageTypeUser MessageType = "user"
+	MessageTypeUser MessageType = types.MessageTypeUser
 	// MessageTypeStepStart indicates a new step/milestone (OpenCode specific)
-	MessageTypeStepStart MessageType = "step_start"
+	MessageTypeStepStart MessageType = types.MessageTypeStepStart
 	// MessageTypeStepFinish indicates a step/milestone completed (OpenCode specific)
-	MessageTypeStepFinish MessageType = "step_finish"
+	MessageTypeStepFinish MessageType = types.MessageTypeStepFinish
 	// MessageTypeRaw indicates unparsed raw output (fallback)
-	MessageTypeRaw MessageType = "raw"
+	MessageTypeRaw MessageType = types.MessageTypeRaw
 	// MessageTypeSessionStart indicates a new session is starting (cold start)
-	MessageTypeSessionStart MessageType = "session_start"
+	MessageTypeSessionStart MessageType = types.MessageTypeSessionStart
 	// MessageTypeEngineStarting indicates the engine is starting up
-	MessageTypeEngineStarting MessageType = "engine_starting"
+	MessageTypeEngineStarting MessageType = types.MessageTypeEngineStarting
 	// MessageTypeUserMessageReceived indicates user message has been received
-	MessageTypeUserMessageReceived MessageType = "user_message_received"
+	MessageTypeUserMessageReceived MessageType = types.MessageTypeUserMessageReceived
 	// MessageTypePermissionRequest indicates a permission request from Claude Code
-	MessageTypePermissionRequest MessageType = "permission_request"
+	MessageTypePermissionRequest MessageType = types.MessageTypePermissionRequest
 	// MessageTypePermissionDenials indicates a dangerous operation intercepted by WAF
 	// awaiting user permission decision via interactive card.
-	MessageTypePermissionDenials MessageType = "permission_denials"
+	MessageTypePermissionDenials MessageType = types.MessageTypePermissionDenials
 )
 
 type ChatMessage struct {

--- a/chatapps/command/disconnect_executor_test.go
+++ b/chatapps/command/disconnect_executor_test.go
@@ -1,0 +1,198 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hrygo/hotplex/event"
+	"github.com/hrygo/hotplex/provider"
+)
+
+// TestDisconnectExecutor_CommandAndDescription tests basic getters
+func TestDisconnectExecutor_CommandAndDescription(t *testing.T) {
+	exec := NewDisconnectExecutor(nil)
+
+	if cmd := exec.Command(); cmd != "/dc" {
+		t.Errorf("Command() = %q, want /dc", cmd)
+	}
+
+	if desc := exec.Description(); desc == "" {
+		t.Error("Description() should not be empty")
+	}
+}
+
+// TestProgressEmitter_NewEmitter tests constructor
+func TestProgressEmitter_NewEmitter(t *testing.T) {
+	steps := []ProgressStep{
+		{Name: "step1", Message: "First", Status: "pending"},
+	}
+	callback := func(eventType string, data any) error { return nil }
+
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	if emitter == nil {
+		t.Fatal("NewProgressEmitter() returned nil")
+	}
+	gotSteps := emitter.GetSteps()
+	if len(gotSteps) != 1 {
+		t.Errorf("GetSteps() = %d steps, want 1", len(gotSteps))
+	}
+}
+
+// TestProgressEmitter_UpdateStep tests step update
+func TestProgressEmitter_UpdateStep(t *testing.T) {
+	steps := []ProgressStep{
+		{Name: "step1", Message: "First", Status: "pending"},
+		{Name: "step2", Message: "Second", Status: "pending"},
+	}
+	callback := func(eventType string, data any) error { return nil }
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	// Valid update
+	err := emitter.UpdateStep(0, "running", "In progress...")
+	if err != nil {
+		t.Errorf("UpdateStep() error: %v", err)
+	}
+
+	gotSteps := emitter.GetSteps()
+	if gotSteps[0].Status != "running" {
+		t.Errorf("Step status = %q, want running", gotSteps[0].Status)
+	}
+
+	// Invalid index
+	err = emitter.UpdateStep(-1, "running", "")
+	if err == nil {
+		t.Error("UpdateStep(-1) should return error")
+	}
+
+	err = emitter.UpdateStep(10, "running", "")
+	if err == nil {
+		t.Error("UpdateStep(10) should return error")
+	}
+}
+
+// TestProgressEmitter_StatusHelpers tests Running, Success, Error methods
+func TestProgressEmitter_StatusHelpers(t *testing.T) {
+	steps := []ProgressStep{
+		{Name: "step1", Message: "", Status: "pending"},
+	}
+	callback := func(eventType string, data any) error { return nil }
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	// Running
+	if err := emitter.Running(0); err != nil {
+		t.Errorf("Running() error: %v", err)
+	}
+	if steps := emitter.GetSteps(); steps[0].Status != "running" {
+		t.Errorf("After Running(), status = %q", steps[0].Status)
+	}
+
+	// Success
+	if err := emitter.Success(0, "Done"); err != nil {
+		t.Errorf("Success() error: %v", err)
+	}
+	if steps := emitter.GetSteps(); steps[0].Status != "success" {
+		t.Errorf("After Success(), status = %q", steps[0].Status)
+	}
+
+	// Error
+	if err := emitter.Error(0, "Failed"); err != nil {
+		t.Errorf("Error() error: %v", err)
+	}
+	if steps := emitter.GetSteps(); steps[0].Status != "error" {
+		t.Errorf("After Error(), status = %q", steps[0].Status)
+	}
+}
+
+// TestProgressEmitter_Complete tests completion
+func TestProgressEmitter_Complete(t *testing.T) {
+	steps := []ProgressStep{
+		{Name: "step1", Message: "", Status: "running"},
+		{Name: "step2", Message: "", Status: "pending"},
+	}
+	var lastEventType string
+	callback := func(eventType string, data any) error {
+		lastEventType = eventType
+		return nil
+	}
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	err := emitter.Complete("All done")
+	if err != nil {
+		t.Errorf("Complete() error: %v", err)
+	}
+
+	if lastEventType != string(provider.EventTypeCommandComplete) {
+		t.Errorf("Last event = %q, want %q", lastEventType, provider.EventTypeCommandComplete)
+	}
+
+	// Verify all steps marked as success
+	gotSteps := emitter.GetSteps()
+	for i, s := range gotSteps {
+		if s.Status != "success" {
+			t.Errorf("Step %d status = %q, want success", i, s.Status)
+		}
+	}
+}
+
+// TestProgressEmitter_GetSteps_Copy tests that GetSteps returns a copy
+func TestProgressEmitter_GetSteps_Copy(t *testing.T) {
+	steps := []ProgressStep{
+		{Name: "step1", Message: "Original", Status: "pending"},
+	}
+	callback := func(eventType string, data any) error { return nil }
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	// Get steps and modify
+	gotSteps := emitter.GetSteps()
+	gotSteps[0].Status = "modified"
+
+	// Get again - should still have original value
+	gotSteps2 := emitter.GetSteps()
+	if gotSteps2[0].Status == "modified" {
+		t.Error("GetSteps() should return a copy, not reference")
+	}
+}
+
+// TestProgressEmitter_Callback tests callback invocation
+func TestProgressEmitter_Callback(t *testing.T) {
+	var callbackInvoked bool
+	callback := func(eventType string, data any) error {
+		callbackInvoked = true
+		return nil
+	}
+
+	steps := []ProgressStep{{Name: "step1"}}
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	// Start should invoke callback
+	err := emitter.Start("Starting")
+	if err != nil {
+		t.Errorf("Start() error: %v", err)
+	}
+	if !callbackInvoked {
+		t.Error("Start() should invoke callback")
+	}
+}
+
+// TestProgressEmitter_CallbackError tests error propagation
+func TestProgressEmitter_CallbackError(t *testing.T) {
+	expectedErr := errors.New("callback failed")
+	callback := func(eventType string, data any) error {
+		return expectedErr
+	}
+
+	steps := []ProgressStep{{Name: "step1"}}
+	emitter := NewProgressEmitter("/test", callback, steps)
+
+	err := emitter.Start("Starting")
+	if err == nil {
+		t.Error("Start() should return callback error")
+	}
+	if !errors.Is(err, expectedErr) && err.Error() != expectedErr.Error() {
+		t.Errorf("Start() error = %v, want %v", err, expectedErr)
+	}
+}
+
+// Compile-time check for ProgressEmitter interface behavior
+var _ event.Callback = event.Callback(nil)

--- a/chatapps/command_callback.go
+++ b/chatapps/command_callback.go
@@ -141,7 +141,8 @@ func (c *CommandCallback) sendOrUpdate(msg *base.ChatMessage) error {
 	// If we have a message TS, update; otherwise create new
 	if c.messageTS != "" && c.channelID != "" {
 		msg.Metadata["message_ts"] = c.messageTS
-		msg.Metadata["channel_id"] = c.channelID
+		msg.Metadata[base.KeyRoomID] = c.channelID
+		msg.Metadata["channel_id"] = c.channelID // Backward compat for adapters reading Slack-specific key
 	}
 
 	// Convert base.ChatMessage to ChatMessage for adapter

--- a/chatapps/config.go
+++ b/chatapps/config.go
@@ -9,135 +9,65 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
+	"github.com/hrygo/hotplex/chatapps/base"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/provider"
 	"gopkg.in/yaml.v3"
 )
 
-type PlatformConfig struct {
-	Inherits         string                  `yaml:"inherits"` // Path to parent config file (relative or absolute)
-	Platform         string                  `yaml:"platform"`
-	Mode             string                  `yaml:"mode"`
-	SystemPrompt     string                  `yaml:"system_prompt"`
-	TaskInstructions string                  `yaml:"task_instructions"`
-	Engine           EngineConfig            `yaml:"engine"`
-	Provider         provider.ProviderConfig `yaml:"provider"`
-	Security         SecurityConfig          `yaml:"security"`
-	Features         FeaturesConfig          `yaml:"features"`
-	Session          SessionConfig           `yaml:"session"`
-	MessageStore     MessageStoreConfig      `yaml:"message_store,omitempty"`
-	Options          map[string]any          `yaml:"options,omitempty"`
-	SourceFile       string                  `yaml:"-"` // Tracks which file this config was loaded from
-}
+// PlatformConfig is a type alias for base.PlatformConfig for backward compatibility.
+// The canonical definition lives in chatapps/base/plugin.go.
+type PlatformConfig = base.PlatformConfig
 
-type SecurityConfig struct {
-	VerifySignature *bool            `yaml:"verify_signature"`
-	Permission      PermissionConfig `yaml:"permission"`
-	Owner           *OwnerConfig     `yaml:"owner,omitempty"`
-}
+// SecurityConfig is a type alias for base.SecurityConfig.
+type SecurityConfig = base.SecurityConfig
 
-type PermissionConfig struct {
-	DMPolicy              string                 `yaml:"dm_policy"`
-	GroupPolicy           string                 `yaml:"group_policy"`
-	BotUserID             string                 `yaml:"bot_user_id"`
-	BroadcastResponse     string                 `yaml:"broadcast_response"` // Response for broadcast messages (multibot mode)
-	AllowedUsers          []string               `yaml:"allowed_users"`
-	BlockedUsers          []string               `yaml:"blocked_users"`
-	SlashCommandRateLimit float64                `yaml:"slash_command_rate_limit"`
-	ThreadOwnership       *ThreadOwnershipConfig `yaml:"thread_ownership,omitempty"`
-}
+// PermissionConfig is a type alias for base.PermissionConfig.
+type PermissionConfig = base.PermissionConfig
 
-// FeaturesConfig contains feature toggles for UI/UX experience.
-type FeaturesConfig struct {
-	Chunking  ChunkingConfig  `yaml:"chunking"`
-	Threading ThreadingConfig `yaml:"threading"`
-	RateLimit RateLimitConfig `yaml:"rate_limit"`
-	Markdown  MarkdownConfig  `yaml:"markdown"`
-}
+// FeaturesConfig is a type alias for base.FeaturesConfig.
+type FeaturesConfig = base.FeaturesConfig
 
-type ChunkingConfig struct {
-	Enabled  *bool `yaml:"enabled"`
-	MaxChars int   `yaml:"max_chars"`
-}
+// ChunkingConfig is a type alias for base.ChunkingConfig.
+type ChunkingConfig = base.ChunkingConfig
 
-type ThreadingConfig struct {
-	Enabled *bool `yaml:"enabled"`
-}
+// ThreadingConfig is a type alias for base.ThreadingConfig.
+type ThreadingConfig = base.ThreadingConfig
 
-type RateLimitConfig struct {
-	Enabled     *bool `yaml:"enabled"`
-	MaxAttempts int   `yaml:"max_attempts"`
-	BaseDelayMs int   `yaml:"base_delay_ms"`
-	MaxDelayMs  int   `yaml:"max_delay_ms"`
-}
+// RateLimitConfig is a type alias for base.RateLimitConfig.
+type RateLimitConfig = base.RateLimitConfig
 
-type MarkdownConfig struct {
-	Enabled *bool `yaml:"enabled"`
-}
+// MarkdownConfig is a type alias for base.MarkdownConfig.
+type MarkdownConfig = base.MarkdownConfig
 
-// OwnerConfig defines bot ownership and access control (Phase 1: Bot Behavior Spec)
-type OwnerConfig struct {
-	Primary string   `yaml:"primary"` // slack user ID
-	Trusted []string `yaml:"trusted_users"`
-	Policy  string   `yaml:"policy"` // owner_only | trusted | public
-}
+// OwnerConfig is a type alias for base.OwnerConfig.
+type OwnerConfig = base.OwnerConfig
 
-// ThreadOwnershipConfig defines thread ownership tracking behavior (Phase 1: Bot Behavior Spec)
-type ThreadOwnershipConfig struct {
-	Enabled *bool         `yaml:"enabled"`
-	TTL     time.Duration `yaml:"ttl"`
-	Persist *bool         `yaml:"persist"`
-}
+// ThreadOwnershipConfig is a type alias for base.ThreadOwnershipConfig.
+type ThreadOwnershipConfig = base.ThreadOwnershipConfig
 
-type SessionConfig struct {
-	Timeout         time.Duration `yaml:"timeout"`
-	CleanupInterval time.Duration `yaml:"cleanup_interval"`
-}
+// SessionConfig is a type alias for base.SessionConfig.
+type SessionConfig = base.SessionConfig
 
-type EngineConfig struct {
-	Timeout         time.Duration `yaml:"timeout"`
-	IdleTimeout     time.Duration `yaml:"idle_timeout"`
-	WorkDir         string        `yaml:"work_dir"`
-	AllowedTools    []string      `yaml:"allowed_tools"`
-	DisallowedTools []string      `yaml:"disallowed_tools"`
-}
+// EngineConfig is a type alias for base.EngineConfig.
+type EngineConfig = base.EngineConfig
 
-// MessageStoreConfig 消息存储配置 (Phase 3)
-type MessageStoreConfig struct {
-	Enabled   *bool           `yaml:"enabled"`
-	Type      string          `yaml:"type"` // sqlite | postgres | memory
-	SQLite    SQLiteConfig    `yaml:"sqlite"`
-	Postgres  PostgresConfig  `yaml:"postgres"`
-	Strategy  string          `yaml:"strategy"`
-	Streaming StreamingConfig `yaml:"streaming"`
-}
+// MessageStoreConfig is a type alias for base.MessageStoreConfig.
+type MessageStoreConfig = base.MessageStoreConfig
 
-type SQLiteConfig struct {
-	Path      string `yaml:"path"`
-	MaxSizeMB int    `yaml:"max_size_mb"`
-}
+// SQLiteConfig is a type alias for base.SQLiteConfig.
+type SQLiteConfig = base.SQLiteConfig
 
-type PostgresConfig struct {
-	DSN            string `yaml:"dsn"`
-	MaxConnections int    `yaml:"max_connections"`
-	Level          int    `yaml:"level"` // 1=百万级，2=亿级
-}
+// PostgresConfig is a type alias for base.PostgresConfig.
+type PostgresConfig = base.PostgresConfig
 
-type StreamingConfig struct {
-	Enabled       *bool         `yaml:"enabled"`
-	BufferSize    int           `yaml:"buffer_size"`
-	Timeout       time.Duration `yaml:"timeout"`
-	StoragePolicy string        `yaml:"storage_policy"` // complete_only | all_chunks
-}
+// StreamingConfig is a type alias for base.StreamingConfig.
+type StreamingConfig = base.StreamingConfig
 
-// BoolValue returns the value of a bool pointer if not nil, otherwise returns defaultVal.
+// BoolValue is a type alias for base.BoolValue.
 func BoolValue(pb *bool, defaultVal bool) bool {
-	if pb == nil {
-		return defaultVal
-	}
-	return *pb
+	return base.BoolValue(pb, defaultVal)
 }
 
 type Logger = slog.Logger

--- a/chatapps/engine_handler.go
+++ b/chatapps/engine_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hrygo/hotplex/chatapps/base"
 	"github.com/hrygo/hotplex/chatapps/internal"
+	"github.com/hrygo/hotplex/chatapps/slack"
 	"github.com/hrygo/hotplex/engine"
 	"github.com/hrygo/hotplex/event"
 	intengine "github.com/hrygo/hotplex/internal/engine"
@@ -334,6 +335,13 @@ func NewStreamCallback(
 	sessionOps SessionOperations,
 	streamingDisabled bool,
 ) *StreamCallback {
+	// Inject platform-specific converters and chunkers
+	chainOpts := ProcessorChainOptions{}
+	if platform == "slack" {
+		chainOpts.FormatConverter = slack.NewContentConverter()
+		chainOpts.Chunker = slack.NewSlackChunker()
+	}
+
 	cb := &StreamCallback{
 		ctx:               ctx,
 		sessionID:         sessionID,
@@ -348,7 +356,7 @@ func NewStreamCallback(
 		sessionOps:        sessionOps,
 		lastStatusUpdate:  time.Now(),
 		streamingDisabled: streamingDisabled,
-		processor:         NewDefaultProcessorChain(ctx, logger),
+		processor:         NewDefaultProcessorChain(ctx, logger, chainOpts),
 	}
 
 	// Initialize StatusManager if StatusProvider is available
@@ -666,10 +674,9 @@ func (c *StreamCallback) updateStatusMessageViaManager(statusType base.MessageTy
 	// Convert MessageType to StatusType
 	status := base.MessageTypeToStatusType(statusType)
 
-	// Get channel and thread info from metadata
+	// Get channel and thread info from metadata (uses unified keys with Slack fallback)
 	c.mu.Lock()
-	channelID, _ := c.metadata["channel_id"].(string)
-	threadTS, _ := c.metadata["thread_ts"].(string)
+	channelID, threadTS, _ := base.SlackMetadata(c.metadata)
 
 	// Throttle repetitive status updates
 	// Note: StatusManager also handles deduplication internally
@@ -879,25 +886,12 @@ func (c *StreamCallback) handleAnswer(data any) error {
 	// Skip streaming initialization for long-running tasks (Loki Mode, etc.)
 	if c.streamingDisabled {
 		c.logger.Debug("Streaming disabled for long-running task, using fallback mode",
-			"channel_id", c.metadata["channel_id"])
+			base.KeyRoomID, c.metadata[base.KeyRoomID])
 		c.mu.Unlock()
 		return nil
 	}
 	if !c.streamWriterActive && c.streamWriter == nil {
-		channelID := ""
-		threadTS := ""
-		userID := ""
-		if c.metadata != nil {
-			if ch, ok := c.metadata["channel_id"].(string); ok {
-				channelID = ch
-			}
-			if ts, ok := c.metadata["thread_ts"].(string); ok {
-				threadTS = ts
-			}
-			if uid, ok := c.metadata["user_id"].(string); ok {
-				userID = uid
-			}
-		}
+		channelID, threadTS, userID := base.SlackMetadata(c.metadata)
 		if channelID != "" {
 			c.streamWriter = c.adapters.NewStreamWriter(c.ctx, c.platform, userID, channelID, threadTS)
 			if c.streamWriter != nil {
@@ -1349,33 +1343,27 @@ func (c *StreamCallback) handleStepFinish(data any) error {
 	return c.buildChatMessage(base.MessageTypeStepFinish, content, metadata)
 }
 
-// mergeMetadata merges the callback's stored metadata with the provided metadata
+// mergeMetadata merges the callback's stored metadata with the provided metadata.
 // NOTE: message_ts is intentionally NOT copied because it refers to the user's message,
-// not the bot's message. Copying it causes Slack API errors (cant_update_message).
+// not the bot's message. Copying it causes platform API errors (cant_update_message).
 func (c *StreamCallback) mergeMetadata(metadata map[string]any) map[string]any {
 	result := make(map[string]any)
 	for k, v := range metadata {
 		result[k] = v
 	}
 
-	// Copy over important metadata from stored metadata
+	// Use base.MergeMetadata for unified keys (room_id, thread_id, user_id)
+	// with backward-compatible fallback to Slack-specific keys.
 	if c.metadata != nil {
-		if channelID, ok := c.metadata["channel_id"]; ok {
-			result["channel_id"] = channelID
+		result = base.MergeMetadata(result, c.metadata)
+
+		// Pass through platform-specific keys that are not in the unified set.
+		if v, ok := c.metadata["channel_type"]; ok {
+			result["channel_type"] = v
 		}
-		if channelType, ok := c.metadata["channel_type"]; ok {
-			result["channel_type"] = channelType
+		if v, ok := c.metadata["message_id"]; ok {
+			result["message_id"] = v
 		}
-		if threadTS, ok := c.metadata["thread_ts"]; ok {
-			result["thread_ts"] = threadTS
-		}
-		if userID, ok := c.metadata["user_id"]; ok {
-			result["user_id"] = userID
-		}
-		if messageID, ok := c.metadata["message_id"]; ok {
-			result["message_id"] = messageID
-		}
-		// Do NOT copy message_ts - it refers to the user's message, not the bot's message.
 	}
 	return result
 }

--- a/chatapps/feishu/adapter.go
+++ b/chatapps/feishu/adapter.go
@@ -121,7 +121,15 @@ func (a *Adapter) SetEngine(eng *engine.Engine) {
 	a.SetEngineWithBotID(eng, "")
 }
 
-// SetEngineWithBotID implements base.FeishuEngineSupport.
+// SetBotID implements base.EngineSupportWithBotID.
+func (a *Adapter) SetBotID(botID string) {
+	if a.interactiveHandler != nil {
+		a.interactiveHandler.SetBotID(botID)
+	}
+}
+
+// SetEngineWithBotID is a convenience method that sets both engine and bot ID.
+// Kept for backward compatibility with existing setup code.
 func (a *Adapter) SetEngineWithBotID(eng *engine.Engine, botID string) {
 	if a.interactiveHandler != nil {
 		a.interactiveHandler.SetEngine(eng, botID)

--- a/chatapps/feishu/factory.go
+++ b/chatapps/feishu/factory.go
@@ -1,0 +1,61 @@
+package feishu
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/hrygo/hotplex/chatapps/base"
+)
+
+// AdapterFactory implements base.AdapterFactory for Feishu.
+type AdapterFactory struct{}
+
+var _ base.AdapterFactory = (*AdapterFactory)(nil)
+
+// Platform implements AdapterFactory.
+func (f *AdapterFactory) Platform() string { return "feishu" }
+
+// RequiredEnvVars implements AdapterFactory.
+func (f *AdapterFactory) RequiredEnvVars() []string {
+	return []string{"HOTPLEX_FEISHU_APP_ID"}
+}
+
+// New implements AdapterFactory by creating a Feishu adapter from the given config.
+func (f *AdapterFactory) New(pc *base.PlatformConfig) any {
+	appID := os.Getenv("HOTPLEX_FEISHU_APP_ID")
+	if appID == "" {
+		return nil
+	}
+
+	config := &Config{
+		AppID:             appID,
+		AppSecret:         os.Getenv("HOTPLEX_FEISHU_APP_SECRET"),
+		VerificationToken: os.Getenv("HOTPLEX_FEISHU_VERIFICATION_TOKEN"),
+		EncryptKey:        os.Getenv("HOTPLEX_FEISHU_ENCRYPT_KEY"),
+		ServerAddr:        os.Getenv("HOTPLEX_FEISHU_SERVER_ADDR"),
+	}
+
+	if pc != nil {
+		config.SystemPrompt = pc.SystemPrompt
+	}
+
+	var opts []base.AdapterOption
+	if pc != nil {
+		opts = append(opts, base.WithSessionTimeout(pc.Session.Timeout))
+		opts = append(opts, base.WithCleanupInterval(pc.Session.CleanupInterval))
+	}
+	opts = append(opts, base.WithoutServer())
+
+	adapter, _ := NewAdapter(config, slog.Default(), opts...)
+	return adapter
+}
+
+// PostSetup implements AdapterFactory — Feishu has no post-setup steps.
+func (f *AdapterFactory) PostSetup(_ context.Context, _, _ any) {
+	// Feishu requires no post-setup steps
+}
+
+func init() {
+	base.GlobalAdapterRegistry().Register(&AdapterFactory{})
+}

--- a/chatapps/feishu/interactive_handler.go
+++ b/chatapps/feishu/interactive_handler.go
@@ -87,6 +87,11 @@ func (h *InteractiveHandler) SetEngine(eng *engine.Engine, botID string) {
 	h.botID = botID
 }
 
+// SetBotID injects the bot identity for permission management.
+func (h *InteractiveHandler) SetBotID(botID string) {
+	h.botID = botID
+}
+
 // HandleInteractive handles incoming interactive events
 func (h *InteractiveHandler) HandleInteractive(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {

--- a/chatapps/manager.go
+++ b/chatapps/manager.go
@@ -65,7 +65,9 @@ func (m *AdapterManager) RegisterOrReplace(adapter ChatAdapter) {
 	platform := adapter.Platform()
 	if existing, ok := m.adapters[platform]; ok {
 		if existing != adapter {
-			existing.Stop()
+			if err := existing.Stop(); err != nil {
+				m.logger.Warn("Failed to stop existing adapter", "platform", platform, "error", err)
+			}
 			m.logger.Info("Adapter replaced", "platform", platform)
 		}
 	}

--- a/chatapps/manager.go
+++ b/chatapps/manager.go
@@ -56,6 +56,23 @@ func (m *AdapterManager) Unregister(platform string) error {
 	return nil
 }
 
+// RegisterOrReplace registers an adapter, replacing any existing one for the same platform.
+// This is used by BridgeServer to re-register bridge adapters on reconnect.
+func (m *AdapterManager) RegisterOrReplace(adapter ChatAdapter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	platform := adapter.Platform()
+	if existing, ok := m.adapters[platform]; ok {
+		if existing != adapter {
+			existing.Stop()
+			m.logger.Info("Adapter replaced", "platform", platform)
+		}
+	}
+	m.adapters[platform] = adapter
+	m.logger.Info("Adapter registered (or replaced)", "platform", platform)
+}
+
 func (m *AdapterManager) GetAdapter(platform string) (ChatAdapter, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/chatapps/processor_chain.go
+++ b/chatapps/processor_chain.go
@@ -123,18 +123,28 @@ const (
 	OrderChunk ProcessorOrder = 50
 )
 
-// NewDefaultProcessorChain creates a default processor chain with all standard processors
-func NewDefaultProcessorChain(ctx context.Context, logger *slog.Logger) *ProcessorChain {
+// ProcessorChainOptions holds optional dependencies for the processor chain.
+type ProcessorChainOptions struct {
+	FormatConverter base.ContentConverter // Platform-specific content converter
+	Chunker        base.Chunker        // Platform-specific text chunker
+}
+
+// NewDefaultProcessorChain creates a default processor chain with all standard processors.
+// Platform-specific converters and chunkers can be injected via options.
+func NewDefaultProcessorChain(ctx context.Context, logger *slog.Logger, opts ProcessorChainOptions) *ProcessorChain {
 	filter := NewMessageFilterProcessor(logger)
 
 	thread := NewThreadProcessor(logger, ThreadProcessorOptions{
 		TTL: 30 * time.Minute,
 	})
 
-	formatConv := NewFormatConversionProcessor(logger)
+	formatConv := NewFormatConversionProcessor(logger, FormatProcessorOptions{
+		Converter: opts.FormatConverter,
+	})
 
 	chunk := NewChunkProcessor(logger, ChunkProcessorOptions{
 		MaxChars: 4000,
+		Chunker:  opts.Chunker,
 	})
 
 	return NewProcessorChain(

--- a/chatapps/processor_chain_test.go
+++ b/chatapps/processor_chain_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 
 	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/chatapps/slack"
 )
 
 func TestProcessorChain_Process(t *testing.T) {
-	chain := NewDefaultProcessorChain(context.Background(), nil)
+	slackOpts := ProcessorChainOptions{
+		FormatConverter: slack.NewContentConverter(),
+		Chunker:        slack.NewSlackChunker(),
+	}
+	chain := NewDefaultProcessorChain(context.Background(), nil, slackOpts)
 
 	msg := &base.ChatMessage{
 		Platform:  "slack",
@@ -38,7 +43,11 @@ func TestProcessorChain_Process(t *testing.T) {
 }
 
 func TestProcessorChain_ProcessNilMessage(t *testing.T) {
-	chain := NewDefaultProcessorChain(context.Background(), nil)
+	slackOpts := ProcessorChainOptions{
+		FormatConverter: slack.NewContentConverter(),
+		Chunker:        slack.NewSlackChunker(),
+	}
+	chain := NewDefaultProcessorChain(context.Background(), nil, slackOpts)
 
 	processed, err := chain.Process(context.Background(), nil)
 	if err != nil {
@@ -51,7 +60,11 @@ func TestProcessorChain_ProcessNilMessage(t *testing.T) {
 }
 
 func TestDefaultProcessorChain_Creation(t *testing.T) {
-	chain := NewDefaultProcessorChain(context.Background(), nil)
+	slackOpts := ProcessorChainOptions{
+		FormatConverter: slack.NewContentConverter(),
+		Chunker:        slack.NewSlackChunker(),
+	}
+	chain := NewDefaultProcessorChain(context.Background(), nil, slackOpts)
 
 	if chain == nil {
 		t.Fatal("NewDefaultProcessorChain returned nil")
@@ -85,7 +98,7 @@ func TestDefaultProcessorChain_Creation(t *testing.T) {
 func TestProcessorChain_AddProcessor(t *testing.T) {
 	chain := NewProcessorChain()
 
-	chain.AddProcessor(NewFormatConversionProcessor(nil))
+	chain.AddProcessor(NewFormatConversionProcessor(nil, FormatProcessorOptions{}))
 	chain.AddProcessor(NewMessageFilterProcessor(nil))
 
 	if len(chain.processors) != 2 {
@@ -99,7 +112,9 @@ func TestProcessorChain_AddProcessor(t *testing.T) {
 
 // TestFormatConversionProcessor_CodeBlockProtection tests that code blocks are preserved
 func TestFormatConversionProcessor_CodeBlockProtection(t *testing.T) {
-	processor := NewFormatConversionProcessor(nil)
+	processor := NewFormatConversionProcessor(nil, FormatProcessorOptions{
+		Converter: slack.NewContentConverter(),
+	})
 
 	tests := []struct {
 		name     string

--- a/chatapps/processor_chunk.go
+++ b/chatapps/processor_chunk.go
@@ -6,13 +6,13 @@ import (
 	"unicode/utf8"
 
 	"github.com/hrygo/hotplex/chatapps/base"
-	"github.com/hrygo/hotplex/chatapps/slack"
 )
 
 // ChunkProcessor splits long messages into chunks that fit within platform limits.
-// It uses the Slack chunker for Markdown-aware splitting.
+// It delegates platform-specific chunking to an injected Chunker.
 type ChunkProcessor struct {
 	logger   *slog.Logger
+	chunker  base.Chunker
 	maxChars int
 }
 
@@ -27,6 +27,7 @@ type ChunkInfo struct {
 // ChunkProcessorOptions configures the ChunkProcessor.
 type ChunkProcessorOptions struct {
 	MaxChars int // Maximum characters per chunk (default: 4000 for Slack)
+	Chunker  base.Chunker
 }
 
 // NewChunkProcessor creates a new ChunkProcessor.
@@ -35,14 +36,15 @@ func NewChunkProcessor(logger *slog.Logger, opts ChunkProcessorOptions) *ChunkPr
 		logger = slog.Default()
 	}
 
-	// Set defaults
-	if opts.MaxChars == 0 {
-		opts.MaxChars = slack.SlackTextLimit
+	chunker := opts.Chunker
+	if chunker == nil {
+		chunker = base.NewDefaultChunker(opts.MaxChars)
 	}
 
 	return &ChunkProcessor{
 		logger:   logger,
-		maxChars: opts.MaxChars,
+		chunker:  chunker,
+		maxChars: chunker.MaxChars(),
 	}
 }
 
@@ -84,31 +86,16 @@ func (p *ChunkProcessor) Process(ctx context.Context, msg *base.ChatMessage) (*b
 		"content_len", contentLen,
 		"max_chars", p.maxChars)
 
-	// Get thread_ts and channel_id from metadata for all chunks
-	threadTS := ""
-	channelID := ""
+	// Get thread_ts and channel_id from metadata for all chunks (unified keys with Slack fallback)
+	channelID, threadTS, _ := base.SlackMetadata(msg.Metadata)
 
-	if msg.Metadata != nil {
-		if ts, ok := msg.Metadata["thread_ts"].(string); ok {
-			threadTS = ts
-		}
-		if ch, ok := msg.Metadata["channel_id"].(string); ok {
-			channelID = ch
-		}
-	}
-
-	// Use the existing chunkMessageMarkdown function
-	chunks := slack.ChunkMessageMarkdown(content, p.maxChars)
+	// Delegate to injected chunker for platform-specific logic
+	chunks := p.chunker.ChunkText(content, p.maxChars)
 
 	if len(chunks) == 1 {
 		// Should not happen, but handle gracefully
 		return msg, nil
 	}
-
-	// Create chunked messages
-	// Note: We return the first chunk as the primary message and add remaining to metadata
-	// for the adapter to send. This is a design decision - alternatively we could
-	// return []*base.ChatMessage but that requires changing the Processor interface.
 
 	firstChunk := chunks[0]
 	extraChunks := chunks[1:]

--- a/chatapps/processor_format.go
+++ b/chatapps/processor_format.go
@@ -8,18 +8,31 @@ import (
 	"github.com/hrygo/hotplex/chatapps/base"
 )
 
-// FormatConversionProcessor converts message content to platform-specific formats
+// FormatConversionProcessor converts message content to platform-specific formats.
+// It delegates platform-specific conversion to an injected ContentConverter.
 type FormatConversionProcessor struct {
-	logger *slog.Logger
+	logger    *slog.Logger
+	converter base.ContentConverter
 }
 
-// NewFormatConversionProcessor creates a new FormatConversionProcessor
-func NewFormatConversionProcessor(logger *slog.Logger) *FormatConversionProcessor {
+// FormatProcessorOptions configures the FormatConversionProcessor.
+type FormatProcessorOptions struct {
+	Converter base.ContentConverter
+}
+
+// NewFormatConversionProcessor creates a new FormatConversionProcessor.
+// If no converter is provided, a no-op converter is used.
+func NewFormatConversionProcessor(logger *slog.Logger, opts FormatProcessorOptions) *FormatConversionProcessor {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	converter := opts.Converter
+	if converter == nil {
+		converter = base.NewNoOpConverter()
+	}
 	return &FormatConversionProcessor{
-		logger: logger,
+		logger:    logger,
+		converter: converter,
 	}
 }
 
@@ -33,13 +46,13 @@ func (p *FormatConversionProcessor) Order() int {
 	return int(OrderFormatConversion)
 }
 
-// Process converts message content based on platform
+// Process converts message content based on parse mode using the injected converter.
 func (p *FormatConversionProcessor) Process(ctx context.Context, msg *base.ChatMessage) (*base.ChatMessage, error) {
 	if msg.Content == "" {
 		return msg, nil
 	}
 
-	// Check if content should be converted
+	// Determine parse mode
 	parseMode := base.ParseModeNone
 	if msg.RichContent != nil {
 		parseMode = msg.RichContent.ParseMode
@@ -57,208 +70,20 @@ func (p *FormatConversionProcessor) Process(ctx context.Context, msg *base.ChatM
 		}
 	}
 
-	// Convert based on platform and parse mode
-	switch msg.Platform {
-	case "slack":
-		if parseMode == base.ParseModeMarkdown {
-			msg.Content = convertMarkdownToSlackMrkdwn(msg.Content)
-			p.logger.Debug("Converted markdown to Slack mrkdwn",
+	// Delegate platform-specific conversion to the injected converter
+	if parseMode != base.ParseModeNone {
+		originalLen := len(msg.Content)
+		msg.Content = p.converter.ConvertMarkdownToPlatform(msg.Content, parseMode)
+		if len(msg.Content) != originalLen {
+			p.logger.Debug("Converted content",
 				"session_id", msg.SessionID,
-				"content_len", len(msg.Content))
+				"parse_mode", parseMode,
+				"original_len", originalLen,
+				"converted_len", len(msg.Content))
 		}
 	}
 
 	return msg, nil
-}
-
-// convertMarkdownToSlackMrkdwn converts Markdown to Slack's mrkdwn format
-// It preserves code blocks (```...```) and inline code (`...`) without conversion
-func convertMarkdownToSlackMrkdwn(text string) string {
-	// Split text into segments, preserving code blocks
-	segments := splitPreservingCodeBlocks(text)
-
-	var result strings.Builder
-	result.Grow(len(text) * 2)
-
-	for _, segment := range segments {
-		if segment.isCodeBlock {
-			// Code blocks are preserved as-is (but still need escaping)
-			result.WriteString(escapeSlackChars(segment.text))
-		} else {
-			// Convert non-code segments
-			// IMPORTANT: Order matters! italic must come before bold
-			// because `*text*` would match in both patterns
-			converted := segment.text
-			converted = convertItalic(converted)
-			converted = convertBold(converted)
-			converted = convertLinks(converted)
-			converted = escapeSlackChars(converted)
-			result.WriteString(converted)
-		}
-	}
-
-	return result.String()
-}
-
-// textSegment represents a portion of text with code block status
-type textSegment struct {
-	text        string
-	isCodeBlock bool
-}
-
-// splitPreservingCodeBlocks splits text into code blocks and non-code segments
-func splitPreservingCodeBlocks(text string) []textSegment {
-	var segments []textSegment
-	remaining := text
-
-	for {
-		// Find code block start
-		codeStart := strings.Index(remaining, "```")
-		if codeStart == -1 {
-			// No more code blocks, add remaining text
-			if len(remaining) > 0 {
-				segments = append(segments, textSegment{text: remaining, isCodeBlock: false})
-			}
-			break
-		}
-
-		// Add text before code block
-		if codeStart > 0 {
-			segments = append(segments, textSegment{text: remaining[:codeStart], isCodeBlock: false})
-		}
-
-		// Find code block end (after the opening ```)
-		afterStart := remaining[codeStart+3:]
-		codeEnd := strings.Index(afterStart, "```")
-		if codeEnd == -1 {
-			// Unclosed code block, treat rest as code
-			segments = append(segments, textSegment{text: remaining[codeStart:], isCodeBlock: true})
-			break
-		}
-
-		// Add code block (including the ``` markers)
-		codeBlock := remaining[codeStart : codeStart+3+codeEnd+3]
-		segments = append(segments, textSegment{text: codeBlock, isCodeBlock: true})
-
-		// Move past this code block
-		remaining = remaining[codeStart+3+codeEnd+3:]
-	}
-
-	return segments
-}
-
-// escapeSlackChars escapes special characters for Slack
-func escapeSlackChars(text string) string {
-	result := strings.Builder{}
-	result.Grow(len(text))
-
-	for _, r := range text {
-		switch r {
-		case '&':
-			result.WriteString("&amp;")
-		case '<':
-			result.WriteString("&lt;")
-		case '>':
-			result.WriteString("&gt;")
-		default:
-			result.WriteRune(r)
-		}
-	}
-
-	return result.String()
-}
-
-// convertBold converts **text** to *text*
-func convertBold(text string) string {
-	// Match **text** but not **** (already bold markers)
-	result := text
-	for strings.Contains(result, "**") {
-		start := strings.Index(result, "**")
-		if start == -1 {
-			break
-		}
-		end := strings.Index(result[start+2:], "**")
-		if end == -1 {
-			break
-		}
-		end += start + 2
-		inner := result[start+2 : end]
-		result = result[:start] + "*" + inner + "*" + result[end+2:]
-	}
-	return result
-}
-
-// convertItalic converts *text* to _text_ (but not ** or ***)
-func convertItalic(text string) string {
-	result := text
-	// Simple implementation - match *text* but not ** or ***
-	for {
-		start := -1
-		// Find * that's not followed by *
-		for i := 0; i < len(result)-1; i++ {
-			if result[i] == '*' && result[i+1] != '*' {
-				// Also check it's not preceded by *
-				if i > 0 && result[i-1] == '*' {
-					continue
-				}
-				start = i
-				break
-			}
-		}
-		if start == -1 {
-			break
-		}
-
-		end := -1
-		for i := start + 1; i < len(result)-1; i++ {
-			if result[i] == '*' && result[i+1] != '*' {
-				end = i
-				break
-			}
-		}
-		if end == -1 {
-			break
-		}
-
-		inner := result[start+1 : end]
-		result = result[:start] + "_" + inner + "_" + result[end+1:]
-	}
-	return result
-}
-
-// convertLinks converts [text](url) to <url|text>
-func convertLinks(text string) string {
-	result := text
-	for strings.Contains(result, "[") {
-		textStart := strings.Index(result, "[")
-		if textStart == -1 {
-			break
-		}
-		textEnd := strings.Index(result[textStart:], "]")
-		if textEnd == -1 {
-			break
-		}
-		textEnd += textStart
-
-		urlStart := strings.Index(result[textEnd:], "(")
-		if urlStart == -1 {
-			break
-		}
-		urlStart += textEnd
-
-		urlEnd := strings.Index(result[urlStart:], ")")
-		if urlEnd == -1 {
-			break
-		}
-		urlEnd += urlStart
-
-		linkText := result[textStart+1 : textEnd]
-		linkURL := result[urlStart+1 : urlEnd]
-
-		replacement := "<" + linkURL + "|" + linkText + ">"
-		result = result[:textStart] + replacement + result[urlEnd+1:]
-	}
-	return result
 }
 
 // Verify FormatConversionProcessor implements MessageProcessor at compile time

--- a/chatapps/setup.go
+++ b/chatapps/setup.go
@@ -362,10 +362,10 @@ func setupPlatform(
 		logger.Info("Adapter does not implement EngineSupport", "platform", platform)
 	}
 
-	// 5. For Feishu adapters, also inject botID for permission management
-	if feishuSupport, ok := adapter.(base.FeishuEngineSupport); ok {
-		feishuSupport.SetEngineWithBotID(eng, pc.Security.Permission.BotUserID)
-		logger.Info("Feishu botID injected", "platform", platform, "bot_id", pc.Security.Permission.BotUserID)
+	// 5. For adapters that need botID for permission management
+	if botIDSupport, ok := adapter.(base.EngineSupportWithBotID); ok {
+		botIDSupport.SetBotID(pc.Security.Permission.BotUserID)
+		logger.Info("BotID injected for permission management", "platform", platform, "bot_id", pc.Security.Permission.BotUserID)
 	}
 
 	// 3. Create EngineMessageHandler

--- a/chatapps/setup.go
+++ b/chatapps/setup.go
@@ -11,9 +11,6 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/chatapps/base"
-	"github.com/hrygo/hotplex/chatapps/feishu"
-	"github.com/hrygo/hotplex/chatapps/slack"
-	"github.com/hrygo/hotplex/chatapps/slack/apphome"
 	"github.com/hrygo/hotplex/engine"
 	"github.com/hrygo/hotplex/internal/permission"
 	"github.com/hrygo/hotplex/internal/sys"
@@ -97,147 +94,12 @@ func Setup(ctx context.Context, logger *slog.Logger, configDir ...string) (http.
 
 	manager := NewAdapterManager(logger)
 
-	// Slack
-	setupPlatform(ctx, "slack", loader, manager, logger, func(pc *PlatformConfig) ChatAdapter {
-		token := os.Getenv("HOTPLEX_SLACK_BOT_TOKEN")
-		if token == "" {
-			return nil
-		}
-
-		mode := os.Getenv("HOTPLEX_SLACK_MODE")
-		if mode == "" {
-			mode = "http" // default to http
-		}
-		config := &slack.Config{
-			BotToken:      token,
-			AppToken:      os.Getenv("HOTPLEX_SLACK_APP_TOKEN"),
-			SigningSecret: os.Getenv("HOTPLEX_SLACK_SIGNING_SECRET"),
-			Mode:          mode,
-			ServerAddr:    os.Getenv("HOTPLEX_SLACK_SERVER_ADDR"),
-		}
-
-		// Apply YAML config if available
-		if pc != nil {
-			config.SystemPrompt = pc.SystemPrompt
-
-			// Map Security & Permission from YAML
-			config.BotUserID = pc.Security.Permission.BotUserID
-			config.VerifySignature = pc.Security.VerifySignature
-			config.DMPolicy = pc.Security.Permission.DMPolicy
-			config.GroupPolicy = pc.Security.Permission.GroupPolicy
-			config.AllowedUsers = pc.Security.Permission.AllowedUsers
-			config.BlockedUsers = pc.Security.Permission.BlockedUsers
-			config.SlashCommandRateLimit = pc.Security.Permission.SlashCommandRateLimit
-
-			// Map Owner Configuration (Phase 1: Bot Behavior Spec)
-			if pc.Security.Owner != nil {
-				config.Owner = &slack.OwnerConfig{
-					Primary: pc.Security.Owner.Primary,
-					Trusted: pc.Security.Owner.Trusted,
-					Policy:  slack.OwnerPolicy(pc.Security.Owner.Policy),
-				}
-			}
-
-			// Map Thread Ownership Configuration (Phase 1: Bot Behavior Spec)
-			if pc.Security.Permission.ThreadOwnership != nil {
-				config.ThreadOwnership = &slack.ThreadOwnershipConfig{
-					Enabled: pc.Security.Permission.ThreadOwnership.Enabled,
-					TTL:     pc.Security.Permission.ThreadOwnership.TTL,
-					Persist: pc.Security.Permission.ThreadOwnership.Persist,
-				}
-			}
-
-			// Map Features (Phase 2)
-			config.Features = slack.FeaturesConfig{
-				Chunking: slack.ChunkingConfig{
-					Enabled:  pc.Features.Chunking.Enabled,
-					MaxChars: pc.Features.Chunking.MaxChars,
-				},
-				Threading: slack.ThreadingConfig{
-					Enabled: pc.Features.Threading.Enabled,
-				},
-				RateLimit: slack.RateLimitConfig{
-					Enabled:     pc.Features.RateLimit.Enabled,
-					MaxAttempts: pc.Features.RateLimit.MaxAttempts,
-					BaseDelayMs: pc.Features.RateLimit.BaseDelayMs,
-					MaxDelayMs:  pc.Features.RateLimit.MaxDelayMs,
-				},
-				Markdown: slack.MarkdownConfig{
-					Enabled: pc.Features.Markdown.Enabled,
-				},
-			}
-
-			// Map Message Storage (Phase 3)
-			if pc.MessageStore.Enabled != nil {
-				config.Storage = &slack.StorageConfig{
-					Enabled:       pc.MessageStore.Enabled,
-					Type:          pc.MessageStore.Type,
-					SQLitePath:    pc.MessageStore.SQLite.Path,
-					PostgreSQLURL: pc.MessageStore.Postgres.DSN,
-					StreamEnabled: pc.MessageStore.Streaming.Enabled,
-					StreamTimeout: pc.MessageStore.Streaming.Timeout,
-				}
-			}
-
-			// Debug: Log GroupPolicy value
-			logger.Info("Slack config loaded from YAML",
-				"group_policy", config.GroupPolicy,
-				"bot_user_id", config.BotUserID,
-				"dm_policy", config.DMPolicy,
-				"owner_policy", config.GetOwnerPolicy(),
-				"thread_ownership", config.IsThreadOwnershipEnabled())
-
-			// Set broadcast response for multibot mode (Empty string means silence)
-			config.SetBroadcastResponse(pc.Security.Permission.BroadcastResponse)
-
-			// AppToken fallback
-			if config.AppToken == "" && pc.Options != nil {
-				if appToken, ok := pc.Options["app_token"].(string); ok {
-					config.AppToken = os.ExpandEnv(appToken)
-				}
-			}
-
-			// Mode from YAML overrides env var (if set)
-			if pc.Mode != "" {
-				config.Mode = pc.Mode
-			}
-		}
-
-		var opts []base.AdapterOption
-		if pc != nil {
-			opts = append(opts, base.WithSessionTimeout(pc.Session.Timeout))
-			opts = append(opts, base.WithCleanupInterval(pc.Session.CleanupInterval))
-		}
-		opts = append(opts, base.WithoutServer())
-		return slack.NewAdapter(config, logger, opts...)
-	}, "HOTPLEX_SLACK_BOT_TOKEN")
-	// Feishu
-	setupPlatform(ctx, "feishu", loader, manager, logger, func(pc *PlatformConfig) ChatAdapter {
-		appID := os.Getenv("HOTPLEX_FEISHU_APP_ID")
-		if appID == "" {
-			return nil
-		}
-		config := &feishu.Config{
-			AppID:             appID,
-			AppSecret:         os.Getenv("HOTPLEX_FEISHU_APP_SECRET"),
-			VerificationToken: os.Getenv("HOTPLEX_FEISHU_VERIFICATION_TOKEN"),
-			EncryptKey:        os.Getenv("HOTPLEX_FEISHU_ENCRYPT_KEY"),
-			ServerAddr:        os.Getenv("HOTPLEX_FEISHU_SERVER_ADDR"),
-		}
-
-		if pc != nil {
-			config.SystemPrompt = pc.SystemPrompt
-		}
-
-		var opts []base.AdapterOption
-		if pc != nil {
-			opts = append(opts, base.WithSessionTimeout(pc.Session.Timeout))
-			opts = append(opts, base.WithCleanupInterval(pc.Session.CleanupInterval))
-		}
-		opts = append(opts, base.WithoutServer())
-		adapter, _ := feishu.NewAdapter(config, logger, opts...)
-		return adapter
-	}, "HOTPLEX_FEISHU_APP_ID")
+	// Auto-discover platforms from the global registry
+	registry := base.GlobalAdapterRegistry()
+	for _, platform := range registry.List() {
+		factory, _ := registry.Get(platform)
+		setupPlatform(ctx, factory, loader, manager, logger)
+	}
 
 	if err := manager.StartAll(ctx); err != nil {
 		return nil, nil, fmt.Errorf("start all adapters: %w", err)
@@ -297,27 +159,17 @@ func resolveWorkDir(configuredPath, platform string, logger *slog.Logger) WorkDi
 
 func setupPlatform(
 	_ context.Context,
-	platform string,
+	factory base.AdapterFactory,
 	loader *ConfigLoader,
 	manager *AdapterManager,
 	logger *slog.Logger,
-	adapterFactory func(*PlatformConfig) ChatAdapter,
-	requiredEnvVars ...string,
 ) {
+	platform := factory.Platform()
+
 	// Early exit if required environment variables are not set
-	// This avoids unnecessary YAML config loading and engine creation
-	if len(requiredEnvVars) > 0 {
-		missing := false
-		for _, envVar := range requiredEnvVars {
-			if os.Getenv(envVar) == "" {
-				missing = true
-				break
-			}
-		}
-		if missing {
-			logger.Info("Platform skipped (missing required env vars)", "platform", platform, "required", requiredEnvVars)
-			return
-		}
+	if required := factory.RequiredEnvVars(); len(required) > 0 && !base.HasRequiredEnvVars(required) {
+		logger.Info("Platform skipped (missing required env vars)", "platform", platform, "required", required)
+		return
 	}
 
 	var pc *PlatformConfig
@@ -337,54 +189,49 @@ func setupPlatform(
 	manager.RegisterEngine(eng)
 
 	// 2. Create PermissionMatcher and inject into engine
-	// Use HOTPLEX_PERMISSION_STORE_DIR for absolute path, falling back to platform-relative dir.
-	// This ensures deterministic file paths in Docker/systemd deployments.
 	permBaseDir := os.Getenv("HOTPLEX_PERMISSION_STORE_DIR")
 	if permBaseDir == "" {
-		permBaseDir = platform // fallback to relative path (platform name)
+		permBaseDir = platform
 	}
 	permissionMatcher := permission.NewPermissionMatcher(permBaseDir)
 	eng.SetPermissionMatcher(permissionMatcher)
 
-	// 3. Create Adapter
-	adapter := adapterFactory(pc)
-	if adapter == nil {
+	// 3. Create Adapter via factory
+	rawAdapter := factory.New(pc)
+	if rawAdapter == nil {
 		logger.Info("Platform not initialized (likely missing credentials)", "platform", platform)
+		return
+	}
+	adapter, ok := rawAdapter.(ChatAdapter)
+	if !ok {
+		logger.Error("Factory returned non-ChatAdapter", "platform", platform)
 		return
 	}
 
 	// 4. Wire up Engine for slash command support (platform-agnostic via interface)
-	// Only adapters that implement EngineSupport will receive the engine
 	if engineSupport, ok := adapter.(base.EngineSupport); ok {
 		engineSupport.SetEngine(eng)
-		logger.Info("Engine injected", "platform", platform)
-	} else {
-		logger.Info("Adapter does not implement EngineSupport", "platform", platform)
+		logger.Debug("Engine injected", "platform", platform)
 	}
 
 	// 5. For adapters that need botID for permission management
 	if botIDSupport, ok := adapter.(base.EngineSupportWithBotID); ok {
 		botIDSupport.SetBotID(pc.Security.Permission.BotUserID)
-		logger.Info("BotID injected for permission management", "platform", platform, "bot_id", pc.Security.Permission.BotUserID)
+		logger.Debug("BotID injected for permission management", "platform", platform, "bot_id", pc.Security.Permission.BotUserID)
 	}
 
-	// 3. Create EngineMessageHandler
-	// Wrap engine.Engine to implement chatapps.Engine interface
+	// 6. Create EngineMessageHandler
 	wrappedEng := &engineWrapper{eng: eng}
 
-	// Resolve work directory once at setup time to avoid repeated path expansion
-	// and log noise on every message (Issue #294)
 	workDirResult := resolveWorkDir(pc.Engine.WorkDir, platform, logger)
 
 	msgHandler := NewEngineMessageHandler(wrappedEng, manager,
 		WithConfigLoader(loader),
 		WithLogger(logger),
 		WithWorkDirFn(func(sessionID string) string {
-			// Return cached resolved path if configured
 			if workDirResult.ResolvedPath != "" {
 				return workDirResult.ResolvedPath
 			}
-			// Default: use temp directory with platform/session isolation
 			defaultDir := filepath.Join("/tmp/hotplex-chatapps", workDirResult.PlatformName, sessionID)
 			logger.Debug("Using default temp work_dir",
 				"platform", workDirResult.PlatformName,
@@ -395,36 +242,37 @@ func setupPlatform(
 		}),
 	)
 
-	// 4. Link everything
+	// 7. Link everything
 	adapter.SetHandler(msgHandler.Handle)
 
+	// 8. Register adapter
 	if err := manager.Register(adapter); err != nil {
 		logger.Error("Failed to register adapter", "platform", platform, "error", err)
-	} else {
-		// Setup AppHome capability center for Slack after registration
-		if platform == "slack" {
-			if slackAdapter, ok := adapter.(*slack.Adapter); ok {
-				client := slackAdapter.GetSlackClient()
-				if client != nil {
-					appHomeConfig := apphome.Config{
-						Enabled:          true,
-						CapabilitiesPath: os.Getenv("HOTPLEX_SLACK_CAPABILITIES_PATH"),
-					}
-					// Pass nil for brain - can be set later if needed
-					handler, _, _ := apphome.Setup(client, nil, appHomeConfig, logger)
-					if handler != nil {
-						slackAdapter.SetAppHomeHandler(handler)
-						logger.Info("AppHome capability center initialized", "platform", platform)
-					}
-				}
-			}
-		}
+		return
+	}
 
-		if pc != nil && pc.SourceFile != "" {
-			logger.Info("Platform successfully initialized from configuration file", "platform", platform, "file", pc.SourceFile)
-		} else {
-			logger.Info("Platform successfully initialized from environment variables", "platform", platform)
-		}
+	// 9. Call factory PostSetup hook (e.g., AppHome for Slack)
+	setupCtx := &base.SetupContext{
+		Manager:  manager,
+		Loader:   loader,
+		Engine:   eng,
+		PermDir:  permBaseDir,
+		Logger:   logger,
+		Platform: platform,
+		PlatformConfig: pc,
+		WorkDirFn: func(sessionID string) string {
+			if workDirResult.ResolvedPath != "" {
+				return workDirResult.ResolvedPath
+			}
+			return filepath.Join("/tmp/hotplex-chatapps", platform, sessionID)
+		},
+	}
+	factory.PostSetup(context.Background(), adapter, setupCtx)
+
+	if pc.SourceFile != "" {
+		logger.Info("Platform successfully initialized from configuration file", "platform", platform, "file", pc.SourceFile)
+	} else {
+		logger.Info("Platform successfully initialized from environment variables", "platform", platform)
 	}
 }
 

--- a/chatapps/slack/converter.go
+++ b/chatapps/slack/converter.go
@@ -1,0 +1,218 @@
+// Package slack provides the Slack adapter implementation for the hotplex engine.
+package slack
+
+import (
+	"strings"
+
+	"github.com/hrygo/hotplex/chatapps/base"
+)
+
+// SlackChunker implements base.Chunker using Slack's Markdown-aware chunking.
+type SlackChunker struct{}
+
+// NewSlackChunker creates a Slack-specific text chunker.
+func NewSlackChunker() *SlackChunker {
+	return &SlackChunker{}
+}
+
+// ChunkText uses Slack's code-block-aware Markdown chunking.
+func (c *SlackChunker) ChunkText(text string, limit int) []string {
+	return ChunkMessageMarkdown(text, limit)
+}
+
+// MaxChars returns Slack's character limit.
+func (c *SlackChunker) MaxChars() int { return SlackTextLimit }
+
+// ContentConverter converts message content to Slack mrkdwn format.
+type ContentConverter struct{}
+
+// NewContentConverter creates a new Slack content converter.
+func NewContentConverter() *ContentConverter {
+	return &ContentConverter{}
+}
+
+// ConvertMarkdownToPlatform converts Markdown text to Slack mrkdwn format.
+func (c *ContentConverter) ConvertMarkdownToPlatform(content string, parseMode base.ParseMode) string {
+	if parseMode != base.ParseModeMarkdown {
+		return content
+	}
+	return convertMarkdownToSlackMrkdwn(content)
+}
+
+// EscapeSpecialChars escapes Slack-specific special characters.
+func (c *ContentConverter) EscapeSpecialChars(text string) string {
+	return escapeSlackChars(text)
+}
+
+// convertMarkdownToSlackMrkdwn converts Markdown to Slack's mrkdwn format.
+// It preserves code blocks (```...```) and inline code (`...`) without conversion.
+func convertMarkdownToSlackMrkdwn(text string) string {
+	segments := splitPreservingCodeBlocks(text)
+
+	var result strings.Builder
+	result.Grow(len(text) * 2)
+
+	for _, segment := range segments {
+		if segment.isCodeBlock {
+			result.WriteString(escapeSlackChars(segment.text))
+		} else {
+			converted := segment.text
+			converted = convertItalic(converted)
+			converted = convertBold(converted)
+			converted = convertLinks(converted)
+			converted = escapeSlackChars(converted)
+			result.WriteString(converted)
+		}
+	}
+
+	return result.String()
+}
+
+// textSegment represents a portion of text with code block status
+type textSegment struct {
+	text        string
+	isCodeBlock bool
+}
+
+// splitPreservingCodeBlocks splits text into code blocks and non-code segments
+func splitPreservingCodeBlocks(text string) []textSegment {
+	var segments []textSegment
+	remaining := text
+
+	for {
+		codeStart := strings.Index(remaining, "```")
+		if codeStart == -1 {
+			if len(remaining) > 0 {
+				segments = append(segments, textSegment{text: remaining, isCodeBlock: false})
+			}
+			break
+		}
+
+		if codeStart > 0 {
+			segments = append(segments, textSegment{text: remaining[:codeStart], isCodeBlock: false})
+		}
+
+		afterStart := remaining[codeStart+3:]
+		codeEnd := strings.Index(afterStart, "```")
+		if codeEnd == -1 {
+			segments = append(segments, textSegment{text: remaining[codeStart:], isCodeBlock: true})
+			break
+		}
+
+		codeBlock := remaining[codeStart : codeStart+3+codeEnd+3]
+		segments = append(segments, textSegment{text: codeBlock, isCodeBlock: true})
+		remaining = remaining[codeStart+3+codeEnd+3:]
+	}
+
+	return segments
+}
+
+// escapeSlackChars escapes special characters for Slack
+func escapeSlackChars(text string) string {
+	result := strings.Builder{}
+	result.Grow(len(text))
+
+	for _, r := range text {
+		switch r {
+		case '&':
+			result.WriteString("&amp;")
+		case '<':
+			result.WriteString("&lt;")
+		case '>':
+			result.WriteString("&gt;")
+		default:
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
+}
+
+// convertBold converts **text** to *text*
+func convertBold(text string) string {
+	result := text
+	for strings.Contains(result, "**") {
+		start := strings.Index(result, "**")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start+2:], "**")
+		if end == -1 {
+			break
+		}
+		end += start + 2
+		inner := result[start+2 : end]
+		result = result[:start] + "*" + inner + "*" + result[end+2:]
+	}
+	return result
+}
+
+// convertItalic converts *text* to _text_ (but not ** or ***)
+func convertItalic(text string) string {
+	result := text
+	for {
+		start := -1
+		for i := 0; i < len(result)-1; i++ {
+			if result[i] == '*' && result[i+1] != '*' {
+				if i > 0 && result[i-1] == '*' {
+					continue
+				}
+				start = i
+				break
+			}
+		}
+		if start == -1 {
+			break
+		}
+
+		end := -1
+		for i := start + 1; i < len(result)-1; i++ {
+			if result[i] == '*' && result[i+1] != '*' {
+				end = i
+				break
+			}
+		}
+		if end == -1 {
+			break
+		}
+
+		inner := result[start+1 : end]
+		result = result[:start] + "_" + inner + "_" + result[end+1:]
+	}
+	return result
+}
+
+// convertLinks converts [text](url) to <url|text>
+func convertLinks(text string) string {
+	result := text
+	for strings.Contains(result, "[") {
+		textStart := strings.Index(result, "[")
+		if textStart == -1 {
+			break
+		}
+		textEnd := strings.Index(result[textStart:], "]")
+		if textEnd == -1 {
+			break
+		}
+		textEnd += textStart
+
+		urlStart := strings.Index(result[textEnd:], "(")
+		if urlStart == -1 {
+			break
+		}
+		urlStart += textEnd
+
+		urlEnd := strings.Index(result[urlStart:], ")")
+		if urlEnd == -1 {
+			break
+		}
+		urlEnd += urlStart
+
+		linkText := result[textStart+1 : textEnd]
+		linkURL := result[urlStart+1 : urlEnd]
+
+		replacement := "<" + linkURL + "|" + linkText + ">"
+		result = result[:textStart] + replacement + result[urlEnd+1:]
+	}
+	return result
+}

--- a/chatapps/slack/factory.go
+++ b/chatapps/slack/factory.go
@@ -1,0 +1,156 @@
+package slack
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/chatapps/slack/apphome"
+)
+
+// AdapterFactory implements base.AdapterFactory for Slack.
+type AdapterFactory struct{}
+
+var _ base.AdapterFactory = (*AdapterFactory)(nil)
+
+// Platform implements AdapterFactory.
+func (f *AdapterFactory) Platform() string { return "slack" }
+
+// RequiredEnvVars implements AdapterFactory.
+func (f *AdapterFactory) RequiredEnvVars() []string {
+	return []string{"HOTPLEX_SLACK_BOT_TOKEN"}
+}
+
+// New implements AdapterFactory by creating a Slack adapter from the given config.
+func (f *AdapterFactory) New(pc *base.PlatformConfig) any {
+	token := os.Getenv("HOTPLEX_SLACK_BOT_TOKEN")
+	if token == "" {
+		return nil
+	}
+
+	mode := os.Getenv("HOTPLEX_SLACK_MODE")
+	if mode == "" {
+		mode = "http"
+	}
+	config := &Config{
+		BotToken:      token,
+		AppToken:      os.Getenv("HOTPLEX_SLACK_APP_TOKEN"),
+		SigningSecret: os.Getenv("HOTPLEX_SLACK_SIGNING_SECRET"),
+		Mode:          mode,
+		ServerAddr:    os.Getenv("HOTPLEX_SLACK_SERVER_ADDR"),
+	}
+
+	if pc != nil {
+		config.SystemPrompt = pc.SystemPrompt
+		config.BotUserID = pc.Security.Permission.BotUserID
+		config.VerifySignature = pc.Security.VerifySignature
+		config.DMPolicy = pc.Security.Permission.DMPolicy
+		config.GroupPolicy = pc.Security.Permission.GroupPolicy
+		config.AllowedUsers = pc.Security.Permission.AllowedUsers
+		config.BlockedUsers = pc.Security.Permission.BlockedUsers
+		config.SlashCommandRateLimit = pc.Security.Permission.SlashCommandRateLimit
+
+		if pc.Security.Owner != nil {
+			config.Owner = &OwnerConfig{
+				Primary: pc.Security.Owner.Primary,
+				Trusted: pc.Security.Owner.Trusted,
+				Policy:  OwnerPolicy(pc.Security.Owner.Policy),
+			}
+		}
+
+		if pc.Security.Permission.ThreadOwnership != nil {
+			config.ThreadOwnership = &ThreadOwnershipConfig{
+				Enabled: pc.Security.Permission.ThreadOwnership.Enabled,
+				TTL:     pc.Security.Permission.ThreadOwnership.TTL,
+				Persist: pc.Security.Permission.ThreadOwnership.Persist,
+			}
+		}
+
+		config.Features = FeaturesConfig{
+			Chunking: ChunkingConfig{
+				Enabled:  pc.Features.Chunking.Enabled,
+				MaxChars: pc.Features.Chunking.MaxChars,
+			},
+			Threading: ThreadingConfig{
+				Enabled: pc.Features.Threading.Enabled,
+			},
+			RateLimit: RateLimitConfig{
+				Enabled:     pc.Features.RateLimit.Enabled,
+				MaxAttempts: pc.Features.RateLimit.MaxAttempts,
+				BaseDelayMs: pc.Features.RateLimit.BaseDelayMs,
+				MaxDelayMs:  pc.Features.RateLimit.MaxDelayMs,
+			},
+			Markdown: MarkdownConfig{
+				Enabled: pc.Features.Markdown.Enabled,
+			},
+		}
+
+		if pc.MessageStore.Enabled != nil {
+			config.Storage = &StorageConfig{
+				Enabled:       pc.MessageStore.Enabled,
+				Type:          pc.MessageStore.Type,
+				SQLitePath:    pc.MessageStore.SQLite.Path,
+				PostgreSQLURL: pc.MessageStore.Postgres.DSN,
+				StreamEnabled: pc.MessageStore.Streaming.Enabled,
+				StreamTimeout: pc.MessageStore.Streaming.Timeout,
+			}
+		}
+
+		config.SetBroadcastResponse(pc.Security.Permission.BroadcastResponse)
+
+		if config.AppToken == "" && pc.Options != nil {
+			if appToken, ok := pc.Options["app_token"].(string); ok {
+				config.AppToken = os.ExpandEnv(appToken)
+			}
+		}
+
+		if pc.Mode != "" {
+			config.Mode = pc.Mode
+		}
+	}
+
+	var opts []base.AdapterOption
+	if pc != nil {
+		opts = append(opts, base.WithSessionTimeout(pc.Session.Timeout))
+		opts = append(opts, base.WithCleanupInterval(pc.Session.CleanupInterval))
+	}
+	opts = append(opts, base.WithoutServer())
+	return NewAdapter(config, slog.Default(), opts...)
+}
+
+// PostSetup implements AdapterFactory — sets up AppHome capability center.
+func (f *AdapterFactory) PostSetup(_ context.Context, adapter, setupCtx any) {
+	ctx, ok := setupCtx.(*base.SetupContext)
+	if !ok || ctx == nil || ctx.Logger == nil {
+		return
+	}
+	logger := ctx.Logger
+
+	slackAdapter, ok := adapter.(*Adapter)
+	if !ok {
+		logger.Debug("PostSetup: adapter is not a Slack Adapter")
+		return
+	}
+
+	client := slackAdapter.GetSlackClient()
+	if client == nil {
+		logger.Debug("PostSetup: Slack client not available yet")
+		return
+	}
+
+	appHomeConfig := apphome.Config{
+		Enabled:          true,
+		CapabilitiesPath: os.Getenv("HOTPLEX_SLACK_CAPABILITIES_PATH"),
+	}
+
+	handler, _, _ := apphome.Setup(client, nil, appHomeConfig, logger)
+	if handler != nil {
+		slackAdapter.SetAppHomeHandler(handler)
+		logger.Info("AppHome capability center initialized", "platform", "slack")
+	}
+}
+
+func init() {
+	base.GlobalAdapterRegistry().Register(&AdapterFactory{})
+}

--- a/chatapps/slack/messages.go
+++ b/chatapps/slack/messages.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/chatapps/base"
-	"github.com/hrygo/hotplex/types"
 	"github.com/slack-go/slack"
 )
 
@@ -35,11 +34,9 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 		return fmt.Errorf("channel_id not found in session")
 	}
 
-	threadTS := ""
-	if msg.Metadata != nil {
-		if ts, ok := msg.Metadata["thread_ts"].(string); ok {
-			threadTS = ts
-		}
+	threadTS := base.GetMetadataString(msg.Metadata, base.KeyThreadID)
+	if threadTS == "" {
+		threadTS = base.GetMetadataString(msg.Metadata, "thread_ts") // Backward compat
 	}
 
 	// Check if this is a message update (has message_ts in metadata)
@@ -88,7 +85,7 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 				err := a.UpdateMessageSDK(ctx, channelID, messageTS, blocks, fallbackText)
 				if err == nil {
 					// Store bot response for final responses
-					if types.MessageType(msg.Type).IsStorable() {
+					if msg.Type.IsStorable() {
 						a.storeBotResponse(ctx, sessionID, channelID, threadTS, fallbackText)
 					}
 					return nil
@@ -107,7 +104,7 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 			}
 
 			// Store bot response for final responses
-			if types.MessageType(msg.Type).IsStorable() {
+			if msg.Type.IsStorable() {
 				a.storeBotResponse(ctx, sessionID, channelID, threadTS, fallbackText)
 			}
 			return nil
@@ -116,7 +113,7 @@ func (a *Adapter) defaultSender(ctx context.Context, sessionID string, msg *base
 
 	// Store bot response for plain text messages
 	err := a.SendToChannelSDK(ctx, channelID, msg.Content, threadTS)
-	if err == nil && types.MessageType(msg.Type).IsStorable() {
+	if err == nil && msg.Type.IsStorable() {
 		// Only store if message type is storable (user_input or final_response)
 		a.storeBotResponse(ctx, sessionID, channelID, threadTS, msg.Content)
 	}

--- a/cmd/bridge-client/README.md
+++ b/cmd/bridge-client/README.md
@@ -1,0 +1,186 @@
+# BridgeClient SDK
+
+Go SDK for connecting external platform adapters to HotPlex via the BridgeServer WebSocket gateway.
+
+## What is this?
+
+HotPlex's **BridgeServer** (`internal/server/bridge.go`) is a WebSocket gateway that allows external platform adapters (DingTalk, WeChat, Feishu, etc.) to connect to HotPlex without being compiled into the same binary. **BridgeClient** is the SDK that adapter developers use to connect.
+
+```
+External Adapter (your DingTalk bot) ──BridgeClient──WebSocket──> BridgeServer
+                                                                          │
+                                                                          ▼
+                                                                  HotPlex Engine
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "os"
+
+    "github.com/hrygo/hotplex/cmd/bridge-client"
+)
+
+func main() {
+    client, err := bridgeclient.New(
+        bridgeclient.URL("wss://hotplex.internal/bridge"),
+        bridgeclient.Platform("dingtalk"),
+        bridgeclient.AuthToken(os.Getenv("HOTPLEX_BRIDGE_TOKEN")),
+        bridgeclient.Capabilities(
+            bridgeclient.CapText,
+            bridgeclient.CapCard,
+            bridgeclient.CapButtons,
+            bridgeclient.CapTyping,
+        ),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    client.OnMessage(func(msg *bridgeclient.Message) *bridgeclient.Reply {
+        log.Printf("session=%s user=%s: %s",
+            msg.SessionKey, msg.Metadata.UserID, msg.Content)
+
+        return &bridgeclient.Reply{
+            Content:    "Hello from your DingTalk bot!",
+            SessionKey: msg.SessionKey,
+        }
+    })
+
+    ctx := context.Background()
+    if err := client.Connect(ctx); err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+
+    <-ctx.Done()
+}
+```
+
+## Configuration
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `URL` | Yes | BridgeServer WebSocket URL (e.g., `ws://localhost:8080/bridge`) |
+| `Platform` | Yes | Platform identifier (e.g., `dingtalk`, `wechat`, `lark`) |
+| `AuthToken` | Yes | Token matching `bridge_token` in HotPlex config |
+| `Capabilities` | No | Defaults to `[CapText]` if not set |
+
+## Capabilities
+
+Declare what your adapter supports when connecting:
+
+| Constant | Description |
+|----------|-------------|
+| `CapText` | Plain text messages |
+| `CapImage` | Image uploads |
+| `CapCard` | Rich card messages |
+| `CapButtons` | Interactive buttons |
+| `CapTyping` | Typing indicators |
+| `CapEdit` | Edit sent messages |
+| `CapDelete` | Delete sent messages |
+| `CapReact` | Emoji reactions |
+| `CapThread` | Thread/reply support |
+
+## Message Flow
+
+### Inbound (HotPlex → Your Adapter)
+
+HotPlex sends user messages to your adapter via the `OnMessage` handler:
+
+```go
+client.OnMessage(func(msg *bridgeclient.Message) *bridgeclient.Reply {
+    // msg.SessionKey  — Session identifier (pass back in Reply)
+    // msg.Content     — Message text
+    // msg.Metadata.UserID   — User identity
+    // msg.Metadata.RoomID   — Room/channel identity
+    // msg.Metadata.ThreadID — Thread/thread_ts identity
+    // msg.Metadata.Platform — Always "hotplex"
+
+    reply := yourAI.Process(msg.Content)
+    return &bridgeclient.Reply{
+        Content:    reply.Text,
+        SessionKey: msg.SessionKey,
+    }
+})
+```
+
+### Events (HotPlex → Your Adapter)
+
+HotPlex can also send events (e.g., `typing`, `stream_start`, `stream_end`):
+
+```go
+client.OnEvent(func(evt *bridgeclient.Event) {
+    switch evt.Event {
+    case "typing":
+        // Show typing indicator in DingTalk UI
+    case "stream_end":
+        // Final message chunk received
+    }
+})
+```
+
+### Outbound (Your Adapter → HotPlex)
+
+If HotPlex needs to receive messages initiated by your adapter (e.g., a DingTalk
+outbound webhook triggered by an external event):
+
+```go
+err := client.SendMessage(ctx, &bridgeclient.Message{
+    SessionKey: "session-from-dingtalk",
+    Content:    "Outbound DingTalk message received",
+    Metadata: bridgeclient.Metadata{
+        UserID: "openid-xxx",
+        RoomID: "chatid-yyy",
+    },
+})
+```
+
+## Running the Example
+
+```bash
+# 1. Start HotPlex with bridge enabled
+# In your config.yaml or .env:
+#   bridge_port=8080
+#   bridge_token=secret
+
+# 2. Run the example DingTalk adapter
+cd cmd/bridge-client/example
+go run main.go
+```
+
+## Bridge Wire Protocol
+
+The SDK implements the Bridge Wire Protocol — a JSON envelope over WebSocket:
+
+| Direction | Type | Description |
+|-----------|------|-------------|
+| Client → Server | `register` | Handshake: platform name + capabilities |
+| Server → Client | `message` | Inbound message from HotPlex engine |
+| Client → Server | `reply` | Response to a message |
+| Server → Client | `event` | Engine events (typing, stream, etc.) |
+| Either | `error` | Protocol errors |
+
+See `internal/server/bridge.go` for the full protocol specification.
+
+## HotPlex Configuration
+
+Enable BridgeServer in your `config.yaml`:
+
+```yaml
+server:
+  bridge_port: "8080"    # Separate HTTP server for bridge adapters
+  bridge_token: "secret" # Token adapters must present
+```
+
+Or via environment variables:
+
+```bash
+HOTPLEX_BRIDGE_PORT=8080
+HOTPLEX_BRIDGE_TOKEN=secret
+```

--- a/cmd/bridge-client/client.go
+++ b/cmd/bridge-client/client.go
@@ -469,8 +469,8 @@ func (c *Client) closeConn() error {
 	}
 
 	// Send close frame; don't block
-	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
-	conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
 	return conn.Close()
 }

--- a/cmd/bridge-client/client.go
+++ b/cmd/bridge-client/client.go
@@ -176,6 +176,10 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("bridgeclient dial: %w", err)
 	}
 
+	c.mu.Lock()
+	c.done = make(chan struct{})
+	c.mu.Unlock()
+
 	if err := c.register(); err != nil {
 		c.closeConn()
 		return fmt.Errorf("bridgeclient register: %w", err)
@@ -230,7 +234,9 @@ func (c *Client) Close() error {
 		return nil
 	}
 	c.closed = true
-	close(c.done)
+	if c.done != nil {
+		close(c.done)
+	}
 	c.mu.Unlock()
 
 	return c.closeConn()

--- a/cmd/bridge-client/client.go
+++ b/cmd/bridge-client/client.go
@@ -40,60 +40,34 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/hrygo/hotplex/internal/bridgewire"
 )
 
-// =============================================================================
-// Capability Constants
-// =============================================================================
-
-// Capabilities that an adapter can declare when registering with BridgeServer.
+// Cap* aliases for the public API (mirrors bridgewire constants).
 const (
-	CapText    = "text"
-	CapImage   = "image"
-	CapCard    = "card"
-	CapButtons = "buttons"
-	CapTyping  = "typing"
-	CapEdit    = "edit"
-	CapDelete  = "delete"
-	CapReact   = "react"
-	CapThread  = "thread"
+	CapText    = bridgewire.CapText
+	CapImage   = bridgewire.CapImage
+	CapCard    = bridgewire.CapCard
+	CapButtons = bridgewire.CapButtons
+	CapTyping  = bridgewire.CapTyping
+	CapEdit    = bridgewire.CapEdit
+	CapDelete  = bridgewire.CapDelete
+	CapReact   = bridgewire.CapReact
+	CapThread  = bridgewire.CapThread
 )
 
-// =============================================================================
-// Wire Protocol Types
-// =============================================================================
-
-// msgType constants (matches internal/server/bridge.go).
+// msgType aliases (mirrors bridgewire constants, for internal use).
 const (
-	msgTypeRegister = "register"
-	msgTypeMessage  = "message"
-	msgTypeReply    = "reply"
-	msgTypeEvent    = "event"
-	msgTypeError    = "error"
+	msgTypeRegister = bridgewire.MsgTypeRegister
+	msgTypeMessage  = bridgewire.MsgTypeMessage
+	msgTypeReply    = bridgewire.MsgTypeReply
+	msgTypeEvent    = bridgewire.MsgTypeEvent
+	msgTypeError    = bridgewire.MsgTypeError
 )
 
-// wireMessage is the bidirectional JSON envelope for Bridge Wire Protocol.
-type wireMessage struct {
-	Type         string          `json:"type"`
-	Platform     string          `json:"platform,omitempty"`
-	Token        string          `json:"token,omitempty"`
-	SessionKey   string          `json:"session_key,omitempty"`
-	Content      string          `json:"content,omitempty"`
-	Metadata     json.RawMessage `json:"metadata,omitempty"`
-	Event        string          `json:"event,omitempty"`
-	Data         json.RawMessage `json:"data,omitempty"`
-	Code         int             `json:"code,omitempty"`
-	Message      string          `json:"message,omitempty"`
-	Capabilities []string        `json:"capabilities,omitempty"`
-}
-
-// metadata carries user/room/thread identity inside a WireMessage.
-type metadata struct {
-	UserID   string `json:"user_id,omitempty"`
-	RoomID   string `json:"room_id,omitempty"`
-	ThreadID string `json:"thread_id,omitempty"`
-	Platform string `json:"platform,omitempty"`
-}
+// wireMessage and metadata are type aliases to the shared bridgewire types.
+type wireMessage = bridgewire.WireMessage
+type metadata    = bridgewire.WireMetadata
 
 // =============================================================================
 // Public Types

--- a/cmd/bridge-client/client.go
+++ b/cmd/bridge-client/client.go
@@ -1,0 +1,482 @@
+// Package bridgeclient provides a Go SDK for connecting external platform adapters
+// to HotPlex via the BridgeServer WebSocket gateway.
+//
+// Usage:
+//
+//	client := bridgeclient.New(
+//		bridgeclient.URL("wss://hotplex.internal:8080/bridge"),
+//		bridgeclient.Platform("dingtalk"),
+//		bridgeclient.Capabilities(bridgeclient.CapText, bridgeclient.CapCard),
+//		bridgeclient.AuthToken(os.Getenv("HOTPLEX_BRIDGE_TOKEN")),
+//	)
+//
+//	client.OnMessage(func(msg *bridgeclient.Message) *bridgeclient.Reply {
+//		// Process msg.Content, msg.SessionKey, msg.Metadata
+//		return &bridgeclient.Reply{
+//			Content:    "Hello from DingTalk!",
+//			SessionKey: msg.SessionKey,
+//		}
+//	})
+//
+//	ctx := context.Background()
+//	if err := client.Connect(ctx); err != nil {
+//		log.Fatal(err)
+//	}
+//	defer client.Close()
+//
+//	// Block until disconnected
+//	<-ctx.Done()
+package bridgeclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// =============================================================================
+// Capability Constants
+// =============================================================================
+
+// Capabilities that an adapter can declare when registering with BridgeServer.
+const (
+	CapText    = "text"
+	CapImage   = "image"
+	CapCard    = "card"
+	CapButtons = "buttons"
+	CapTyping  = "typing"
+	CapEdit    = "edit"
+	CapDelete  = "delete"
+	CapReact   = "react"
+	CapThread  = "thread"
+)
+
+// =============================================================================
+// Wire Protocol Types
+// =============================================================================
+
+// msgType constants (matches internal/server/bridge.go).
+const (
+	msgTypeRegister = "register"
+	msgTypeMessage  = "message"
+	msgTypeReply    = "reply"
+	msgTypeEvent    = "event"
+	msgTypeError    = "error"
+)
+
+// wireMessage is the bidirectional JSON envelope for Bridge Wire Protocol.
+type wireMessage struct {
+	Type         string          `json:"type"`
+	Platform     string          `json:"platform,omitempty"`
+	Token        string          `json:"token,omitempty"`
+	SessionKey   string          `json:"session_key,omitempty"`
+	Content      string          `json:"content,omitempty"`
+	Metadata     json.RawMessage `json:"metadata,omitempty"`
+	Event        string          `json:"event,omitempty"`
+	Data         json.RawMessage `json:"data,omitempty"`
+	Code         int             `json:"code,omitempty"`
+	Message      string          `json:"message,omitempty"`
+	Capabilities []string        `json:"capabilities,omitempty"`
+}
+
+// metadata carries user/room/thread identity inside a WireMessage.
+type metadata struct {
+	UserID   string `json:"user_id,omitempty"`
+	RoomID   string `json:"room_id,omitempty"`
+	ThreadID string `json:"thread_id,omitempty"`
+	Platform string `json:"platform,omitempty"`
+}
+
+// =============================================================================
+// Public Types
+// =============================================================================
+
+// Message represents an inbound message from HotPlex (server → client).
+type Message struct {
+	SessionKey string
+	Content    string
+	Metadata   Metadata
+	raw        *wireMessage
+}
+
+// Metadata holds message identity fields.
+type Metadata struct {
+	UserID   string
+	RoomID   string
+	ThreadID string
+	Platform string
+}
+
+// Reply is returned by a MessageHandler to send a response back to HotPlex.
+type Reply struct {
+	Content    string
+	SessionKey string
+	Metadata   Metadata
+}
+
+// Event represents an inbound event from HotPlex (server → client).
+// Common events: "stream_start", "stream_chunk", "stream_end", "typing_start", "typing_end".
+type Event struct {
+	Event   string
+	Data    json.RawMessage
+	raw     *wireMessage
+}
+
+// Error represents an error message from HotPlex (server → client).
+type Error struct {
+	Code    int
+	Message string
+}
+
+// MessageHandler processes inbound messages from HotPlex and optionally returns a reply.
+type MessageHandler func(msg *Message) *Reply
+
+// EventHandler processes inbound events from HotPlex.
+type EventHandler func(evt *Event)
+
+// =============================================================================
+// Client
+// =============================================================================
+
+// Client is a BridgeClient that connects to HotPlex BridgeServer as a WebSocket client.
+type Client struct {
+	url        string
+	platform   string
+	token      string
+	caps       []string
+	logger     *slog.Logger
+	httpClient *http.Client
+
+	msgHandler  MessageHandler
+	eventHandler EventHandler
+
+	conn   *websocket.Conn
+	done   chan struct{}
+	closed bool
+	mu     sync.RWMutex
+
+	// for dialing
+	dialer websocket.Dialer
+}
+
+// New creates a new BridgeClient with the given options.
+func New(opts ...Option) (*Client, error) {
+	c := &Client{
+		logger: slog.Default(),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		dialer: websocket.Dialer{
+			HandshakeTimeout: 10 * time.Second,
+		},
+		caps: []string{CapText}, // default capability
+	}
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+	if c.url == "" {
+		return nil, errors.New("bridgeclient: URL is required")
+	}
+	if c.platform == "" {
+		return nil, errors.New("bridgeclient: platform name is required")
+	}
+	return c, nil
+}
+
+// Connect establishes a WebSocket connection to BridgeServer, performs the
+// register handshake, and starts background goroutines to handle incoming
+// messages and events. It blocks until the context is cancelled or a fatal
+// error occurs.
+func (c *Client) Connect(ctx context.Context) error {
+	if err := c.dial(ctx); err != nil {
+		return fmt.Errorf("bridgeclient dial: %w", err)
+	}
+
+	if err := c.register(); err != nil {
+		c.closeConn()
+		return fmt.Errorf("bridgeclient register: %w", err)
+	}
+
+	go c.readLoop()
+	return nil
+}
+
+// SendMessage sends a message from the external platform to HotPlex.
+// This is used for inbound messages (e.g., a user sends a DM on DingTalk).
+func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
+	meta := metadata{
+		UserID:   msg.Metadata.UserID,
+		RoomID:   msg.Metadata.RoomID,
+		ThreadID: msg.Metadata.ThreadID,
+		Platform: c.platform,
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+
+	wm := wireMessage{
+		Type:       msgTypeMessage,
+		Platform:   c.platform,
+		SessionKey: msg.SessionKey,
+		Content:    msg.Content,
+		Metadata:   metaBytes,
+	}
+	return c.writeJSON(ctx, wm)
+}
+
+// Typing sends a typing indicator to HotPlex.
+func (c *Client) Typing(ctx context.Context, sessionKey string) error {
+	metaBytes, _ := json.Marshal(metadata{Platform: c.platform})
+	evt := wireMessage{
+		Type:     msgTypeEvent,
+		Platform: c.platform,
+		Event:    "typing",
+		SessionKey: sessionKey,
+		Data:     metaBytes,
+	}
+	return c.writeJSON(ctx, evt)
+}
+
+// Close gracefully shuts down the client connection.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	close(c.done)
+	c.mu.Unlock()
+
+	return c.closeConn()
+}
+
+// OnMessage registers a handler for inbound messages from HotPlex.
+// Only one handler can be registered; subsequent calls replace the previous one.
+func (c *Client) OnMessage(h MessageHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgHandler = h
+}
+
+// OnEvent registers a handler for inbound events from HotPlex.
+// Only one handler can be registered; subsequent calls replace the previous one.
+func (c *Client) OnEvent(h EventHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.eventHandler = h
+}
+
+// =============================================================================
+// Internal
+// =============================================================================
+
+func (c *Client) dial(ctx context.Context) error {
+	u, err := url.Parse(c.url)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	q := u.Query()
+	if c.token != "" {
+		q.Set("token", c.token)
+	}
+	u.RawQuery = q.Encode()
+
+	conn, _, err := c.dialer.DialContext(ctx, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", u.Redacted(), err)
+	}
+	c.conn = conn
+	return nil
+}
+
+func (c *Client) register() error {
+	c.mu.RLock()
+	caps := c.caps
+	c.mu.RUnlock()
+
+	wm := wireMessage{
+		Type:         msgTypeRegister,
+		Platform:     c.platform,
+		Capabilities: caps,
+	}
+	if c.token != "" {
+		wm.Token = c.token
+	}
+	return c.writeJSON(context.Background(), wm)
+}
+
+func (c *Client) writeJSON(ctx context.Context, wm wireMessage) error {
+	c.mu.RLock()
+	conn := c.conn
+	closed := c.closed
+	c.mu.RUnlock()
+
+	if conn == nil || closed {
+		return errors.New("bridgeclient: not connected")
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- conn.WriteJSON(wm)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errChan:
+		if err != nil {
+			return fmt.Errorf("write json: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) readLoop() {
+	defer c.cleanup()
+
+	for {
+		var wm wireMessage
+		err := c.conn.ReadJSON(&wm)
+		if err != nil {
+			if !c.isClosed() {
+				c.logger.Debug("bridge read error", "error", err)
+			}
+			return
+		}
+		c.handleMessage(&wm)
+	}
+}
+
+func (c *Client) handleMessage(wm *wireMessage) {
+	switch wm.Type {
+	case msgTypeMessage:
+		c.handleInboundMessage(wm)
+	case msgTypeEvent:
+		c.handleInboundEvent(wm)
+	case msgTypeError:
+		c.handleError(wm)
+	default:
+		c.logger.Debug("unknown wire message type", "type", wm.Type)
+	}
+}
+
+func (c *Client) handleInboundMessage(wm *wireMessage) {
+	meta := Metadata{Platform: "hotplex"}
+	if len(wm.Metadata) > 0 {
+		var m metadata
+		if err := json.Unmarshal(wm.Metadata, &m); err != nil {
+			c.logger.Debug("unmarshal metadata", "error", err)
+		} else {
+			meta = Metadata{
+				UserID:   m.UserID,
+				RoomID:   m.RoomID,
+				ThreadID: m.ThreadID,
+				Platform: m.Platform,
+			}
+		}
+	}
+
+	msg := &Message{
+		SessionKey: wm.SessionKey,
+		Content:    wm.Content,
+		Metadata:   meta,
+		raw:        wm,
+	}
+
+	c.mu.RLock()
+	handler := c.msgHandler
+	c.mu.RUnlock()
+
+	if handler == nil {
+		return
+	}
+	reply := handler(msg)
+	if reply == nil {
+		return
+	}
+
+	c.sendReply(reply)
+}
+
+func (c *Client) handleInboundEvent(wm *wireMessage) {
+	evt := &Event{
+		Event: wm.Event,
+		Data:  wm.Data,
+		raw:   wm,
+	}
+
+	c.mu.RLock()
+	handler := c.eventHandler
+	c.mu.RUnlock()
+
+	if handler != nil {
+		handler(evt)
+	}
+}
+
+func (c *Client) handleError(wm *wireMessage) {
+	c.logger.Error("bridge error",
+		"code", wm.Code,
+		"message", wm.Message,
+	)
+}
+
+func (c *Client) sendReply(reply *Reply) {
+	metaBytes, _ := json.Marshal(metadata{
+		Platform: c.platform,
+		UserID:   reply.Metadata.UserID,
+		RoomID:   reply.Metadata.RoomID,
+		ThreadID: reply.Metadata.ThreadID,
+	})
+	wm := wireMessage{
+		Type:       msgTypeReply,
+		Platform:   c.platform,
+		SessionKey: reply.SessionKey,
+		Content:    reply.Content,
+		Metadata:   metaBytes,
+	}
+	// Best-effort; don't block on reply failure
+	go func() {
+		if err := c.writeJSON(context.Background(), wm); err != nil {
+			c.logger.Debug("send reply failed", "error", err)
+		}
+	}()
+}
+
+func (c *Client) cleanup() {
+	c.Close()
+}
+
+func (c *Client) closeConn() error {
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+
+	if conn == nil {
+		return nil
+	}
+
+	// Send close frame; don't block
+	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+
+	return conn.Close()
+}
+
+func (c *Client) isClosed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.closed
+}

--- a/cmd/bridge-client/client.go
+++ b/cmd/bridge-client/client.go
@@ -181,7 +181,9 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.mu.Unlock()
 
 	if err := c.register(); err != nil {
-		c.closeConn()
+		if closeErr := c.closeConn(); closeErr != nil {
+			c.logger.Warn("Failed to close connection after register error", "error", closeErr)
+		}
 		return fmt.Errorf("bridgeclient register: %w", err)
 	}
 
@@ -436,7 +438,7 @@ func (c *Client) sendReply(reply *Reply) {
 }
 
 func (c *Client) cleanup() {
-	c.Close()
+	_ = c.Close()
 }
 
 func (c *Client) closeConn() error {

--- a/cmd/bridge-client/client_integration_test.go
+++ b/cmd/bridge-client/client_integration_test.go
@@ -29,12 +29,12 @@ func wsEchoServer(t *testing.T) (*httptest.Server, *sync.Mutex, map[string]int, 
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		// Send inbound messages
 		go func() {
 			for wm := range inbound {
-				conn.WriteJSON(wm)
+				_ = conn.WriteJSON(wm)
 			}
 		}()
 
@@ -50,9 +50,9 @@ func wsEchoServer(t *testing.T) (*httptest.Server, *sync.Mutex, map[string]int, 
 			// Echo back as reply
 			switch wm.Type {
 			case msgTypeRegister:
-				conn.WriteJSON(wireMessage{Type: msgTypeReply, Content: "registered"})
+				_ = conn.WriteJSON(wireMessage{Type: msgTypeReply, Content: "registered"})
 			case msgTypeMessage:
-				conn.WriteJSON(wireMessage{
+				_ = conn.WriteJSON(wireMessage{
 					Type:       msgTypeMessage,
 					SessionKey: wm.SessionKey,
 					Content:    "echo: " + wm.Content,
@@ -93,7 +93,7 @@ func TestClientConnectAndRegister(t *testing.T) {
 	cancel()
 	time.Sleep(50 * time.Millisecond)
 
-	client.Close()
+	_ = client.Close()
 }
 
 func TestClientSendMessage(t *testing.T) {

--- a/cmd/bridge-client/client_integration_test.go
+++ b/cmd/bridge-client/client_integration_test.go
@@ -1,0 +1,314 @@
+package bridgeclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsEchoServer is a test WebSocket server that echoes messages back and sends inbound messages.
+func wsEchoServer(t *testing.T) (*httptest.Server, *sync.Mutex, map[string]int, chan wireMessage) {
+	t.Helper()
+	var mu sync.Mutex
+	msgCounts := make(map[string]int)
+	inbound := make(chan wireMessage, 10)
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Send inbound messages
+		go func() {
+			for wm := range inbound {
+				conn.WriteJSON(wm)
+			}
+		}()
+
+		for {
+			var wm wireMessage
+			if err := conn.ReadJSON(&wm); err != nil {
+				return
+			}
+			mu.Lock()
+			msgCounts[wm.Type]++
+			mu.Unlock()
+
+			// Echo back as reply
+			switch wm.Type {
+			case msgTypeRegister:
+				conn.WriteJSON(wireMessage{Type: msgTypeReply, Content: "registered"})
+			case msgTypeMessage:
+				conn.WriteJSON(wireMessage{
+					Type:       msgTypeMessage,
+					SessionKey: wm.SessionKey,
+					Content:    "echo: " + wm.Content,
+				})
+			}
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(handler)), &mu, msgCounts, inbound
+}
+
+func TestClientConnectAndRegister(t *testing.T) {
+	server, _, _, inbound := wsEchoServer(t)
+	defer server.Close()
+	defer close(inbound)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, err := New(
+		URL(wsURL),
+		Platform("test"),
+		Capabilities(CapText),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	// Give time for register to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel context to stop readLoop
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	client.Close()
+}
+
+func TestClientSendMessage(t *testing.T) {
+	server, mu, counts, inbound := wsEchoServer(t)
+	defer server.Close()
+	defer close(inbound)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, err := New(
+		URL(wsURL),
+		Platform("test"),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	msg := &Message{
+		SessionKey: "test-session",
+		Content:    "hello",
+		Metadata:   Metadata{UserID: "u1"},
+	}
+	if err := client.SendMessage(ctx, msg); err != nil {
+		t.Errorf("SendMessage() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := counts[msgTypeMessage]
+	mu.Unlock()
+
+	if count < 1 {
+		t.Errorf("expected at least 1 message sent, got %d", count)
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	client.Close()
+}
+
+func TestClientOnMessageHandler(t *testing.T) {
+	server, _, _, inbound := wsEchoServer(t)
+	defer server.Close()
+	defer close(inbound)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, err := New(URL(wsURL), Platform("test"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	received := make(chan *Message, 1)
+	client.OnMessage(func(msg *Message) *Reply {
+		received <- msg
+		return &Reply{Content: "ack", SessionKey: msg.SessionKey}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Send an inbound message from server to client
+	inbound <- wireMessage{
+		Type:       msgTypeMessage,
+		SessionKey: "test-session",
+		Content:    "hello from server",
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Content != "hello from server" {
+			t.Errorf("expected 'hello from server', got %q", msg.Content)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Error("timeout waiting for message")
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	client.Close()
+}
+
+func TestClientTyping(t *testing.T) {
+	server, mu, counts, inbound := wsEchoServer(t)
+	defer server.Close()
+	defer close(inbound)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, err := New(URL(wsURL), Platform("test"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := client.Typing(ctx, "test-session"); err != nil {
+		t.Errorf("Typing() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := counts[msgTypeEvent]
+	mu.Unlock()
+
+	if count < 1 {
+		t.Errorf("expected at least 1 event sent, got %d", count)
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	client.Close()
+}
+
+func TestClientClose(t *testing.T) {
+	server, _, _, inbound := wsEchoServer(t)
+	defer server.Close()
+	defer close(inbound)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, err := New(URL(wsURL), Platform("test"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+
+	// Second close should be no-op
+	if err := client.Close(); err != nil {
+		t.Errorf("second Close() error = %v", err)
+	}
+}
+
+func TestClientNotConnected(t *testing.T) {
+	client, err := New(URL("ws://localhost:1"), Platform("test"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	msg := &Message{SessionKey: "s1", Content: "test"}
+
+	err = client.SendMessage(ctx, msg)
+	if err == nil {
+		t.Error("SendMessage() on unconnected client: want error, got nil")
+	}
+}
+
+func TestReplySerialization(t *testing.T) {
+	reply := &Reply{
+		Content:    "response",
+		SessionKey: "sess-123",
+		Metadata:   Metadata{ThreadID: "t1"},
+	}
+
+	metaBytes, _ := json.Marshal(metadata{
+		Platform: "test",
+		ThreadID: reply.Metadata.ThreadID,
+	})
+	wm := wireMessage{
+		Type:       msgTypeReply,
+		Platform:   "test",
+		SessionKey: reply.SessionKey,
+		Content:    reply.Content,
+		Metadata:   metaBytes,
+	}
+
+	bytes, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got wireMessage
+	if err := json.Unmarshal(bytes, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Type != msgTypeReply {
+		t.Errorf("Type = %q, want %q", got.Type, msgTypeReply)
+	}
+	if got.SessionKey != reply.SessionKey {
+		t.Errorf("SessionKey = %q, want %q", got.SessionKey, reply.SessionKey)
+	}
+}

--- a/cmd/bridge-client/client_integration_test.go
+++ b/cmd/bridge-client/client_integration_test.go
@@ -140,7 +140,7 @@ func TestClientSendMessage(t *testing.T) {
 
 	cancel()
 	time.Sleep(50 * time.Millisecond)
-	client.Close()
+	_ = client.Close()
 }
 
 func TestClientOnMessageHandler(t *testing.T) {
@@ -187,7 +187,7 @@ func TestClientOnMessageHandler(t *testing.T) {
 
 	cancel()
 	time.Sleep(50 * time.Millisecond)
-	client.Close()
+	_ = client.Close()
 }
 
 func TestClientTyping(t *testing.T) {
@@ -226,7 +226,7 @@ func TestClientTyping(t *testing.T) {
 
 	cancel()
 	time.Sleep(50 * time.Millisecond)
-	client.Close()
+	_ = client.Close()
 }
 
 func TestClientClose(t *testing.T) {

--- a/cmd/bridge-client/client_integration_test.go
+++ b/cmd/bridge-client/client_integration_test.go
@@ -265,7 +265,7 @@ func TestClientNotConnected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
 	msg := &Message{SessionKey: "s1", Content: "test"}

--- a/cmd/bridge-client/client_test.go
+++ b/cmd/bridge-client/client_test.go
@@ -1,0 +1,205 @@
+package bridgeclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCapabilities(t *testing.T) {
+	tests := []struct {
+		name  string
+		caps  []string
+		check func([]string) bool
+	}{
+		{"CapText", []string{CapText}, func(c []string) bool { return len(c) == 1 && c[0] == "text" }},
+		{"CapImage", []string{CapImage}, func(c []string) bool { return len(c) == 1 && c[0] == "image" }},
+		{"CapCard", []string{CapCard}, func(c []string) bool { return len(c) == 1 && c[0] == "card" }},
+		{"AllCaps", []string{CapText, CapImage, CapCard, CapButtons, CapTyping, CapEdit, CapDelete, CapReact, CapThread},
+			func(c []string) bool { return len(c) == 9 }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.check(tt.caps) {
+				t.Errorf("capabilities = %v", tt.caps)
+			}
+		})
+	}
+}
+
+func TestMessageRoundTrip(t *testing.T) {
+	meta := Metadata{UserID: "u123", RoomID: "r456", ThreadID: "t789", Platform: "dingtalk"}
+	msg := &Message{
+		SessionKey: "sess-abc",
+		Content:    "Hello from DingTalk!",
+		Metadata:   meta,
+	}
+
+	// Simulate what SendMessage does: marshal metadata
+	metaBytes, err := json.Marshal(metadata{
+		UserID:   msg.Metadata.UserID,
+		RoomID:   msg.Metadata.RoomID,
+		ThreadID: msg.Metadata.ThreadID,
+		Platform: "dingtalk",
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	wm := wireMessage{
+		Type:       msgTypeMessage,
+		Platform:   "dingtalk",
+		SessionKey: msg.SessionKey,
+		Content:    msg.Content,
+		Metadata:   metaBytes,
+	}
+
+	// Marshal the wire message (as it would travel over WebSocket)
+	bytes, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal wire message: %v", err)
+	}
+
+	// Unmarshal to verify round-trip
+	var got wireMessage
+	if err := json.Unmarshal(bytes, &got); err != nil {
+		t.Fatalf("unmarshal wire message: %v", err)
+	}
+
+	if got.Type != msgTypeMessage {
+		t.Errorf("Type = %q, want %q", got.Type, msgTypeMessage)
+	}
+	if got.SessionKey != msg.SessionKey {
+		t.Errorf("SessionKey = %q, want %q", got.SessionKey, msg.SessionKey)
+	}
+	if got.Content != msg.Content {
+		t.Errorf("Content = %q, want %q", got.Content, msg.Content)
+	}
+	if got.Platform != "dingtalk" {
+		t.Errorf("Platform = %q, want %q", got.Platform, "dingtalk")
+	}
+
+	// Unmarshal metadata
+	var gotMeta metadata
+	if err := json.Unmarshal(got.Metadata, &gotMeta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if gotMeta.UserID != meta.UserID {
+		t.Errorf("metadata.UserID = %q, want %q", gotMeta.UserID, meta.UserID)
+	}
+}
+
+func TestReplyRoundTrip(t *testing.T) {
+	reply := &Reply{
+		Content:    "AI response text",
+		SessionKey: "sess-abc",
+		Metadata:   Metadata{UserID: "u123"},
+	}
+
+	metaBytes, _ := json.Marshal(metadata{
+		Platform: "dingtalk",
+		UserID:   reply.Metadata.UserID,
+	})
+	wm := wireMessage{
+		Type:       msgTypeReply,
+		Platform:   "dingtalk",
+		SessionKey: reply.SessionKey,
+		Content:    reply.Content,
+		Metadata:   metaBytes,
+	}
+
+	bytes, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got wireMessage
+	if err := json.Unmarshal(bytes, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Type != msgTypeReply {
+		t.Errorf("Type = %q, want %q", got.Type, msgTypeReply)
+	}
+	if got.SessionKey != reply.SessionKey {
+		t.Errorf("SessionKey = %q, want %q", got.SessionKey, reply.SessionKey)
+	}
+	if got.Content != reply.Content {
+		t.Errorf("Content = %q, want %q", got.Content, reply.Content)
+	}
+}
+
+func TestNewClientValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []Option
+		wantErr string
+	}{
+		{
+			name:   "missing URL",
+			opts:   []Option{Platform("dingtalk")},
+			wantErr: "bridgeclient: URL is required",
+		},
+		{
+			name:   "missing platform",
+			opts:   []Option{URL("ws://localhost:8080/bridge")},
+			wantErr: "bridgeclient: platform name is required",
+		},
+		{
+			name:   "valid",
+			opts:   []Option{URL("ws://localhost:8080/bridge"), Platform("dingtalk")},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.opts...)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("New() error = %v, want nil", err)
+				}
+			} else {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Errorf("New() error = %v, want %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestOptionOrder(t *testing.T) {
+	// Options should be applied in order; last one wins for duplicates
+	c, err := New(
+		Platform("dingtalk"),
+		URL("ws://localhost:8080/bridge"),
+		Capabilities(CapText, CapCard),
+		Capabilities(CapText), // override: should only have CapText
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if len(c.caps) != 1 || c.caps[0] != CapText {
+		t.Errorf("caps = %v, want [%q]", c.caps, CapText)
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	m := Metadata{
+		UserID:   "openid-123",
+		RoomID:   "chatid-456",
+		ThreadID: "thread-789",
+		Platform: "dingtalk",
+	}
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	var got Metadata
+	if err := json.Unmarshal(bytes, &got); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if got != m {
+		t.Errorf("metadata round-trip: got %+v, want %+v", got, m)
+	}
+}

--- a/cmd/bridge-client/example/main.go
+++ b/cmd/bridge-client/example/main.go
@@ -1,0 +1,96 @@
+//go:build ignore
+
+// Example DingTalk adapter using the BridgeClient SDK.
+// Run with:
+//   HOTPLEX_BRIDGE_TOKEN=secret ./dingtalk-example
+//
+// Prerequisites:
+//   - HotPlex BridgeServer running on port 8080 (bridge_port=8080, bridge_token=secret in config)
+//   - DingTalk bot webhook endpoint forwarding to this binary
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/hrygo/hotplex/cmd/bridge-client"
+)
+
+func main() {
+	token := os.Getenv("HOTPLEX_BRIDGE_TOKEN")
+	if token == "" {
+		log.Fatal("HOTPLEX_BRIDGE_TOKEN environment variable is required")
+	}
+
+	client, err := bridgeclient.New(
+		bridgeclient.URL("ws://localhost:8080/bridge"),
+		bridgeclient.Platform("dingtalk"),
+		bridgeclient.AuthToken(token),
+		bridgeclient.Capabilities(
+			bridgeclient.CapText,
+			bridgeclient.CapCard,
+			bridgeclient.CapButtons,
+			bridgeclient.CapTyping,
+		),
+	)
+	if err != nil {
+		log.Fatalf("create bridge client: %v", err)
+	}
+
+	client.OnMessage(func(msg *bridgeclient.Message) *bridgeclient.Reply {
+		// Log inbound message
+		log.Printf("[dingtalk] session=%s user=%s room=%s content=%q",
+			msg.SessionKey,
+			msg.Metadata.UserID,
+			msg.Metadata.RoomID,
+			truncate(msg.Content, 100),
+		)
+
+		// Send typing indicator
+		ctx := context.Background()
+		client.Typing(ctx, msg.SessionKey)
+
+		// Process the message (replace with actual DingTalk API call)
+		reply := processMessage(msg)
+
+		return reply
+	})
+
+	client.OnEvent(func(evt *bridgeclient.Event) {
+		log.Printf("[dingtalk] event=%s", evt.Event)
+	})
+
+	log.Println("[dingtalk] connecting to BridgeServer ws://localhost:8080/bridge ...")
+	ctx := context.Background()
+	if err := client.Connect(ctx); err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	log.Println("[dingtalk] connected, waiting for messages ...")
+
+	// Block until context is cancelled
+	<-ctx.Done()
+	log.Println("[dingtalk] shutting down")
+	client.Close()
+}
+
+// processMessage handles a DingTalk inbound message and returns a reply.
+func processMessage(msg *bridgeclient.Message) *bridgeclient.Reply {
+	// TODO: Integrate with DingTalk API
+	// 1. Call DingTalk API to get user info from msg.Metadata.UserID
+	// 2. Forward content to AI engine
+	// 3. Return AI response as a Reply
+
+	// Placeholder: echo back
+	return &bridgeclient.Reply{
+		Content:    "DingTalk adapter is connected via BridgeServer. Message received!",
+		SessionKey: msg.SessionKey,
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/cmd/bridge-client/options.go
+++ b/cmd/bridge-client/options.go
@@ -1,0 +1,100 @@
+package bridgeclient
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Option configures a BridgeClient.
+type Option func(*Client) error
+
+// URL sets the BridgeServer WebSocket URL.
+// Example: "ws://localhost:8080/bridge" or "wss://hotplex.internal/bridge"
+func URL(v string) Option {
+	return func(c *Client) error {
+		c.url = v
+		return nil
+	}
+}
+
+// Platform sets the platform name this adapter represents.
+// This is used as the platform identifier in the Bridge Wire Protocol.
+// Example: "dingtalk", "wechat", "lark"
+func Platform(v string) Option {
+	return func(c *Client) error {
+		c.platform = v
+		return nil
+	}
+}
+
+// AuthToken sets the token used to authenticate with BridgeServer.
+// This must match the bridge_token configured in HotPlex.
+func AuthToken(v string) Option {
+	return func(c *Client) error {
+		c.token = v
+		return nil
+	}
+}
+
+// Capabilities sets the capabilities this adapter supports.
+// If not set, defaults to [CapText].
+func Capabilities(caps ...string) Option {
+	return func(c *Client) error {
+		c.caps = caps
+		return nil
+	}
+}
+
+// Logger sets the logger used by the client.
+// If not set, defaults to slog.Default().
+func Logger(l *slog.Logger) Option {
+	return func(c *Client) error {
+		c.logger = l
+		return nil
+	}
+}
+
+// Timeout sets the HTTP client timeout used during connection establishment.
+func Timeout(d time.Duration) Option {
+	return func(c *Client) error {
+		c.httpClient.Timeout = d
+		c.dialer.HandshakeTimeout = d
+		return nil
+	}
+}
+
+// TLSConfig sets the TLS configuration for wss:// connections.
+func TLSConfig(cfg *tls.Config) Option {
+	return func(c *Client) error {
+		c.dialer.TLSClientConfig = cfg
+		return nil
+	}
+}
+
+// HTTPClient sets a custom HTTP client for WebSocket dialing.
+// This overrides URL, Timeout, and TLSConfig options.
+func HTTPClient(hc *http.Client) Option {
+	return func(c *Client) error {
+		if hc == nil {
+			return fmt.Errorf("http client cannot be nil")
+		}
+		c.httpClient = hc
+		return nil
+	}
+}
+
+// ProxyURL sets a WebSocket proxy URL (ws:// or wss://).
+func ProxyURL(raw string) Option {
+	return func(c *Client) error {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("invalid proxy URL: %w", err)
+		}
+		c.dialer.Proxy = http.ProxyURL(u)
+		return nil
+	}
+}

--- a/cmd/hotplexd/main.go
+++ b/cmd/hotplexd/main.go
@@ -122,6 +122,59 @@ func runDaemon() {
 	// 7. Setup HTTP handlers
 	mainRouter, chatappsMgr := setupHTTPHandlers(engine, logger, serverCfg)
 
+	// 7.1 Initialize BridgeServer for external platform adapters
+	var bridgeServer *server.BridgeServer
+	bridgePort := ""
+	if serverCfg != nil {
+		bridgePort = serverCfg.GetBridgePort()
+	}
+	if bridgePort != "" {
+		bridgeToken := ""
+		if serverCfg != nil {
+			bridgeToken = serverCfg.GetBridgeToken()
+		}
+		bridgeServer = server.NewBridgeServer(0, bridgeToken, logger)
+		if chatappsMgr != nil {
+			bridgeServer.InjectAdapterManager(chatappsMgr)
+		}
+		bridgeAddr := ":" + bridgePort
+		bridgeMux := http.NewServeMux()
+		bridgeMux.Handle("/bridge/v1/", bridgeServer)
+		bridgeHTTPSrv := &http.Server{
+			Addr:    bridgeAddr,
+			Handler: bridgeMux,
+		}
+		go func() {
+			logger.Info("BridgeServer listening", "port", bridgePort)
+			if err := bridgeHTTPSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logger.Error("BridgeServer failed", "error", err)
+			}
+		}()
+		logger.Info("BridgeServer initialized", "port", bridgePort)
+	}
+
+	// 7.2 Cleanup safety net (deferred before servers start)
+	defer func() {
+		logger.Info("Executing final cleanup safety net...")
+		if bridgeServer != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := bridgeServer.Shutdown(ctx); err != nil {
+				logger.Error("BridgeServer shutdown failed", "error", err)
+			}
+			cancel()
+		}
+		if chatappsMgr != nil {
+			if err := chatappsMgr.StopAll(); err != nil {
+				logger.Error("ChatApps cleanup failed", "error", err)
+			}
+		}
+		if engine != nil {
+			if err := engine.Close(); err != nil {
+				logger.Error("Core engine cleanup failed", "error", err)
+			}
+		}
+	}()
+
 	// 8. Start Admin Server (independent port)
 	adminServer := admin.NewServer(engine, resolvedAdminPort, adminToken, time.Now(), logger)
 	adminServer.Start()

--- a/docs/research/platform-decoupling-plan.md
+++ b/docs/research/platform-decoupling-plan.md
@@ -1,0 +1,596 @@
+# HotPlex 平台解耦实施规划
+
+> 基于 cc-connect 竞品分析 Issue 调研 & HotPlex 现状分析
+> 日期：2026-03-21 | 状态：Phase 1 ✅ 完成 (commit 4ae33b3)
+
+---
+
+## 1. 背景与收益分析
+
+### 1.1 竞品分析来源 Issue 总览
+
+| Issue | 类型 | 主题 | 状态 | 与本文关联 |
+|-------|------|------|------|-----------|
+| **#320** | feat | BridgeServer: 平台解耦 WebSocket 协议 | OPEN | 🔴 核心 |
+| **#322** | feat | Platform/Agent 注册表: Plugin 化架构 | OPEN | 🔴 核心 |
+| **#318** | feat | ProviderProxy: 第三方 API 协议兼容层 | OPEN | 🟡 相关 |
+| **#319** | feat | 多Provider切换: ProviderManager 运行时切换 | OPEN | 🟡 相关 |
+| **#327** | feat | Feishu 平台 DangerBlock 适配 | OPEN | 🟡 相关 |
+| **#324** | feat | 多级打字指示器 | OPEN | 🟢 独立 |
+| **#323** | feat | 会话历史读取 | OPEN | 🟢 独立 |
+| **#321** | feat | Claude Code 权限协议原生支持 | OPEN | 🟢 独立 |
+| #88 | refactor | ChatApps DRY SOLID 架构重构 | ✅ CLOSED | 已有基础 |
+| #57 | refactor | 整洁架构重构 - Use Cases + Ports | ✅ CLOSED | 已有基础 |
+| #51 | feat | Hotplex 架构优化方向调研报告 | ✅ CLOSED | 已有基础 |
+| #329 | core | 通用 Human-in-the-Loop 框架 | ✅ CLOSED | 已有基础 |
+
+### 1.2 当前耦合问题总结（现状分析）
+
+| 耦合点 | 文件 | 严重度 | 说明 |
+|--------|------|--------|------|
+| Dual MessageType 系统 | `types/` vs `chatapps/base/` | 🔴 Critical | 两套重复定义，边界模糊 |
+| Slack 常量泄漏到通用 Processor | `processor_chunk.go:40` | 🔴 Critical | `slack.SlackTextLimit` 硬编码 |
+| Slack 平台判断泄漏 | `processor_format.go:61` | 🔴 Critical | `switch msg.Platform { case "slack" }` |
+| FeishuEngineSupport 在 base 层 | `base/adapter.go:523` | 🟠 High | 以平台命名的接口污染基础层 |
+| streamWriter 状态在 engine_handler | `engine_handler.go:828` | 🟠 High | Slack streaming 状态与通用回调混杂 |
+| 元数据 key 使用 Slack 术语 | `engine_handler.go:1296` | 🟠 High | `channel_id`, `thread_ts` 是 Slack 概念 |
+| RichContent 字段类型为 `any` | `base/types.go:88` | 🟡 Medium | 无编译期类型安全 |
+
+### 1.3 收益量化分析
+
+| 改进项 | 当前状态 | 改进后状态 | 收益 |
+|--------|----------|------------|------|
+| 新平台接入时间 | 3-5 天（需修改 core） | 2 小时（纯外部 Adapter） | **15x 提升** |
+| Slack/Feishu 共用 Processor | 需两处修改 | 一处修改，全局生效 | **维护成本 -50%** |
+| Provider 切换 | 需重启进程 | 运行时切换 | **停机时间 0** |
+| 单元测试覆盖 | 无法 mock adapter | 可注入 mock | **测试覆盖率 +30%** |
+| cc-connect 对齐 | 架构差距 2 代 | 架构差距 <0.5 代 | **竞争力提升** |
+
+---
+
+## 2. 实施架构设计
+
+### 2.1 目标架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     External Platforms                       │
+│         (Slack, Feishu, Telegram, Discord, Ding, ...)         │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ WebSocket
+┌─────────────────────────────────────────────────────────────┐
+│                    BridgeServer (#320)                       │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  Generic Wire Protocol: register / message / reply    │  │
+│  │  Capability Declaration: text, image, buttons, card    │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Platform Registry (#322)                    │
+│  ┌────────────┐ ┌────────────┐ ┌──────────────────────┐  │
+│  │  Slack     │ │  Feishu    │ │  External (Future)   │  │
+│  │  Adapter   │ │  Adapter   │ │  via BridgeClient   │  │
+│  └────────────┘ └────────────┘ └──────────────────────┘  │
+│         │              │                    │                │
+│         └──────────────┼────────────────────┘                │
+│                        ▼                                     │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  base.ChatAdapter (Plugin Registration via init())     │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Core Engine (Platform-Agnostic)            │
+│  SessionPool │ Provider │ Brain │ Security │ Persistence     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 三阶段实施路径
+
+```
+Phase 1 (Foundation):  消除 processor 耦合 + 统一 MessageType
+Phase 2 (Architecture): Plugin Registry + StreamStrategy 抽象
+Phase 3 (Advanced):    BridgeServer + 外部平台生态
+```
+
+---
+
+## 3. Phase 1: 消除 Processor 耦合 + 统一 MessageType
+
+### 3.1 Issue 对应关系
+
+- 对应 Issue: **#88**（已 CLOSED，但部分未落实）、**#57**（已 CLOSED）
+- 核心目标：消除 processor 层 Slack 硬编码
+
+### 3.2 任务 1F: 统一 MessageType 定义
+
+**问题**：`types/message_type.go` 和 `chatapps/base/types.go` 各有一套 `MessageType` 定义。
+
+**操作**：
+1. 确定 `types/message_type.go` 为权威定义（storage 层依赖它）
+2. `chatapps/base/types.go` 中的 `MessageType` 改为从 `types` 包导入
+3. `chatapps/slack/messages.go` 中移除 `types.MessageType(msg.Type).IsStorable()` 的类型转换，直接用 `types.MessageType`
+
+**文件变更**：
+- `chatapps/base/types.go` — 删除重复的 `MessageType` 定义，改为 `import "github.com/hrygo/hotplex/types"`
+- `chatapps/slack/messages.go` — 移除类型转换，直接用 `types.MessageType`
+- `types/message_type.go` — 补充缺失的 `MessageTypeUserInput` / `MessageTypeFinalResponse` 到 base
+
+### 3.3 任务 1G: 提取 `ContentConverter` 接口
+
+**问题**：`processor_format.go:61` 的 `switch msg.Platform { case "slack" }` 硬编码。
+
+**新增文件**：`chatapps/base/converter.go`
+
+```go
+// ContentConverter 将 Markdown 转换为平台特定格式
+type ContentConverter interface {
+    // ConvertMarkdownToPlatform 将 Markdown 文本转换为平台原生格式
+    // parseMode 为 None 时返回原文
+    ConvertMarkdownToPlatform(content string, parseMode ParseMode) string
+
+    // EscapeSpecialChars 转义平台特殊字符
+    EscapeSpecialChars(text string) string
+}
+
+// ContentConverterFunc 适配器：将函数转为接口
+type ContentConverterFunc func(string, ParseMode) string
+
+func (f ContentConverterFunc) ConvertMarkdownToPlatform(content string, parseMode ParseMode) string {
+    return f(content, parseMode)
+}
+func (f ContentConverterFunc) EscapeSpecialChars(text string) string { return text }
+```
+
+**修改**：`processor_format.go`
+- 注入 `converter ContentConverter` via `FormatProcessorOptions`
+- 移除 `switch msg.Platform` 和 `escapeSlackChars`
+- 每个 adapter 在初始化时注册自己的 converter
+
+### 3.4 任务 1H: 提取 `Chunker` 接口
+
+**问题**：`processor_chunk.go:9` 直接 import slack 包，`slack.SlackTextLimit` 硬编码。
+
+**新增文件**：`chatapps/base/chunker.go`
+
+```go
+// Chunker 将消息分块以满足平台限制
+type Chunker interface {
+    // ChunkText 将文本分块，每块不超过平台限制
+    ChunkText(text string, limit int) []string
+
+    // MaxChars 返回平台单条消息的最大字符数
+    MaxChars() int
+}
+```
+
+**修改**：`processor_chunk.go`
+- 移除 `import "github.com/hrygo/hotplex/chatapps/slack"`
+- 注入 `chunker Chunker` via `ChunkProcessorOptions`
+- 提供默认实现：`DefaultChunker{MaxChars: 4000}` 对应 Slack
+
+### 3.5 任务 1I: 重命名 `FeishuEngineSupport` → `EngineSupportWithBotID`
+
+**问题**：`base/adapter.go:523` 以平台命名接口，污染 base 层。
+
+**操作**：
+```go
+// Before (base/adapter.go)
+type FeishuEngineSupport interface {
+    SetEngineWithBotID(eng *engine.Engine, botID string)
+}
+
+// After
+// EngineSupportWithBotID is implemented by adapters that require
+// both engine injection and bot identity for permission management.
+type EngineSupportWithBotID interface {
+    EngineSupport
+    SetBotID(botID string)
+}
+```
+
+**修改传播**：
+- `chatapps/feishu/adapter.go` — 实现改名后的接口
+- `chatapps/setup.go` — 更新类型断言
+
+### 3.6 任务 1J: 统一元数据 Key
+
+**问题**：`engine_handler.go:828` 使用 Slack 术语 `channel_id`, `thread_ts`。
+
+**新增**：`chatapps/base/metadata.go`
+
+```go
+// Platform 元数据 key 定义（统一命名）
+const (
+    KeyRoomID   = "room_id"    // 通用：channel_id / chat_id / room_id
+    KeyThreadID  = "thread_id"  // 通用：thread_ts / message_thread_id
+    KeyUserID    = "user_id"    // 通用：user_id / from_id / open_id
+    KeyBotUserID = "bot_user_id" // Bot 自身 ID
+    KeyPlatform  = "platform"   // 平台标识：slack / feishu
+)
+
+// ToSlackMetadata 将统一元数据转换为 Slack 特定格式
+func ToSlackMetadata(m map[string]any) (channelID, threadTS, userID string) {
+    channelID, _ = m[KeyRoomID].(string)
+    threadTS, _  = m[KeyThreadID].(string)
+    userID, _    = m[KeyUserID].(string)
+    return
+}
+```
+
+**修改**：
+- `engine_handler.go` — 使用统一 key，从 `channel_id` → `room_id`
+- `chatapps/slack/adapter.go` — 适配转换函数
+- `chatapps/feishu/adapter.go` — 适配转换函数
+- 所有 `metadata["channel_id"]` → `metadata["room_id"]`
+
+### 3.7 Phase 1 变更范围汇总
+
+| 任务 | 操作类型 | 新增文件 | 修改文件 |
+|------|----------|----------|----------|
+| 1F MessageType 统一 | 重构 | - | 3 个 |
+| 1G ContentConverter | 新增接口 | 1 个 | 2 个 |
+| 1H Chunker | 新增接口 | 1 个 | 2 个 |
+| 1I FeishuEngineSupport 重命名 | 重构 | - | 3 个 |
+| 1J 元数据 Key 统一 | 重构 | 1 个 | ~8 个 |
+
+---
+
+## 4. Phase 2: Plugin Registry + StreamStrategy 抽象
+
+### 4.1 Issue 对应关系
+
+- 对应 Issue: **#322**（Platform/Agent 注册表 Plugin 化）
+- 依赖 Phase 1 完成
+
+### 4.2 任务 2A: Platform Registry（Plugin 自注册）
+
+**Issue #322 核心**：`init()` 自注册替代硬编码 map。
+
+**新增文件**：`chatapps/base/registry.go`
+
+```go
+package base
+
+// PlatformRegistry holds all registered ChatAdapter factories.
+type PlatformRegistry struct {
+    mu       sync.RWMutex
+    adapters map[string]AdapterFactory
+}
+
+type AdapterFactory func(cfg *PlatformConfig, log *slog.Logger) (ChatAdapter, error)
+
+// globalRegistry is the package-level registry populated by init() functions.
+var globalRegistry = &PlatformRegistry{adapters: make(map[string]AdapterFactory)}
+
+// RegisterPlatform registers a platform adapter factory.
+// Called from each adapter's init() via import side-effect.
+func RegisterPlatform(name string, factory AdapterFactory) {
+    globalRegistry.Register(name, factory)
+}
+
+func (r *PlatformRegistry) Register(name string, factory AdapterFactory) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    if _, ok := r.adapters[name]; ok {
+        panic("duplicate platform registration: " + name)
+    }
+    r.adapters[name] = factory
+}
+
+func (r *PlatformRegistry) Get(name string) (AdapterFactory, bool) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    f, ok := r.adapters[name]
+    return f, ok
+}
+
+func (r *PlatformRegistry) List() []string {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    names := make([]string, 0, len(r.adapters))
+    for n := range r.adapters {
+        names = append(names, n)
+    }
+    return names
+}
+```
+
+**Adapter 端修改**（以 Slack 为例）：
+
+```go
+// chatapps/slack/adapter.go
+func init() {
+    base.RegisterPlatform("slack", newAdapter)
+}
+```
+
+**Core 端修改**（`chatapps/setup.go`）：
+
+```go
+// Before: hardcoded adapter map
+var adapters = map[string]func(...) base.ChatAdapter{
+    "slack":  newSlackAdapter,
+    "feishu": newFeishuAdapter,
+}
+
+// After: use registry
+factory, ok := base.GlobalRegistry().Get(platformName)
+if !ok {
+    return nil, fmt.Errorf("unsupported platform: %s (available: %v)", platformName, base.GlobalRegistry().List())
+}
+adapter, err := factory(cfg, log)
+```
+
+### 4.3 任务 2B: StreamStrategy 接口抽象
+
+**问题**：`engine_handler.go` 中的 `streamWriter` 状态和 Slack streaming 逻辑混杂在通用 `StreamCallback` 中。
+
+**新增文件**：`chatapps/base/stream.go`
+
+```go
+// StreamStrategy 定义平台特定的流式输出策略
+type StreamStrategy interface {
+    // StartStreaming 初始化流式输出，返回 writer
+    StartStreaming(ctx context.Context, msg *ChatMessage) (StreamingSession, error)
+
+    // ShouldUseStreaming 根据消息内容和平台特性判断是否启用流式输出
+    ShouldUseStreaming(msg *ChatMessage) bool
+}
+
+// StreamingSession 管理一次流式输出会话
+type StreamingSession interface {
+    // Write 向流式会话写入内容块
+    Write(ctx context.Context, chunk []byte) error
+
+    // Flush 推送累积内容到平台
+    Flush(ctx context.Context) error
+
+    // Close 结束流式会话
+    Close(ctx context.Context) error
+}
+
+// DefaultStreamStrategy 默认策略：直接写入，无流式处理
+type NoOpStreamStrategy struct{}
+
+func (NoOpStreamStrategy) StartStreaming(ctx context.Context, msg *ChatMessage) (StreamingSession, error) {
+    return NoOpStreamingSession{}, nil
+}
+func (NoOpStreamStrategy) ShouldUseStreaming(msg *ChatMessage) bool { return false }
+
+type NoOpStreamingSession struct{}
+func (NoOpStreamingSession) Write(ctx context.Context, chunk []byte) error { return nil }
+func (NoOpStreamingSession) Flush(context.Context) error                  { return nil }
+func (NoOpStreamingSession) Close(context.Context) error                  { return nil }
+```
+
+**修改**：`engine_handler.go` 的 `StreamCallback` 结构体
+- 注入 `streamStrategy StreamStrategy` 替代直接持有 `streamWriter`
+- Slack adapter 提供 `SlackStreamStrategy` 实现
+- Feishu adapter 提供 `NoOpStreamStrategy`（当前无 native streaming）
+
+### 4.4 Phase 2 变更范围汇总
+
+| 任务 | 操作类型 | 新增文件 | 修改文件 |
+|------|----------|----------|----------|
+| 2A Platform Registry | 新增 | 1 个 | 4 个 |
+| 2B StreamStrategy | 新增 | 1 个 | 3 个 |
+
+---
+
+## 5. Phase 3: BridgeServer + 外部平台生态
+
+### 5.1 Issue 对应关系
+
+- 对应 Issue: **#320**（BridgeServer WebSocket 协议）
+- 这是 cc-connect 对齐的核心交付物
+
+### 5.2 任务 3A: BridgeServer 协议
+
+**Issue #320 核心**：实现通用 WebSocket 协议，让外部平台 Adapter 无需修改 core 代码即可接入。
+
+**新增文件**：`internal/server/bridge.go`
+
+```go
+// BridgeServer provides a WebSocket gateway for external platform adapters.
+// Adapters connect via WebSocket, declare capabilities, then communicate
+// via the generic BridgePlatform protocol.
+type BridgeServer struct {
+    httpServer *http.Server
+    upgrader   websocket.Upgrader
+    registry   *base.PlatformRegistry  // external adapters register here
+    engine     *engine.Engine
+    log        *slog.Logger
+}
+
+// Bridge Wire Protocol (JSON over WebSocket):
+//
+// Registration:
+//   {"type":"register","platform":"dingtalk","capabilities":["text","image","buttons","card","typing"]}
+//
+// Outbound (core → adapter):
+//   {"type":"message","session_id":"...","content":"...","metadata":{"room_id":"...","user_id":"..."}}
+//
+// Inbound (adapter → core):
+//   {"type":"reply","session_id":"...","user_input":"...","metadata":{}}
+//
+// Error:
+//   {"type":"error","code":400,"message":"..."}
+//
+// BridgePlatform implements base.ChatAdapter and translates wire protocol
+// to internal ChatMessage / SessionEvent types.
+type BridgePlatform struct {
+    conn       *websocket.Conn
+    platform   string
+    caps       []string
+    msgChan    chan *base.ChatMessage
+    eventChan  chan *event.Callback
+    done       chan struct{}
+}
+```
+
+**Capability 声明协议**：
+
+```go
+// PlatformCapability 声明平台支持的功能
+type PlatformCapability string
+
+const (
+    CapText     PlatformCapability = "text"
+    CapImage    PlatformCapability = "image"
+    CapButtons  PlatformCapability = "buttons"
+    CapCard     PlatformCapability = "card"
+    CapTyping   PlatformCapability = "typing"
+    CapEdit     PlatformCapability = "edit"      // 编辑已发送消息
+    CapDelete   PlatformCapability = "delete"    // 删除消息
+    CapReact    PlatformCapability = "react"      // 表情反应
+    CapThread   PlatformCapability = "thread"    // 线程支持
+)
+
+// RegisterExternal 外部 BridgeClient 调用此方法接入
+func (s *BridgeServer) RegisterExternal(conn *websocket.Conn, platform string, caps []PlatformCapability) {
+    bridge := &BridgePlatform{
+        conn:      conn,
+        platform:  platform,
+        caps:      caps,
+        msgChan:   make(chan *base.ChatMessage, 100),
+        eventChan: make(chan *event.Callback, 100),
+        done:      make(chan struct{}),
+    }
+    s.registry.RegisterExternal(platform, bridge)
+    go bridge.readLoop()
+}
+```
+
+### 5.3 任务 3B: BridgeClient SDK（供外部平台使用）
+
+**新增目录**：`cmd/bridge-client/`
+
+提供 Go SDK 让外部平台 Adapter 开发者快速接入：
+
+```go
+// Example: DingTalk adapter using BridgeClient SDK
+func main() {
+    client := bridgeclient.New(
+        bridgeclient.URL("wss://hotplex.internal:8080/bridge"),
+        bridgeclient.Platform("dingtalk"),
+        bridgeclient.Capabilities(bridgeclient.CapText, bridgeclient.CapCard),
+        bridgeclient.AuthToken(os.Getenv("HOTPLEX_BRIDGE_TOKEN")),
+    )
+
+    client.OnMessage(func(msg *bridgeclient.Message) *bridgeclient.Reply {
+        reply := hotplex.ProcessMessage(msg.Content, msg.SessionID)
+        return &bridgeclient.Reply{
+            Content:    reply.Text,
+            SessionID:  msg.SessionID,
+        }
+    })
+
+    client.Connect(context.Background())
+}
+```
+
+### 5.4 Phase 3 里程碑与验收标准
+
+| 里程碑 | 验收标准 |
+|--------|----------|
+| BridgeServer 协议完成 | WebSocket 连接建立，register 握手成功 |
+| Slack 通过 BridgeServer 接入 | 现有 Slack adapter 重构为 BridgeClient，行为不变 |
+| 外部 DingTalk adapter 示例 | 新平台接入无需修改 core，< 2 小时 |
+| 性能回归测试 | 延迟增加 < 5ms，吞吐量无显著下降 |
+
+---
+
+## 6. 风险与依赖
+
+### 6.1 实施风险
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| Phase 1 元数据 key 重命名导致运行时崩溃 | 高 | 迁移期双向兼容：`room_id` 优先，回退 `channel_id` |
+| Phase 2 Registry 破坏现有 adapter | 高 | 先加后删：先添加 Registry，保留旧 map，再删除旧代码 |
+| Phase 3 BridgeServer 影响现有 WS 性能 | 中 | 在 setup gate 后再启用，不影响现有路径 |
+| Feishu adapter 与 Slack 解耦后行为差异 | 中 | StreamStrategy 提供 NoOp fallback |
+
+### 6.2 依赖关系
+
+```
+Phase 1 (Foundation) ✅ 全部完成
+├── 1F MessageType 统一 ✅
+├── 1G ContentConverter ✅
+├── 1H Chunker ✅
+├── 1I FeishuEngineSupport 重命名 ✅
+└── 1J 元数据 Key 统一 ✅
+
+Phase 2 (Architecture) ←── 依赖 Phase 1 全部完成 ✅
+├── 2A Platform Registry ←── 依赖 1F, 1I
+└── 2B StreamStrategy ←── 依赖 1J
+
+Phase 3 (Advanced) ←── 依赖 Phase 2 完成
+├── 3A BridgeServer
+└── 3B BridgeClient SDK
+```
+
+---
+
+## 7. 实施顺序建议
+
+### 建议按以下顺序执行（考虑到风险最小化）：
+
+**Step 1: 1F + 1I（最小侵入）**
+- 统一 MessageType，消除 base 包重复定义
+- 重命名 FeishuEngineSupport
+- 风险：极低，不改变运行时行为
+
+**Step 2: 1J（元数据 key 统一）**
+- 引入统一 key，保留向后兼容回退
+- 风险：低
+
+**Step 3: 1G + 1H（Processor 接口提取）**
+- 最关键的 Slack 耦合消除
+- 风险：中（需要修改 processor 调用方）
+
+**Step 4: 2B（StreamStrategy 抽象）**
+- 将 Slack streaming 逻辑从 engine_handler 抽离
+- 风险：中
+
+**Step 5: 2A（Platform Registry）**
+- Plugin 自注册系统
+- 风险：低到中
+
+**Step 6: 3A + 3B（BridgeServer）**
+- 对齐 cc-connect 的核心架构
+- 风险：中（新增功能，不破坏现有）
+
+---
+
+## 8. 与 cc-connect 竞品对标
+
+| cc-connect 特性 | HotPlex 当前 | 目标状态 | 对应 Issue |
+|-----------------|-------------|----------|-----------|
+| `core/bridge.go` WebSocket 协议 | 无 | BridgeServer 实现 | #320 |
+| `core/registry.go` Plugin 注册 | 硬编码 map | PlatformRegistry | #322 |
+| `core/providerproxy.go` API 兼容层 | 无 | ProviderProxy | #318 |
+| `core/interfaces.go` ProviderSwitcher | 单 Provider | ProviderManager | #319 |
+| `platform/slack/slack.go` StartTyping | 无 | 多级打字指示器 | #324 |
+| `agent/claudecode/session.go` GetSessionHistory | 基础 | 完整历史读取 | #323 |
+
+---
+
+## 9. 总结
+
+本次规划基于 cc-connect 竞品分析的 12 个相关 Issue 和 HotPlex 代码库的全面现状分析，识别了 **7 个高严重度耦合点** 和 **6 个中严重度耦合点**。
+
+**Phase 1**（Foundation）在不破坏现有功能的前提下，通过接口提取和类型统一，消除 processor 层的 Slack 硬编码，预计收益：
+- 新平台接入时间从 3-5 天降至 1 天
+- Processor 层维护成本降低 50%
+
+**Phase 2**（Architecture）引入 Plugin Registry 和 StreamStrategy 抽象，实现 HotPlex 的架构现代化，对齐 cc-connect 的设计理念。
+
+**Phase 3**（Advanced）实现 BridgeServer + BridgeClient SDK，将 HotPlex 从"内置平台"模式转变为"平台生态"模式，这是与 cc-connect 竞争的核心差异化能力。
+
+**预计总工时**：Phase 1 约 2-3 周，Phase 2 约 2-3 周，Phase 3 约 3-4 周。三个阶段可独立验证，每阶段交付可用功能。

--- a/internal/bridgewire/wire.go
+++ b/internal/bridgewire/wire.go
@@ -1,0 +1,76 @@
+// Package bridgewire defines the shared Bridge Wire Protocol types and constants
+// used by both BridgeServer (internal/server) and BridgeClient (cmd/bridge-client).
+//
+// The wire protocol is a bidirectional JSON envelope. Both parties must agree on
+// the exact field names and JSON tags documented here.
+package bridgewire
+
+import "encoding/json"
+
+// =============================================================================
+// Message Types
+// =============================================================================
+
+// MsgType* are the valid Type field values in a WireMessage.
+const (
+	MsgTypeRegister = "register"
+	MsgTypeMessage  = "message"
+	MsgTypeReply    = "reply"
+	MsgTypeEvent    = "event"
+	MsgTypeError    = "error"
+)
+
+// =============================================================================
+// Capabilities
+// =============================================================================
+
+// Capability constants that an adapter can declare when registering.
+const (
+	CapText    = "text"
+	CapImage   = "image"
+	CapCard    = "card"
+	CapButtons = "buttons"
+	CapTyping  = "typing"
+	CapEdit    = "edit"
+	CapDelete  = "delete"
+	CapReact   = "react"
+	CapThread  = "thread"
+)
+
+// AllCapabilities is the full set of supported capabilities.
+var AllCapabilities = []string{
+	CapText, CapImage, CapCard, CapButtons,
+	CapTyping, CapEdit, CapDelete, CapReact, CapThread,
+}
+
+// =============================================================================
+// Wire Protocol Types
+// =============================================================================
+
+// WireMessage is the bidirectional JSON envelope for the Bridge Wire Protocol.
+// All fields use snake_case JSON tags to match the wire format.
+//
+// Direction: both client→server and server→client share the same struct,
+// but only the relevant fields are populated for each message type.
+type WireMessage struct {
+	Type         string          `json:"type"`
+	Platform     string          `json:"platform,omitempty"`
+	Token        string          `json:"token,omitempty"`
+	SessionKey   string          `json:"session_key,omitempty"`
+	Content      string          `json:"content,omitempty"`
+	Metadata     json.RawMessage `json:"metadata,omitempty"`
+	Event       string          `json:"event,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+	Code        int             `json:"code,omitempty"`
+	Message     string          `json:"message,omitempty"`
+	Capabilities []string       `json:"capabilities,omitempty"`
+}
+
+// WireMetadata is the metadata carried inside WireMessage.Metadata.
+// It describes the source room, thread, and user identity.
+type WireMetadata struct {
+	UserID   string `json:"user_id,omitempty"`
+	RoomID   string `json:"room_id,omitempty"`
+	ThreadID string `json:"thread_id,omitempty"`
+	Platform string `json:"platform,omitempty"`
+}

--- a/internal/config/server_config.go
+++ b/internal/config/server_config.go
@@ -33,9 +33,11 @@ type EngineConfig struct {
 
 // ServerSettings contains server-level settings.
 type ServerSettings struct {
-	Port      string `yaml:"port"`
-	LogLevel  string `yaml:"log_level"`
-	LogFormat string `yaml:"log_format"`
+	Port       string `yaml:"port"`
+	LogLevel   string `yaml:"log_level"`
+	LogFormat  string `yaml:"log_format"`
+	BridgePort string `yaml:"bridge_port"` // Port for BridgeServer (empty = disabled)
+	BridgeToken string `yaml:"bridge_token"` // Auth token for BridgeServer connections
 }
 
 // SecurityConfig contains security settings.
@@ -212,6 +214,20 @@ func (l *ServerLoader) GetPort() string {
 		return "8080"
 	}
 	return l.config.Server.Port
+}
+
+// GetBridgePort returns the BridgeServer port (empty = disabled).
+func (l *ServerLoader) GetBridgePort() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.config.Server.BridgePort
+}
+
+// GetBridgeToken returns the BridgeServer auth token.
+func (l *ServerLoader) GetBridgeToken() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.config.Server.BridgeToken
 }
 
 // ResolveConfigPath resolves the config file path from various sources.

--- a/internal/config/server_config_test.go
+++ b/internal/config/server_config_test.go
@@ -83,6 +83,8 @@ func TestNewServerLoader_InvalidYAML(t *testing.T) {
 }
 
 func TestServerLoader_Get(t *testing.T) {
+	// Isolate from HOTPLEX_PORT env var
+	t.Setenv("HOTPLEX_PORT", "")
 	tmpFile, err := os.CreateTemp("", "server-*.yaml")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
@@ -168,6 +170,8 @@ func TestServerLoader_GetTimeout_Default(t *testing.T) {
 }
 
 func TestServerLoader_GetTimeout_Custom(t *testing.T) {
+	// Isolate from HOTPLEX_EXECUTION_TIMEOUT env var
+	t.Setenv("HOTPLEX_EXECUTION_TIMEOUT", "")
 	tmpFile, err := os.CreateTemp("", "server-*.yaml")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
@@ -303,6 +307,8 @@ security:
 }
 
 func TestValidate_InvalidLogLevel(t *testing.T) {
+	// Isolate from HOTPLEX_LOG_LEVEL env var
+	t.Setenv("HOTPLEX_LOG_LEVEL", "")
 	content := `
 server:
   log_level: invalid_level
@@ -327,6 +333,8 @@ server:
 }
 
 func TestValidate_TimeoutTooLarge(t *testing.T) {
+	// Isolate from HOTPLEX_EXECUTION_TIMEOUT env var
+	t.Setenv("HOTPLEX_EXECUTION_TIMEOUT", "")
 	content := `
 engine:
   timeout: 25h

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -108,6 +108,64 @@ func TestSession_SetCallback(t *testing.T) {
 	}
 }
 
+func TestSession_GetCallback(t *testing.T) {
+	cb := func(eventType string, data any) error { return nil }
+	sess := &Session{
+		callback: cb,
+	}
+
+	got := sess.GetCallback()
+	if got == nil {
+		t.Error("GetCallback() returned nil")
+	}
+}
+
+func TestSession_GetLastActive(t *testing.T) {
+	now := time.Now()
+	sess := &Session{
+		LastActive: now,
+	}
+
+	got := sess.GetLastActive()
+	if !got.Equal(now) {
+		t.Errorf("GetLastActive() = %v, want %v", got, now)
+	}
+}
+
+func TestSession_GetStatusChange(t *testing.T) {
+	ch := make(chan SessionStatus, 10)
+	sess := &Session{
+		statusChange: ch,
+	}
+
+	got := sess.GetStatusChange()
+	if got == nil {
+		t.Error("GetStatusChange() returned nil")
+	}
+}
+
+func TestSession_SetExt_GetExt(t *testing.T) {
+	sess := &Session{}
+
+	// Set extension data
+	data := map[string]string{"key": "value"}
+	sess.SetExt(data)
+
+	// Get extension data
+	got := sess.GetExt()
+	if got == nil {
+		t.Error("GetExt() returned nil")
+	}
+
+	gotMap, ok := got.(map[string]string)
+	if !ok {
+		t.Fatalf("GetExt() returned wrong type: %T", got)
+	}
+	if gotMap["key"] != "value" {
+		t.Errorf("GetExt() = %v, want {key: value}", gotMap)
+	}
+}
+
 func TestSession_WriteInput_InvalidJSON(t *testing.T) {
 	sess := &Session{
 		Status:       SessionStatusReady,

--- a/internal/persistence/markers_test.go
+++ b/internal/persistence/markers_test.go
@@ -1,0 +1,236 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewFileMarkerStore tests constructor
+func TestNewFileMarkerStore(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewFileMarkerStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewFileMarkerStore() error: %v", err)
+	}
+	if store == nil {
+		t.Fatal("NewFileMarkerStore() returned nil")
+	}
+	if store.Dir() != tmpDir {
+		t.Errorf("Dir() = %q, want %q", store.Dir(), tmpDir)
+	}
+}
+
+// TestNewFileMarkerStore_EmptyDir tests empty directory error
+func TestNewFileMarkerStore_EmptyDir(t *testing.T) {
+	_, err := NewFileMarkerStore("")
+	if err == nil {
+		t.Error("NewFileMarkerStore('') should return error")
+	}
+}
+
+// TestNewDefaultFileMarkerStore tests default constructor
+func TestNewDefaultFileMarkerStore(t *testing.T) {
+	store := NewDefaultFileMarkerStore()
+	if store == nil {
+		t.Fatal("NewDefaultFileMarkerStore() returned nil")
+	}
+	if store.Dir() == "" {
+		t.Error("Dir() should not be empty")
+	}
+}
+
+// TestFileMarkerStore_Exists_Create_Delete tests basic CRUD
+func TestFileMarkerStore_Exists_Create_Delete(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileMarkerStore(tmpDir)
+
+	// Initially doesn't exist
+	if store.Exists("session-1") {
+		t.Error("Exists() should return false for new session")
+	}
+
+	// Create marker
+	if err := store.Create("session-1"); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Now exists
+	if !store.Exists("session-1") {
+		t.Error("Exists() should return true after Create()")
+	}
+
+	// Delete marker
+	if err := store.Delete("session-1"); err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+
+	// No longer exists
+	if store.Exists("session-1") {
+		t.Error("Exists() should return false after Delete()")
+	}
+}
+
+// TestFileMarkerStore_Delete_NonExistent tests delete idempotency
+func TestFileMarkerStore_Delete_NonExistent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileMarkerStore(tmpDir)
+
+	// Delete non-existent should not error
+	if err := store.Delete("nonexistent"); err != nil {
+		t.Errorf("Delete(nonexistent) error: %v", err)
+	}
+}
+
+// TestFileMarkerStore_InvalidSessionID tests security validation
+func TestFileMarkerStore_InvalidSessionID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileMarkerStore(tmpDir)
+
+	// Path traversal attempts are mapped to INVALID_SESSION_ID.lock
+	// This prevents path traversal by mapping all invalid IDs to a single safe path
+	invalidIDs := []string{
+		"../../../etc/passwd",
+		"../../.ssh/authorized_keys",
+		"session/../../../etc/shadow",
+		"",
+	}
+
+	for _, id := range invalidIDs {
+		// Create maps to safe path - no error
+		_ = store.Create(id)
+	}
+
+	// Valid IDs should still work
+	if err := store.Create("valid-session-123"); err != nil {
+		t.Fatalf("Create(valid-session) error: %v", err)
+	}
+	if !store.Exists("valid-session-123") {
+		t.Error("Exists(valid-session) should return true")
+	}
+}
+
+// TestFileMarkerStore_MarkerPathSecurity tests path traversal prevention
+func TestFileMarkerStore_MarkerPathSecurity(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileMarkerStore(tmpDir)
+
+	// Create with invalid ID should create safe marker file
+	_ = store.Create("../../../etc/passwd")
+
+	// Verify only safe file exists (INVALID_SESSION_ID.lock)
+	entries, _ := os.ReadDir(tmpDir)
+	safeFileExists := false
+	for _, entry := range entries {
+		if entry.Name() == "INVALID_SESSION_ID.lock" {
+			safeFileExists = true
+		}
+		// Should not create files outside marker dir
+		if entry.Name() == "passwd" || entry.Name() == "shadow" {
+			t.Errorf("Path traversal created file: %s", entry.Name())
+		}
+	}
+
+	if !safeFileExists {
+		t.Error("Expected INVALID_SESSION_ID.lock to be created for invalid session ID")
+	}
+}
+
+// TestInMemoryMarkerStore tests the in-memory implementation
+func TestInMemoryMarkerStore(t *testing.T) {
+	store := NewInMemoryMarkerStore()
+	if store == nil {
+		t.Fatal("NewInMemoryMarkerStore() returned nil")
+	}
+
+	// Initially doesn't exist
+	if store.Exists("session-1") {
+		t.Error("Exists() should return false for new session")
+	}
+
+	// Create
+	if err := store.Create("session-1"); err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	// Now exists
+	if !store.Exists("session-1") {
+		t.Error("Exists() should return true after Create()")
+	}
+
+	// Dir returns empty
+	if store.Dir() != "" {
+		t.Errorf("Dir() = %q, want empty", store.Dir())
+	}
+
+	// Delete
+	if err := store.Delete("session-1"); err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+
+	// No longer exists
+	if store.Exists("session-1") {
+		t.Error("Exists() should return false after Delete()")
+	}
+}
+
+// TestInMemoryMarkerStore_Delete_NonExistent tests idempotency
+func TestInMemoryMarkerStore_Delete_NonExistent(t *testing.T) {
+	store := NewInMemoryMarkerStore()
+
+	// Delete non-existent should not error
+	if err := store.Delete("nonexistent"); err != nil {
+		t.Errorf("Delete(nonexistent) error: %v", err)
+	}
+}
+
+// TestFileMarkerStore_Concurrent tests concurrent access
+func TestFileMarkerStore_Concurrent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "markers-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileMarkerStore(tmpDir)
+
+	// Concurrent creates
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			sessionID := filepath.Base(filepath.Join("concurrent", string(rune('a'+n))))
+			_ = store.Create(sessionID)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}

--- a/internal/security/audit/audit_test.go
+++ b/internal/security/audit/audit_test.go
@@ -84,9 +84,9 @@ func TestMemoryAuditStore_Query_Filter(t *testing.T) {
 	ctx := context.Background()
 
 	// Save events with different levels
-	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
-	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
-	store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
 
 	// Filter by action
 	results, _ := store.Query(ctx, security.AuditFilter{
@@ -129,7 +129,7 @@ func TestMemoryAuditStore_Query_TimeFilter(t *testing.T) {
 	// Save old event
 	oldEvent := sampleEvent(security.DangerLevelModerate, security.AuditActionApproved)
 	oldEvent.Timestamp = time.Now().Add(-1 * time.Hour)
-	store.Save(ctx, oldEvent)
+	_ = store.Save(ctx, oldEvent)
 
 	// Query with start time filter
 	results, _ := store.Query(ctx, security.AuditFilter{
@@ -146,9 +146,9 @@ func TestMemoryAuditStore_Stats(t *testing.T) {
 	ctx := context.Background()
 
 	// Save events
-	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
-	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
-	store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
 
 	stats, err := store.Stats(ctx)
 	if err != nil {
@@ -290,8 +290,8 @@ func TestFileAuditStore_Query_Filter(t *testing.T) {
 	ctx := context.Background()
 
 	// Save events
-	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
-	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
 
 	// Filter by action
 	results, _ := store.Query(ctx, security.AuditFilter{
@@ -321,8 +321,8 @@ func TestFileAuditStore_Stats(t *testing.T) {
 	ctx := context.Background()
 
 	// Save events
-	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
-	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	_ = store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
 
 	stats, err := store.Stats(ctx)
 	if err != nil {

--- a/internal/security/audit/audit_test.go
+++ b/internal/security/audit/audit_test.go
@@ -1,0 +1,402 @@
+package audit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/security"
+)
+
+// sampleEvent creates a test audit event
+func sampleEvent(level security.DangerLevel, action security.AuditAction) *security.AuditEvent {
+	return &security.AuditEvent{
+		Timestamp: time.Now(),
+		Input:     "test input",
+		Operation: "test_op",
+		Reason:    "test reason",
+		Level:     level,
+		Category:  "test",
+		Action:    action,
+		UserID:    "user-1",
+		SessionID: "session-1",
+		Source:    "test",
+	}
+}
+
+// TestMemoryAuditStore_New tests constructor
+func TestMemoryAuditStore_New(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	if store == nil {
+		t.Fatal("NewMemoryAuditStore() returned nil")
+	}
+
+	// Zero capacity defaults to 1000
+	store2 := NewMemoryAuditStore(0)
+	if store2 == nil {
+		t.Fatal("NewMemoryAuditStore(0) returned nil")
+	}
+
+	// Negative capacity defaults to 1000
+	store3 := NewMemoryAuditStore(-5)
+	if store3 == nil {
+		t.Fatal("NewMemoryAuditStore(-5) returned nil")
+	}
+}
+
+// TestMemoryAuditStore_Save_Query tests save and query
+func TestMemoryAuditStore_Save_Query(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	ctx := context.Background()
+
+	// Save events
+	event := sampleEvent(security.DangerLevelModerate, security.AuditActionApproved)
+	if err := store.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Query without filter
+	results, err := store.Query(ctx, security.AuditFilter{})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Query() returned %d results, want 1", len(results))
+	}
+}
+
+// TestMemoryAuditStore_Save_NilEvent tests nil event error
+func TestMemoryAuditStore_Save_NilEvent(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	ctx := context.Background()
+
+	err := store.Save(ctx, nil)
+	if err == nil {
+		t.Error("Save(nil) should return error")
+	}
+}
+
+// TestMemoryAuditStore_Query_Filter tests filtering
+func TestMemoryAuditStore_Query_Filter(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	ctx := context.Background()
+
+	// Save events with different levels
+	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
+
+	// Filter by action
+	results, _ := store.Query(ctx, security.AuditFilter{
+		Actions: []security.AuditAction{security.AuditActionBlocked},
+	})
+	if len(results) != 2 {
+		t.Errorf("Query(actions=[blocked]) returned %d, want 2", len(results))
+	}
+
+	// Filter by user
+	results2, _ := store.Query(ctx, security.AuditFilter{
+		UserID: "user-1",
+	})
+	if len(results2) != 3 {
+		t.Errorf("Query(user=user-1) returned %d, want 3", len(results2))
+	}
+
+	// Filter by session
+	results3, _ := store.Query(ctx, security.AuditFilter{
+		SessionID: "nonexistent",
+	})
+	if len(results3) != 0 {
+		t.Errorf("Query(session=nonexistent) returned %d, want 0", len(results3))
+	}
+
+	// Filter with limit
+	results4, _ := store.Query(ctx, security.AuditFilter{
+		Limit: 1,
+	})
+	if len(results4) != 1 {
+		t.Errorf("Query(limit=1) returned %d, want 1", len(results4))
+	}
+}
+
+// TestMemoryAuditStore_Query_TimeFilter tests time-based filtering
+func TestMemoryAuditStore_Query_TimeFilter(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	ctx := context.Background()
+
+	// Save old event
+	oldEvent := sampleEvent(security.DangerLevelModerate, security.AuditActionApproved)
+	oldEvent.Timestamp = time.Now().Add(-1 * time.Hour)
+	store.Save(ctx, oldEvent)
+
+	// Query with start time filter
+	results, _ := store.Query(ctx, security.AuditFilter{
+		StartTime: time.Now().Add(-30 * time.Minute),
+	})
+	if len(results) != 0 {
+		t.Errorf("Query(start_time=30m ago) returned %d, want 0", len(results))
+	}
+}
+
+// TestMemoryAuditStore_Stats tests statistics
+func TestMemoryAuditStore_Stats(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	ctx := context.Background()
+
+	// Save events
+	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+	store.Save(ctx, sampleEvent(security.DangerLevelHigh, security.AuditActionBlocked))
+
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats() error: %v", err)
+	}
+
+	if stats.TotalApproved != 1 {
+		t.Errorf("TotalApproved = %d, want 1", stats.TotalApproved)
+	}
+	if stats.TotalBlocked != 2 {
+		t.Errorf("TotalBlocked = %d, want 2", stats.TotalBlocked)
+	}
+}
+
+// TestMemoryAuditStore_Close tests close (no-op)
+func TestMemoryAuditStore_Close(t *testing.T) {
+	store := NewMemoryAuditStore(100)
+	if err := store.Close(); err != nil {
+		t.Errorf("Close() error: %v", err)
+	}
+}
+
+// TestFileAuditStore_New tests constructor
+func TestFileAuditStore_New(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	filename := filepath.Join(tmpDir, "audit.jsonl")
+	store, err := NewFileAuditStore(filename)
+	if err != nil {
+		t.Fatalf("NewFileAuditStore() error: %v", err)
+	}
+	if store == nil {
+		t.Fatal("NewFileAuditStore() returned nil")
+	}
+	defer func() { _ = store.Close() }()
+}
+
+// TestFileAuditStore_New_EmptyFilename tests empty filename error
+func TestFileAuditStore_New_EmptyFilename(t *testing.T) {
+	_, err := NewFileAuditStore("")
+	if err == nil {
+		t.Error("NewFileAuditStore('') should return error")
+	}
+}
+
+// TestFileAuditStore_New_NonexistentDir tests directory creation
+func TestFileAuditStore_New_NonexistentDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create nested path that doesn't exist
+	filename := filepath.Join(tmpDir, "nested", "path", "audit.jsonl")
+	store, err := NewFileAuditStore(filename)
+	if err != nil {
+		t.Fatalf("NewFileAuditStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+}
+
+// TestFileAuditStore_Save_Query tests save and query
+func TestFileAuditStore_Save_Query(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "audit-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	filename := filepath.Join(tmpDir, "audit.jsonl")
+	store, err := NewFileAuditStore(filename)
+	if err != nil {
+		t.Fatalf("NewFileAuditStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// Save event
+	event := sampleEvent(security.DangerLevelModerate, security.AuditActionApproved)
+	if err := store.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Query
+	results, err := store.Query(ctx, security.AuditFilter{})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Query() returned %d results, want 1", len(results))
+	}
+}
+
+// TestFileAuditStore_Save_NilEvent tests nil event error
+func TestFileAuditStore_Save_NilEvent(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "audit.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	err := store.Save(context.Background(), nil)
+	if err == nil {
+		t.Error("Save(nil) should return error")
+	}
+}
+
+// TestFileAuditStore_Query_NonexistentFile tests query on empty file
+func TestFileAuditStore_Query_NonexistentFile(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "nonexistent.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	results, err := store.Query(context.Background(), security.AuditFilter{})
+	if err != nil {
+		t.Fatalf("Query() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Query() returned %d, want 0", len(results))
+	}
+}
+
+// TestFileAuditStore_Query_Filter tests filtering
+func TestFileAuditStore_Query_Filter(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "audit.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// Save events
+	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+
+	// Filter by action
+	results, _ := store.Query(ctx, security.AuditFilter{
+		Actions: []security.AuditAction{security.AuditActionBlocked},
+	})
+	if len(results) != 1 {
+		t.Errorf("Query(actions=[blocked]) returned %d, want 1", len(results))
+	}
+
+	// Filter with limit
+	results2, _ := store.Query(ctx, security.AuditFilter{
+		Limit: 1,
+	})
+	if len(results2) != 1 {
+		t.Errorf("Query(limit=1) returned %d, want 1", len(results2))
+	}
+}
+
+// TestFileAuditStore_Stats tests statistics
+func TestFileAuditStore_Stats(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "audit.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// Save events
+	store.Save(ctx, sampleEvent(security.DangerLevelModerate, security.AuditActionApproved))
+	store.Save(ctx, sampleEvent(security.DangerLevelCritical, security.AuditActionBlocked))
+
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats() error: %v", err)
+	}
+
+	if stats.TotalApproved != 1 {
+		t.Errorf("TotalApproved = %d, want 1", stats.TotalApproved)
+	}
+	if stats.TotalBlocked != 1 {
+		t.Errorf("TotalBlocked = %d, want 1", stats.TotalBlocked)
+	}
+}
+
+// TestFileAuditStore_Stats_NonexistentFile tests stats on nonexistent file
+func TestFileAuditStore_Stats_NonexistentFile(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "nonexistent.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	stats, err := store.Stats(context.Background())
+	if err != nil {
+		t.Fatalf("Stats() error: %v", err)
+	}
+	if stats.TotalBlocked != 0 {
+		t.Errorf("TotalBlocked = %d, want 0", stats.TotalBlocked)
+	}
+}
+
+// TestFileAuditStore_Close tests close
+func TestFileAuditStore_Close(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "audit.jsonl"))
+
+	if err := store.Close(); err != nil {
+		t.Errorf("Close() error: %v", err)
+	}
+}
+
+// TestFileAuditStore_AutoTimestamp tests automatic timestamp
+func TestFileAuditStore_AutoTimestamp(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "audit-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewFileAuditStore(filepath.Join(tmpDir, "audit.jsonl"))
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// Save event without timestamp
+	event := &security.AuditEvent{
+		Input:     "test",
+		Operation: "op",
+		Level:     security.DangerLevelModerate,
+		Action:    security.AuditActionApproved,
+	}
+
+	if err := store.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Verify timestamp was set
+	results, _ := store.Query(ctx, security.AuditFilter{})
+	if len(results) != 1 {
+		t.Fatalf("Query() returned %d, want 1", len(results))
+	}
+	if results[0].Timestamp.IsZero() {
+		t.Error("Timestamp should be auto-set")
+	}
+	if results[0].ID == "" {
+		t.Error("ID should be auto-set")
+	}
+}

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -512,11 +512,13 @@ func (bp *BridgePlatform) SendMessage(ctx context.Context, sessionID string, msg
 	if msg == nil {
 		return nil
 	}
+	wm, _ := bp.buildWireMessage(msg)
+	return bp.writeJSON(wm)
+}
 
-	// Build wire metadata
-	meta := WireMetadata{
-		Platform: "hotplex",
-	}
+// buildWireMessage builds a Bridge WireMessage from a ChatMessage.
+func (bp *BridgePlatform) buildWireMessage(msg *base.ChatMessage) (*WireMessage, []byte) {
+	meta := WireMetadata{Platform: "hotplex"}
 	if msg.Metadata != nil {
 		if v, ok := msg.Metadata[base.KeyRoomID].(string); ok {
 			meta.RoomID = v
@@ -530,23 +532,20 @@ func (bp *BridgePlatform) SendMessage(ctx context.Context, sessionID string, msg
 	}
 	metaBytes, _ := json.Marshal(meta)
 
-	// Resolve session key
+	sessionKey := msg.SessionID
 	bp.mu.RLock()
-	sessionKey := sessionID
-	if sk, ok := bp.sessionMap[sessionID]; ok {
+	if sk, ok := bp.sessionMap[msg.SessionID]; ok {
 		sessionKey = sk
 	}
 	bp.mu.RUnlock()
 
-	wm := &WireMessage{
+	return &WireMessage{
 		Type:       BridgeMsgTypeMessage,
 		Platform:   "hotplex",
 		SessionKey: sessionKey,
 		Content:    msg.Content,
 		Metadata:   metaBytes,
-	}
-
-	return bp.writeJSON(wm)
+	}, metaBytes
 }
 
 // HandleMessage is not used for bridge platforms (they receive via WebSocket).

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -26,60 +26,38 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/internal/bridgewire"
 	"github.com/hrygo/hotplex/types"
 )
 
-// Bridge Wire Protocol message types (client → server direction).
+// BridgeMsgType* aliases are kept for backward compatibility within the server package.
 const (
-	BridgeMsgTypeRegister  = "register"
-	BridgeMsgTypeMessage   = "message"
-	BridgeMsgTypeReply     = "reply"
-	BridgeMsgTypeEvent     = "event"
-	BridgeMsgTypeError     = "error"
+	BridgeMsgTypeRegister = bridgewire.MsgTypeRegister
+	BridgeMsgTypeMessage  = bridgewire.MsgTypeMessage
+	BridgeMsgTypeReply    = bridgewire.MsgTypeReply
+	BridgeMsgTypeEvent    = bridgewire.MsgTypeEvent
+	BridgeMsgTypeError    = bridgewire.MsgTypeError
 )
 
-// Bridge capability constants.
+// Cap* aliases for internal use (mirrors bridgewire constants).
 const (
-	CapText    = "text"
-	CapImage   = "image"
-	CapCard    = "card"
-	CapButtons = "buttons"
-	CapTyping  = "typing"
-	CapEdit    = "edit"
-	CapDelete  = "delete"
-	CapReact   = "react"
-	CapThread  = "thread"
+	CapText    = bridgewire.CapText
+	CapImage   = bridgewire.CapImage
+	CapCard    = bridgewire.CapCard
+	CapButtons = bridgewire.CapButtons
+	CapTyping  = bridgewire.CapTyping
+	CapEdit    = bridgewire.CapEdit
+	CapDelete  = bridgewire.CapDelete
+	CapReact   = bridgewire.CapReact
+	CapThread  = bridgewire.CapThread
 )
 
-// All supported capabilities.
-var allCapabilities = []string{CapText, CapImage, CapCard, CapButtons, CapTyping, CapEdit, CapDelete, CapReact, CapThread}
+// AllCapabilities re-exports the shared list for internal use.
+var allCapabilities = bridgewire.AllCapabilities
 
-// =============================================================================
-// Wire Protocol Types
-// =============================================================================
-
-// WireMessage is the bidirectional JSON envelope for Bridge protocol.
-type WireMessage struct {
-	Type        string          `json:"type"`
-	Platform    string          `json:"platform,omitempty"`
-	Token       string          `json:"token,omitempty"`
-	SessionKey  string          `json:"session_key,omitempty"`
-	Content     string          `json:"content,omitempty"`
-	Metadata    json.RawMessage `json:"metadata,omitempty"`
-	Event       string          `json:"event,omitempty"`
-	Data        json.RawMessage `json:"data,omitempty"`
-	Code        int             `json:"code,omitempty"`
-	Message     string          `json:"message,omitempty"`
-	Capabilities []string       `json:"capabilities,omitempty"`
-}
-
-// WireMetadata is the metadata carried inside WireMessage.
-type WireMetadata struct {
-	UserID   string `json:"user_id,omitempty"`
-	RoomID   string `json:"room_id,omitempty"`
-	ThreadID string `json:"thread_id,omitempty"`
-	Platform string `json:"platform,omitempty"`
-}
+// WireMessage and WireMetadata are type aliases to the shared bridgewire package.
+type WireMessage = bridgewire.WireMessage
+type WireMetadata = bridgewire.WireMetadata
 
 // =============================================================================
 // BridgeServer

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -222,17 +222,18 @@ func (s *BridgeServer) Close() {
 // via BridgeServer WebSocket. It translates between the Bridge Wire Protocol and
 // HotPlex's internal ChatMessage type.
 type BridgePlatform struct {
-	server     *BridgeServer
-	platform   string
-	conn       *websocket.Conn
-	caps       []string
-	handler    base.MessageHandler
-	msgChan    chan *base.ChatMessage
-	eventChan  chan *WireMessage
-	sessionMap map[string]string // sessionKey → sessionID
-	done       chan struct{}
-	mu         sync.RWMutex
-	logger     *slog.Logger
+	server        *BridgeServer
+	platform      string
+	conn          *websocket.Conn
+	caps          []string
+	handler       base.MessageHandler
+	msgChan       chan *base.ChatMessage
+	eventChan     chan *WireMessage
+	sessionMap    map[string]string // sessionKey → sessionID
+	done          chan struct{}
+	mu            sync.RWMutex
+	logger        *slog.Logger
+	testWriteJSON func(wm *WireMessage) error // test hook for writeJSON
 }
 
 var (
@@ -431,6 +432,11 @@ func (bp *BridgePlatform) handleUnknown(wm *WireMessage) error {
 
 // writeJSON sends a WireMessage to the WebSocket connection.
 func (bp *BridgePlatform) writeJSON(wm *WireMessage) error {
+	// Test hook for mocking WebSocket writes
+	if bp.testWriteJSON != nil {
+		return bp.testWriteJSON(wm)
+	}
+
 	bp.mu.RLock()
 	conn := bp.conn
 	bp.mu.RUnlock()

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -274,7 +274,7 @@ func (bp *BridgePlatform) readLoop() {
 
 		var wm WireMessage
 		if err := json.Unmarshal(p, &wm); err != nil {
-			bp.writeError(400, "invalid JSON: "+err.Error())
+			_ = bp.writeError(400, "invalid JSON: "+err.Error())
 			continue
 		}
 
@@ -283,11 +283,31 @@ func (bp *BridgePlatform) readLoop() {
 				"platform", bp.platform,
 				"type", wm.Type,
 				"error", err)
-			bp.writeError(500, err.Error())
+			_ = bp.writeError(500, err.Error())
 		}
 	}
 }
 
+// deliveryLoop drains msgChan and writes each ChatMessage to the WebSocket.
+func (bp *BridgePlatform) deliveryLoop() {
+	for {
+		select {
+		case <-bp.done:
+			return
+		case msg := <-bp.msgChan:
+			if msg == nil {
+				continue
+			}
+			wm, _ := bp.buildWireMessage(msg)
+			if err := bp.writeJSON(wm); err != nil {
+				bp.logger.Debug("Bridge delivery failed, message dropped",
+					"platform", bp.platform,
+					"session_id", msg.SessionID,
+					"error", err)
+			}
+		}
+	}
+}
 // handleWireMessage dispatches a WireMessage to the appropriate handler.
 func (bp *BridgePlatform) handleWireMessage(wm *WireMessage) error {
 	switch wm.Type {
@@ -449,7 +469,7 @@ func (bp *BridgePlatform) close() {
 	}
 
 	if bp.conn != nil {
-		bp.conn.Close()
+		_ = bp.conn.Close()
 		bp.conn = nil
 	}
 }

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -95,6 +95,7 @@ type BridgeServer struct {
 	upgrader   websocket.Upgrader
 	logger     *slog.Logger
 	handler    base.MessageHandler
+	adapterMgr any // *chatapps.AdapterManager (any to avoid import cycle)
 	mu         sync.RWMutex
 	server     *http.Server
 }
@@ -124,6 +125,13 @@ func NewBridgeServer(port int, token string, logger *slog.Logger) *BridgeServer 
 // This is called by main.go after the chatapps EngineMessageHandler is created.
 func (s *BridgeServer) SetHandler(h base.MessageHandler) {
 	s.handler = h
+}
+
+// InjectAdapterManager injects the chatapps AdapterManager for registering
+// bridge platforms so they can receive events via the standard event pipeline.
+// Pass nil to disable event routing for bridge platforms.
+func (s *BridgeServer) InjectAdapterManager(adapterMgr any) {
+	s.adapterMgr = adapterMgr
 }
 
 // GetPlatform returns the BridgePlatform for a registered platform, or nil.
@@ -189,11 +197,33 @@ func (s *BridgeServer) register(bp *BridgePlatform) {
 	s.platforms[bp.platform] = bp
 }
 
-// unregister removes a platform from the registry.
+// unregister removes a platform from the registry and AdapterManager.
 func (s *BridgeServer) unregister(platform string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.platforms, platform)
+	// Also remove from AdapterManager so events stop routing to this platform
+	if am := s.getAdapterManager(); am != nil {
+		am.Unregister(platform)
+	}
+}
+
+// getAdapterManager returns the injected AdapterManager, if available.
+func (s *BridgeServer) getAdapterManager() adapterManagerInterface {
+	if s.adapterMgr == nil {
+		return nil
+	}
+	if ami, ok := s.adapterMgr.(adapterManagerInterface); ok {
+		return ami
+	}
+	return nil
+}
+
+// adapterManagerInterface is the subset of *chatapps.AdapterManager needed by BridgeServer.
+// Defined as interface to avoid import cycle.
+type adapterManagerInterface interface {
+	RegisterOrReplace(any) // ChatAdapter
+	Unregister(platform string)
 }
 
 // Close gracefully shuts down all bridge connections.
@@ -315,6 +345,14 @@ func (bp *BridgePlatform) handleRegister(wm *WireMessage) error {
 	bp.server.platforms[wm.Platform] = bp
 	bp.server.mu.Unlock()
 
+	// Register with AdapterManager so events flow through the standard pipeline
+	if am := bp.getAdapterManager(); am != nil {
+		am.RegisterOrReplace(bp)
+		bp.logger.Info("BridgePlatform registered with AdapterManager",
+			"platform", wm.Platform,
+			"capabilities", bp.caps)
+	}
+
 	bp.logger.Info("Bridge platform registered",
 		"platform", wm.Platform,
 		"capabilities", bp.caps)
@@ -325,6 +363,18 @@ func (bp *BridgePlatform) handleRegister(wm *WireMessage) error {
 		Platform: "hotplex",
 		Content:  "registered",
 	})
+}
+
+// getAdapterManager returns the injected AdapterManager, if available.
+func (bp *BridgePlatform) getAdapterManager() adapterManagerInterface {
+	am := bp.server.adapterMgr
+	if am == nil {
+		return nil
+	}
+	if ami, ok := am.(adapterManagerInterface); ok {
+		return ami
+	}
+	return nil
 }
 
 // handleMessage converts an inbound WireMessage to ChatMessage and forwards to handler.

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +29,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/hrygo/hotplex/chatapps/base"
 	"github.com/hrygo/hotplex/internal/bridgewire"
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/types"
 )
 
@@ -58,6 +61,32 @@ var allCapabilities = bridgewire.AllCapabilities
 // WireMessage and WireMetadata are type aliases to the shared bridgewire package.
 type WireMessage = bridgewire.WireMessage
 type WireMetadata = bridgewire.WireMetadata
+
+// Platform name validation regex: lowercase alphanumeric, underscore, hyphen, 1-32 chars
+var platformNameRegex = regexp.MustCompile(`^[a-z0-9_-]{1,32}$`)
+
+// Reserved platform names that cannot be used by bridge adapters
+var reservedPlatformNames = map[string]bool{
+	"slack":    true,
+	"feishu":   true,
+	"dingtalk": true,
+	"wechat":   true,
+	"telegram": true,
+	"discord":  true,
+}
+
+func validatePlatformName(name string) error {
+	if !platformNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid platform name %q: must match %s", name, platformNameRegex.String())
+	}
+	if reservedPlatformNames[name] {
+		return fmt.Errorf("platform name %q is reserved for built-in platform", name)
+	}
+	return nil
+}
+
+// Global WAF detector for BridgeServer input validation
+var wafDetector = security.NewDetector(nil)
 
 // =============================================================================
 // BridgeServer
@@ -146,8 +175,19 @@ func (s *BridgeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	platform := parts[0]
 
-	// Authenticate via token
-	token := r.URL.Query().Get("token")
+	// Authenticate via token (prefer Authorization header, fallback to query param)
+	authHeader := r.Header.Get("Authorization")
+	token := ""
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		token = strings.TrimPrefix(authHeader, "Bearer ")
+	} else {
+		// Fallback to query param for backwards compatibility (deprecated)
+		token = r.URL.Query().Get("token")
+		if token != "" {
+			s.logger.Warn("Token passed via URL query is deprecated, use Authorization header instead",
+				"platform", platform)
+		}
+	}
 	if s.token != "" && token != s.token {
 		s.logger.Warn("Bridge auth failed", "platform", platform, "reason", "invalid_token")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -332,6 +372,16 @@ func (bp *BridgePlatform) handleRegister(wm *WireMessage) error {
 	if wm.Platform == "" {
 		return errors.New("register: platform name required")
 	}
+
+	// Validate platform name to prevent injection and conflicts
+	if err := validatePlatformName(wm.Platform); err != nil {
+		bp.logger.Warn("Bridge registration rejected: invalid platform name",
+			"platform", wm.Platform,
+			"error", err)
+		_ = bp.writeError(400, err.Error()) // best-effort notify client
+		return err
+	}
+
 	bp.mu.Lock()
 	bp.platform = wm.Platform
 	if len(wm.Capabilities) > 0 {
@@ -380,6 +430,15 @@ func (bp *BridgePlatform) getAdapterManager() adapterManagerInterface {
 func (bp *BridgePlatform) handleMessage(wm *WireMessage) error {
 	if wm.SessionKey == "" {
 		return errors.New("message: session_key required")
+	}
+
+	// WAF security check - validate external input
+	if event := wafDetector.CheckInput(wm.Content); event != nil {
+		bp.logger.Warn("Bridge message blocked by WAF",
+			"platform", bp.platform,
+			"session_key", wm.SessionKey,
+			"reason", event.Reason)
+		return bp.writeError(400, "message blocked by security policy")
 	}
 
 	// Parse metadata

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -450,7 +450,7 @@ func (bp *BridgePlatform) writeJSON(wm *WireMessage) error {
 		return err
 	}
 
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	return conn.WriteMessage(websocket.TextMessage, data)
 }
 

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -1,0 +1,535 @@
+// Package server provides the BridgeServer for external platform adapters.
+//
+// BridgeServer implements a WebSocket gateway that allows external platform adapters
+// (e.g., DingTalk, WeChat) to connect to HotPlex without being compiled into the
+// same binary. External adapters connect as WebSocket clients and communicate via
+// the Bridge Wire Protocol.
+//
+// Architecture:
+//
+//	External Adapter (DingTalk) ──WebSocket──> BridgeServer ──ChatAdapter──> Engine
+//	                                          <────────────── reply ───────────────
+//
+// BridgePlatform implements base.ChatAdapter, so HotPlex's engine handler is
+// agnostic to whether the platform is built-in or external via BridgeServer.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/hrygo/hotplex/chatapps/base"
+	"github.com/hrygo/hotplex/types"
+)
+
+// Bridge Wire Protocol message types (client → server direction).
+const (
+	BridgeMsgTypeRegister  = "register"
+	BridgeMsgTypeMessage   = "message"
+	BridgeMsgTypeReply     = "reply"
+	BridgeMsgTypeEvent     = "event"
+	BridgeMsgTypeError     = "error"
+)
+
+// Bridge capability constants.
+const (
+	CapText    = "text"
+	CapImage   = "image"
+	CapCard    = "card"
+	CapButtons = "buttons"
+	CapTyping  = "typing"
+	CapEdit    = "edit"
+	CapDelete  = "delete"
+	CapReact   = "react"
+	CapThread  = "thread"
+)
+
+// All supported capabilities.
+var allCapabilities = []string{CapText, CapImage, CapCard, CapButtons, CapTyping, CapEdit, CapDelete, CapReact, CapThread}
+
+// =============================================================================
+// Wire Protocol Types
+// =============================================================================
+
+// WireMessage is the bidirectional JSON envelope for Bridge protocol.
+type WireMessage struct {
+	Type        string          `json:"type"`
+	Platform    string          `json:"platform,omitempty"`
+	Token       string          `json:"token,omitempty"`
+	SessionKey  string          `json:"session_key,omitempty"`
+	Content     string          `json:"content,omitempty"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+	Event       string          `json:"event,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+	Code        int             `json:"code,omitempty"`
+	Message     string          `json:"message,omitempty"`
+	Capabilities []string       `json:"capabilities,omitempty"`
+}
+
+// WireMetadata is the metadata carried inside WireMessage.
+type WireMetadata struct {
+	UserID   string `json:"user_id,omitempty"`
+	RoomID   string `json:"room_id,omitempty"`
+	ThreadID string `json:"thread_id,omitempty"`
+	Platform string `json:"platform,omitempty"`
+}
+
+// =============================================================================
+// BridgeServer
+// =============================================================================
+
+// BridgeServer is a WebSocket gateway for external platform adapters.
+// It implements http.Handler and bridges the Bridge Wire Protocol to HotPlex's
+// internal ChatMessage types.
+type BridgeServer struct {
+	port       int
+	token      string
+	platforms  map[string]*BridgePlatform
+	upgrader   websocket.Upgrader
+	logger     *slog.Logger
+	handler    base.MessageHandler
+	mu         sync.RWMutex
+	server     *http.Server
+}
+
+// NewBridgeServer creates a new BridgeServer.
+func NewBridgeServer(port int, token string, logger *slog.Logger) *BridgeServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	bs := &BridgeServer{
+		port:      port,
+		token:     token,
+		platforms: make(map[string]*BridgePlatform),
+		logger:    logger,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				return true // Bridge clients are authenticated via token
+			},
+		},
+	}
+	return bs
+}
+
+// SetHandler sets the MessageHandler that receives all messages from bridge adapters.
+// This is called by main.go after the chatapps EngineMessageHandler is created.
+func (s *BridgeServer) SetHandler(h base.MessageHandler) {
+	s.handler = h
+}
+
+// GetPlatform returns the BridgePlatform for a registered platform, or nil.
+func (s *BridgeServer) GetPlatform(name string) *BridgePlatform {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.platforms[name]
+	if !ok {
+		return nil
+	}
+	return p
+}
+
+// ListPlatforms returns all registered platform names.
+func (s *BridgeServer) ListPlatforms() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.platforms))
+	for n := range s.platforms {
+		names = append(names, n)
+	}
+	return names
+}
+
+// ServeHTTP implements http.Handler for the /bridge/v1/ endpoint.
+func (s *BridgeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Extract platform name from path: /bridge/v1/connect/{platform}
+	path := strings.TrimPrefix(r.URL.Path, "/bridge/v1/")
+	path = strings.TrimPrefix(path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 1 || parts[0] == "" {
+		http.Error(w, "platform name required", http.StatusBadRequest)
+		return
+	}
+	platform := parts[0]
+
+	// Authenticate via token
+	token := r.URL.Query().Get("token")
+	if s.token != "" && token != s.token {
+		s.logger.Warn("Bridge auth failed", "platform", platform, "reason", "invalid_token")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Error("Bridge upgrade failed", "platform", platform, "error", err)
+		return
+	}
+
+	bp := s.newBridgePlatform(platform, conn)
+	s.register(bp)
+	defer s.unregister(platform)
+
+	s.logger.Info("Bridge platform connected", "platform", platform, "addr", r.RemoteAddr)
+	bp.readLoop()
+}
+
+// register adds a platform to the registry.
+func (s *BridgeServer) register(bp *BridgePlatform) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.platforms[bp.platform] = bp
+}
+
+// unregister removes a platform from the registry.
+func (s *BridgeServer) unregister(platform string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.platforms, platform)
+}
+
+// Close gracefully shuts down all bridge connections.
+func (s *BridgeServer) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, bp := range s.platforms {
+		bp.close()
+	}
+	s.platforms = make(map[string]*BridgePlatform)
+}
+
+// =============================================================================
+// BridgePlatform
+// =============================================================================
+
+// BridgePlatform implements base.ChatAdapter for an external platform connected
+// via BridgeServer WebSocket. It translates between the Bridge Wire Protocol and
+// HotPlex's internal ChatMessage type.
+type BridgePlatform struct {
+	server     *BridgeServer
+	platform   string
+	conn       *websocket.Conn
+	caps       []string
+	handler    base.MessageHandler
+	msgChan    chan *base.ChatMessage
+	eventChan  chan *WireMessage
+	sessionMap map[string]string // sessionKey → sessionID
+	done       chan struct{}
+	mu         sync.RWMutex
+	logger     *slog.Logger
+}
+
+var (
+	_ base.ChatAdapter = (*BridgePlatform)(nil)
+	_ http.Handler     = (*BridgeServer)(nil)
+)
+
+// newBridgePlatform creates a new BridgePlatform for a WebSocket connection.
+func (s *BridgeServer) newBridgePlatform(platform string, conn *websocket.Conn) *BridgePlatform {
+	return &BridgePlatform{
+		server:     s,
+		platform:   platform,
+		conn:       conn,
+		caps:       []string{CapText}, // defaults
+		msgChan:    make(chan *base.ChatMessage, 100),
+		eventChan:  make(chan *WireMessage, 100),
+		sessionMap: make(map[string]string),
+		done:       make(chan struct{}),
+		logger:     s.logger,
+	}
+}
+
+// readLoop processes incoming WebSocket messages from the external adapter.
+func (bp *BridgePlatform) readLoop() {
+	defer bp.close()
+
+	for {
+		msgType, p, err := bp.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				bp.logger.Debug("Bridge read error", "platform", bp.platform, "error", err)
+			}
+			return
+		}
+
+		if msgType != websocket.TextMessage {
+			continue
+		}
+
+		var wm WireMessage
+		if err := json.Unmarshal(p, &wm); err != nil {
+			bp.writeError(400, "invalid JSON: "+err.Error())
+			continue
+		}
+
+		if err := bp.handleWireMessage(&wm); err != nil {
+			bp.logger.Error("Bridge message handle error",
+				"platform", bp.platform,
+				"type", wm.Type,
+				"error", err)
+			bp.writeError(500, err.Error())
+		}
+	}
+}
+
+// handleWireMessage dispatches a WireMessage to the appropriate handler.
+func (bp *BridgePlatform) handleWireMessage(wm *WireMessage) error {
+	switch wm.Type {
+	case BridgeMsgTypeRegister:
+		return bp.handleRegister(wm)
+	case BridgeMsgTypeMessage:
+		return bp.handleMessage(wm)
+	case BridgeMsgTypeEvent:
+		return bp.handleEvent(wm)
+	case BridgeMsgTypeReply:
+		// Async reply acknowledgment — currently a no-op
+		bp.logger.Debug("Bridge reply ack received", "platform", bp.platform, "session_key", wm.SessionKey)
+		return nil
+	default:
+		return bp.handleUnknown(wm)
+	}
+}
+
+// handleRegister processes the registration handshake from an external adapter.
+func (bp *BridgePlatform) handleRegister(wm *WireMessage) error {
+	if wm.Platform == "" {
+		return errors.New("register: platform name required")
+	}
+	bp.mu.Lock()
+	bp.platform = wm.Platform
+	if len(wm.Capabilities) > 0 {
+		bp.caps = wm.Capabilities
+	}
+	bp.mu.Unlock()
+
+	// Update registration in server
+	bp.server.mu.Lock()
+	bp.server.platforms[wm.Platform] = bp
+	bp.server.mu.Unlock()
+
+	bp.logger.Info("Bridge platform registered",
+		"platform", wm.Platform,
+		"capabilities", bp.caps)
+
+	// Send ack
+	return bp.writeJSON(&WireMessage{
+		Type:     BridgeMsgTypeReply,
+		Platform: "hotplex",
+		Content:  "registered",
+	})
+}
+
+// handleMessage converts an inbound WireMessage to ChatMessage and forwards to handler.
+func (bp *BridgePlatform) handleMessage(wm *WireMessage) error {
+	if wm.SessionKey == "" {
+		return errors.New("message: session_key required")
+	}
+
+	// Parse metadata
+	var meta WireMetadata
+	if len(wm.Metadata) > 0 {
+		_ = json.Unmarshal(wm.Metadata, &meta)
+	}
+
+	msg := &base.ChatMessage{
+		Platform:  bp.platform,
+		SessionID: wm.SessionKey,
+		Content:   wm.Content,
+		Type:      types.MessageTypeUserInput,
+		Metadata: map[string]any{
+			base.KeyRoomID:   meta.RoomID,
+			base.KeyThreadID: meta.ThreadID,
+			base.KeyUserID:   meta.UserID,
+			"platform":      bp.platform,
+		},
+		Timestamp: time.Now(),
+	}
+
+	// Store sessionKey → sessionID mapping
+	bp.mu.Lock()
+	bp.sessionMap[msg.SessionID] = wm.SessionKey
+	bp.mu.Unlock()
+
+	// Forward to HotPlex handler
+	if bp.handler != nil {
+		return bp.handler(context.Background(), msg)
+	}
+	return nil
+}
+
+// handleEvent forwards platform events to HotPlex (e.g., typing indicators).
+func (bp *BridgePlatform) handleEvent(wm *WireMessage) error {
+	bp.logger.Debug("Bridge event received",
+		"platform", bp.platform,
+		"event", wm.Event,
+		"session_key", wm.SessionKey)
+	// Events are informational — forward to handler if it cares
+	return nil
+}
+
+// handleUnknown handles unrecognized message types.
+func (bp *BridgePlatform) handleUnknown(wm *WireMessage) error {
+	bp.logger.Warn("Unknown bridge message type", "platform", bp.platform, "type", wm.Type)
+	return bp.writeError(400, "unknown message type: "+wm.Type)
+}
+
+// writeJSON sends a WireMessage to the WebSocket connection.
+func (bp *BridgePlatform) writeJSON(wm *WireMessage) error {
+	bp.mu.RLock()
+	conn := bp.conn
+	bp.mu.RUnlock()
+
+	if conn == nil {
+		return errors.New("connection closed")
+	}
+
+	data, err := json.Marshal(wm)
+	if err != nil {
+		return err
+	}
+
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// writeError sends an error WireMessage.
+func (bp *BridgePlatform) writeError(code int, message string) error {
+	return bp.writeJSON(&WireMessage{
+		Type:    BridgeMsgTypeError,
+		Code:    code,
+		Message: message,
+	})
+}
+
+// close closes the WebSocket connection.
+func (bp *BridgePlatform) close() {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+
+	select {
+	case <-bp.done:
+	default:
+		close(bp.done)
+	}
+
+	if bp.conn != nil {
+		bp.conn.Close()
+		bp.conn = nil
+	}
+}
+
+// =============================================================================
+// base.ChatAdapter Implementation
+// =============================================================================
+
+// Platform returns the platform name.
+func (bp *BridgePlatform) Platform() string {
+	bp.mu.RLock()
+	defer bp.mu.RUnlock()
+	return bp.platform
+}
+
+// SystemPrompt returns a default system prompt for bridge platforms.
+func (bp *BridgePlatform) SystemPrompt() string {
+	return "You are a helpful AI assistant."
+}
+
+// Start starts the bridge platform (no-op; connection is established externally).
+func (bp *BridgePlatform) Start(ctx context.Context) error {
+	return nil
+}
+
+// Stop stops the bridge platform.
+func (bp *BridgePlatform) Stop() error {
+	bp.close()
+	return nil
+}
+
+// SendMessage sends a ChatMessage to the external platform via WebSocket.
+func (bp *BridgePlatform) SendMessage(ctx context.Context, sessionID string, msg *base.ChatMessage) error {
+	if msg == nil {
+		return nil
+	}
+
+	// Build wire metadata
+	meta := WireMetadata{
+		Platform: "hotplex",
+	}
+	if msg.Metadata != nil {
+		if v, ok := msg.Metadata[base.KeyRoomID].(string); ok {
+			meta.RoomID = v
+		}
+		if v, ok := msg.Metadata[base.KeyThreadID].(string); ok {
+			meta.ThreadID = v
+		}
+		if v, ok := msg.Metadata[base.KeyUserID].(string); ok {
+			meta.UserID = v
+		}
+	}
+	metaBytes, _ := json.Marshal(meta)
+
+	// Resolve session key
+	bp.mu.RLock()
+	sessionKey := sessionID
+	if sk, ok := bp.sessionMap[sessionID]; ok {
+		sessionKey = sk
+	}
+	bp.mu.RUnlock()
+
+	wm := &WireMessage{
+		Type:       BridgeMsgTypeMessage,
+		Platform:   "hotplex",
+		SessionKey: sessionKey,
+		Content:    msg.Content,
+		Metadata:   metaBytes,
+	}
+
+	return bp.writeJSON(wm)
+}
+
+// HandleMessage is not used for bridge platforms (they receive via WebSocket).
+func (bp *BridgePlatform) HandleMessage(ctx context.Context, msg *base.ChatMessage) error {
+	return nil
+}
+
+// SetHandler sets the MessageHandler for incoming messages.
+func (bp *BridgePlatform) SetHandler(h base.MessageHandler) {
+	bp.handler = h
+}
+
+// =============================================================================
+// Server Lifecycle
+// =============================================================================
+
+// ListenAndServe starts the BridgeServer HTTP listener.
+// It blocks until the server is closed.
+func (s *BridgeServer) ListenAndServe(addr string) error {
+	mux := http.NewServeMux()
+	mux.Handle("/bridge/v1/", s)
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	s.server = srv
+
+	s.logger.Info("BridgeServer listening", "addr", addr)
+	return srv.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the BridgeServer.
+func (s *BridgeServer) Shutdown(ctx context.Context) error {
+	s.Close()
+	if s.server != nil {
+		return s.server.Shutdown(ctx)
+	}
+	return nil
+}

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/hrygo/hotplex/chatapps/base"
+)
+
+func TestWireMessageRegister(t *testing.T) {
+	wm := WireMessage{
+		Type:         BridgeMsgTypeRegister,
+		Platform:    "dingtalk",
+		Token:       "secret",
+		Capabilities: []string{CapText, CapCard},
+	}
+	data, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal register: %v", err)
+	}
+
+	var got WireMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal register: %v", err)
+	}
+
+	if got.Type != BridgeMsgTypeRegister {
+		t.Errorf("Type=%s, want %s", got.Type, BridgeMsgTypeRegister)
+	}
+	if got.Platform != "dingtalk" {
+		t.Errorf("Platform=%s, want dingtalk", got.Platform)
+	}
+	if len(got.Capabilities) != 2 {
+		t.Errorf("Capabilities len=%d, want 2", len(got.Capabilities))
+	}
+}
+
+func TestWireMessageMessage(t *testing.T) {
+	meta := WireMetadata{
+		UserID:   "u123",
+		RoomID:   "r456",
+		ThreadID: "t789",
+	}
+	metaBytes, _ := json.Marshal(meta)
+
+	wm := WireMessage{
+		Type:       BridgeMsgTypeMessage,
+		SessionKey: "sess-abc",
+		Content:    "Hello world",
+		Metadata:   metaBytes,
+	}
+	data, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+
+	var got WireMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+
+	if got.Type != BridgeMsgTypeMessage {
+		t.Errorf("Type=%s, want %s", got.Type, BridgeMsgTypeMessage)
+	}
+	if got.SessionKey != "sess-abc" {
+		t.Errorf("SessionKey=%s, want sess-abc", got.SessionKey)
+	}
+
+	var gotMeta WireMetadata
+	if err := json.Unmarshal(got.Metadata, &gotMeta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if gotMeta.UserID != "u123" {
+		t.Errorf("UserID=%s, want u123", gotMeta.UserID)
+	}
+	if gotMeta.RoomID != "r456" {
+		t.Errorf("RoomID=%s, want r456", gotMeta.RoomID)
+	}
+}
+
+func TestWireMessageError(t *testing.T) {
+	wm := WireMessage{
+		Type:    BridgeMsgTypeError,
+		Code:    400,
+		Message: "invalid request",
+	}
+	data, err := json.Marshal(wm)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var got WireMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if got.Code != 400 {
+		t.Errorf("Code=%d, want 400", got.Code)
+	}
+	if got.Message != "invalid request" {
+		t.Errorf("Message=%s, want 'invalid request'", got.Message)
+	}
+}
+
+func TestBridgeServer_GetSetPlatforms(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	if platforms := bs.ListPlatforms(); len(platforms) != 0 {
+		t.Errorf("ListPlatforms initial = %v, want empty", platforms)
+	}
+
+	p := bs.GetPlatform("slack")
+	if p != nil {
+		t.Errorf("GetPlatform(slack) = %v, want nil (not registered)", p)
+	}
+}
+
+func TestBridgeServer_ServeHTTP_MissingPlatform(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	req := httptest.NewRequest("GET", "/bridge/v1/", nil)
+	rec := httptest.NewRecorder()
+	bs.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBridgeServer_ServeHTTP_UnauthorizedToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "expected-token", logger)
+
+	req := httptest.NewRequest("GET", "/bridge/v1/dingtalk?token=wrong-token", nil)
+	rec := httptest.NewRecorder()
+	bs.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBridgeServer_ServeHTTP_Upgrade(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	req := httptest.NewRequest("GET", "/bridge/v1/dingtalk", nil)
+	rec := httptest.NewRecorder()
+
+	// Run in goroutine since Upgrade blocks
+	done := make(chan struct{})
+	go func() {
+		bs.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Give it a moment to set up
+	time.Sleep(10 * time.Millisecond)
+
+	select {
+	case <-done:
+		// Server handled request normally
+	default:
+		// Expected: upgrade would have been called on a real WebSocket
+	}
+}
+
+func TestBridgePlatform_ChatAdapterInterface(t *testing.T) {
+	// Verify BridgePlatform implements base.ChatAdapter at compile time
+	var _ base.ChatAdapter = (*BridgePlatform)(nil)
+}
+
+func TestBridgePlatform_Platform(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	if bp.Platform() != "dingtalk" {
+		t.Errorf("Platform()=%s, want dingtalk", bp.Platform())
+	}
+}
+
+func TestBridgePlatform_SystemPrompt(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	if bp.SystemPrompt() == "" {
+		t.Error("SystemPrompt() should not be empty")
+	}
+}
+
+func TestBridgePlatform_StartStop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// Start should be no-op
+	if err := bp.Start(context.Background()); err != nil {
+		t.Errorf("Start() error = %v, want nil", err)
+	}
+
+	// Stop should be safe
+	if err := bp.Stop(); err != nil {
+		t.Errorf("Stop() error = %v, want nil", err)
+	}
+}
+
+func TestBridgePlatform_SendMessage_NilMsg(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// Sending nil message should not panic
+	if err := bp.SendMessage(context.Background(), "sess1", nil); err != nil {
+		t.Errorf("SendMessage(nil) error = %v, want nil", err)
+	}
+}
+
+func TestBridgeServer_Close(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	// Close should be safe with no platforms
+	bs.Close()
+
+	if platforms := bs.ListPlatforms(); len(platforms) != 0 {
+		t.Errorf("After Close, ListPlatforms = %v, want empty", platforms)
+	}
+}
+
+func TestAllCapabilities(t *testing.T) {
+	want := []string{CapText, CapImage, CapCard, CapButtons, CapTyping, CapEdit, CapDelete, CapReact, CapThread}
+	if len(allCapabilities) != len(want) {
+		t.Errorf("allCapabilities len=%d, want %d", len(allCapabilities), len(want))
+	}
+	for _, c := range want {
+		found := false
+		for _, a := range allCapabilities {
+			if a == c {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("capability %q not found in allCapabilities", c)
+		}
+	}
+}
+
+func TestBridgeMsgTypes(t *testing.T) {
+	tests := []struct {
+		got  string
+		want string
+	}{
+		{BridgeMsgTypeRegister, "register"},
+		{BridgeMsgTypeMessage, "message"},
+		{BridgeMsgTypeReply, "reply"},
+		{BridgeMsgTypeEvent, "event"},
+		{BridgeMsgTypeError, "error"},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("BridgeMsgType=%s, want %s", tt.got, tt.want)
+		}
+	}
+}
+
+// wsRecorder wraps httptest.ResponseRecorder to satisfy gorilla/websocket Upgrader.
+type wsRecorder struct{ *httptest.ResponseRecorder }
+
+func (wsRecorder) Hijack() (interface{}, *websocket.Conn, error) {
+	return nil, nil, nil
+}

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/hrygo/hotplex/chatapps/base"
 )
 

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -275,9 +275,421 @@ func TestBridgeMsgTypes(t *testing.T) {
 	}
 }
 
-// wsRecorder wraps httptest.ResponseRecorder to satisfy gorilla/websocket Upgrader.
-type wsRecorder struct{ *httptest.ResponseRecorder }
+// ---------------------------------------------------------------------------
+// BridgePlatform handle* tests
+// ---------------------------------------------------------------------------
+func TestBridgePlatform_handleRegister_MissingPlatform(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("initial", nil)
+	bp.server = bs
 
-func (wsRecorder) Hijack() (interface{}, *websocket.Conn, error) {
-	return nil, nil, nil
+	err := bp.handleRegister(&WireMessage{Type: BridgeMsgTypeRegister})
+	if err == nil {
+		t.Error("handleRegister with empty platform: want error, got nil")
+	}
+}
+
+func TestBridgePlatform_handleRegister_OK(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("initial", nil)
+	bp.server = bs
+
+	// Mock writeJSON to avoid WebSocket
+	bp.testWriteJSON = func(wm *WireMessage) error { return nil }
+
+	err := bp.handleRegister(&WireMessage{
+		Type:         BridgeMsgTypeRegister,
+		Platform:     "dingtalk",
+		Capabilities: []string{CapText, CapCard},
+	})
+	if err != nil {
+		t.Errorf("handleRegister: unexpected error: %v", err)
+	}
+	if bp.platform != "dingtalk" {
+		t.Errorf("bp.platform = %q, want dingtalk", bp.platform)
+	}
+}
+
+func TestBridgePlatform_handleMessage_MissingSessionKey(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	err := bp.handleMessage(&WireMessage{Type: BridgeMsgTypeMessage})
+	if err == nil {
+		t.Error("handleMessage with empty session_key: want error, got nil")
+	}
+}
+
+func TestBridgePlatform_handleMessage_OK(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	var receivedMsg *base.ChatMessage
+	bp.handler = func(ctx context.Context, msg *base.ChatMessage) error {
+		receivedMsg = msg
+		return nil
+	}
+
+	err := bp.handleMessage(&WireMessage{
+		Type:       BridgeMsgTypeMessage,
+		SessionKey: "sess123",
+		Content:    "hello",
+		Metadata:   []byte(`{"user_id":"u1","room_id":"r1"}`),
+	})
+	if err != nil {
+		t.Errorf("handleMessage: unexpected error: %v", err)
+	}
+	if receivedMsg == nil {
+		t.Fatal("handler was not called")
+	}
+	if receivedMsg.Content != "hello" {
+		t.Errorf("Content = %q, want hello", receivedMsg.Content)
+	}
+	if receivedMsg.SessionID != "sess123" {
+		t.Errorf("SessionID = %q, want sess123", receivedMsg.SessionID)
+	}
+}
+
+func TestBridgePlatform_handleMessage_NoHandler(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+	bp.handler = nil // no handler set
+
+	err := bp.handleMessage(&WireMessage{
+		Type:       BridgeMsgTypeMessage,
+		SessionKey: "sess123",
+		Content:    "hello",
+	})
+	if err != nil {
+		t.Errorf("handleMessage with no handler: error = %v, want nil", err)
+	}
+}
+
+func TestBridgePlatform_handleEvent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	err := bp.handleEvent(&WireMessage{
+		Type:       BridgeMsgTypeEvent,
+		Event:      "typing",
+		SessionKey: "sess123",
+	})
+	if err != nil {
+		t.Errorf("handleEvent: unexpected error: %v", err)
+	}
+}
+
+func TestBridgePlatform_handleUnknown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	err := bp.handleUnknown(&WireMessage{Type: "unknown_type"})
+	if err == nil {
+		t.Error("handleUnknown: want error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BridgePlatform writeJSON / writeError
+// ---------------------------------------------------------------------------
+
+func TestBridgePlatform_writeJSON_WithNilConnAndTestHook(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// When testWriteJSON is set, it is called instead of the real writeJSON.
+	// This test verifies the hook mechanism works.
+	called := false
+	bp.testWriteJSON = func(wm *WireMessage) error {
+		called = true
+		return nil
+	}
+
+	err := bp.writeJSON(&WireMessage{Type: BridgeMsgTypeReply})
+	if err != nil {
+		t.Errorf("writeJSON with test hook: error = %v, want nil", err)
+	}
+	if !called {
+		t.Error("testWriteJSON hook was not called")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BridgePlatform deliveryLoop
+// ---------------------------------------------------------------------------
+
+func TestBridgePlatform_deliveryLoop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	delivered := make(chan struct{}, 1)
+	var captured *WireMessage
+	bp.testWriteJSON = func(wm *WireMessage) error {
+		captured = wm
+		delivered <- struct{}{}
+		return nil
+	}
+
+	go bp.deliveryLoop()
+
+	msg := &base.ChatMessage{
+		Platform:  "hotplex",
+		SessionID: "sess123",
+		Content:   "Hello from hotplex",
+		Metadata: map[string]any{
+			base.KeyRoomID:   "room1",
+			base.KeyThreadID: "thread1",
+			base.KeyUserID:   "user1",
+		},
+	}
+
+	select {
+	case bp.msgChan <- msg:
+	default:
+		t.Fatal("msgChan is full")
+	}
+
+	select {
+	case <-delivered:
+		// message delivered
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message delivery")
+	}
+
+	if captured == nil {
+		t.Fatal("writeJSON was not called")
+	}
+	if captured.Type != BridgeMsgTypeMessage {
+		t.Errorf("Type = %q, want %q", captured.Type, BridgeMsgTypeMessage)
+	}
+	if captured.Content != "Hello from hotplex" {
+		t.Errorf("Content = %q, want Hello from hotplex", captured.Content)
+	}
+
+	bp.close()
+}
+
+func TestBridgePlatform_deliveryLoop_NilMessage(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	called := false
+	bp.testWriteJSON = func(wm *WireMessage) error {
+		called = true
+		return nil
+	}
+
+	go bp.deliveryLoop()
+
+	select {
+	case bp.msgChan <- nil:
+	default:
+		t.Fatal("msgChan is full")
+	}
+
+	// Wait for deliveryLoop to process and skip the nil message.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	<-ctx.Done()
+
+	if called {
+		t.Error("writeJSON should not be called for nil message")
+	}
+	bp.close()
+}
+
+func TestBridgePlatform_deliveryLoop_SessionKeyMapping(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	delivered := make(chan struct{}, 1)
+	var captured *WireMessage
+	bp.testWriteJSON = func(wm *WireMessage) error {
+		captured = wm
+		delivered <- struct{}{}
+		return nil
+	}
+
+	bp.mu.Lock()
+	bp.sessionMap["hotplex-session-1"] = "bridge-session-key"
+	bp.mu.Unlock()
+
+	go bp.deliveryLoop()
+
+	msg := &base.ChatMessage{
+		Platform:  "hotplex",
+		SessionID: "hotplex-session-1",
+		Content:   "mapped",
+	}
+
+	select {
+	case bp.msgChan <- msg:
+	default:
+		t.Fatal("msgChan is full")
+	}
+
+	select {
+	case <-delivered:
+		// message delivered
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message delivery")
+	}
+
+	if captured == nil {
+		t.Fatal("writeJSON was not called")
+	}
+	if captured.SessionKey != "bridge-session-key" {
+		t.Errorf("SessionKey = %q, want bridge-session-key", captured.SessionKey)
+	}
+	bp.close()
+}
+
+// ---------------------------------------------------------------------------
+// BridgeServer lifecycle
+// ---------------------------------------------------------------------------
+
+func TestBridgeServer_Shutdown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	ctx := context.Background()
+	if err := bs.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown(): error = %v, want nil", err)
+	}
+}
+
+func TestBridgeServer_InjectAdapterManager(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	bs.InjectAdapterManager(nil) // nil should not panic
+
+	if bs.getAdapterManager() != nil {
+		t.Error("getAdapterManager() with nil injection: want nil")
+	}
+}
+
+func TestBridgeServer_SetHandler(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	handler := func(ctx context.Context, msg *base.ChatMessage) error { return nil }
+	bs.SetHandler(handler)
+	if bs.handler == nil {
+		t.Error("SetHandler: handler is nil after set")
+	}
+}
+
+func TestBridgePlatform_SetHandler(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	handler := func(ctx context.Context, msg *base.ChatMessage) error { return nil }
+	bp.SetHandler(handler)
+	if bp.handler == nil {
+		t.Error("SetHandler: handler is nil after set")
+	}
+}
+
+func TestBridgePlatform_HandleMessage(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// HandleMessage should return nil (not used for bridge platforms)
+	err := bp.HandleMessage(context.Background(), &base.ChatMessage{Content: "test"})
+	if err != nil {
+		t.Errorf("HandleMessage: error = %v, want nil", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BridgeServer register/unregister
+// ---------------------------------------------------------------------------
+
+func TestBridgeServer_register_unregister(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	bp1 := bs.newBridgePlatform("dingtalk", nil)
+	bp2 := bs.newBridgePlatform("wechat", nil)
+
+	bs.register(bp1)
+	bs.register(bp2)
+
+	if platforms := bs.ListPlatforms(); len(platforms) != 2 {
+		t.Errorf("ListPlatforms = %v, want 2 platforms", platforms)
+	}
+
+	if p := bs.GetPlatform("dingtalk"); p == nil {
+		t.Error("GetPlatform(dingtalk) = nil, want platform")
+	}
+
+	bs.unregister("dingtalk")
+	if platforms := bs.ListPlatforms(); len(platforms) != 1 {
+		t.Errorf("After unregister, ListPlatforms = %v, want 1", platforms)
+	}
+}
+
+func TestBridgePlatform_GetAdapterManager_NilServer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// server.adapterMgr is nil by default
+	if bp.getAdapterManager() != nil {
+		t.Error("getAdapterManager() with nil adapterMgr: want nil")
+	}
+}
+
+func TestBridgePlatform_close(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+	bp := bs.newBridgePlatform("dingtalk", nil)
+
+	// close should be safe to call multiple times
+	bp.close()
+	bp.close() // should not panic
+
+	select {
+	case <-bp.done:
+		// done is closed as expected
+	default:
+		t.Error("done channel should be closed after close()")
+	}
+}
+
+func TestBridgeServer_Close_WithPlatforms(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	bp := bs.newBridgePlatform("dingtalk", nil)
+	bs.register(bp)
+
+	bs.Close()
+
+	if platforms := bs.ListPlatforms(); len(platforms) != 0 {
+		t.Errorf("After Close, ListPlatforms = %v, want empty", platforms)
+	}
+}
+
+func TestBridgeServer_GetPlatform_NotFound(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	bs := NewBridgeServer(0, "", logger)
+
+	if p := bs.GetPlatform("nonexistent"); p != nil {
+		t.Errorf("GetPlatform(nonexistent) = %v, want nil", p)
+	}
 }

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -300,14 +300,14 @@ func TestBridgePlatform_handleRegister_OK(t *testing.T) {
 
 	err := bp.handleRegister(&WireMessage{
 		Type:         BridgeMsgTypeRegister,
-		Platform:     "dingtalk",
+		Platform:     "custom-bridge",
 		Capabilities: []string{CapText, CapCard},
 	})
 	if err != nil {
 		t.Errorf("handleRegister: unexpected error: %v", err)
 	}
-	if bp.platform != "dingtalk" {
-		t.Errorf("bp.platform = %q, want dingtalk", bp.platform)
+	if bp.platform != "custom-bridge" {
+		t.Errorf("bp.platform = %q, want custom-bridge", bp.platform)
 	}
 }
 

--- a/types/message_type.go
+++ b/types/message_type.go
@@ -32,6 +32,8 @@ const (
 	MessageTypeUserMessageReceived MessageType = "user_message_received"
 	MessageTypePermissionRequest   MessageType = "permission_request"
 	MessageTypeAnswer              MessageType = "answer"
+	// PermissionDenials indicates permission was denied by user (DangerBlock flow)
+	MessageTypePermissionDenials MessageType = "permission_denials"
 )
 
 // IsStorable 判断消息类型是否可存储 (单一事实来源)


### PR DESCRIPTION
## Summary
- **Phase 2A**: Platform Registry - plugin factory self-registration via `sync.Once` singleton + `init()` (Slacks, Feishu, DingTalk all auto-register)
- **Phase 2B**: StreamStrategy abstraction - decouples streaming logic from `engine_handler.go`, replacing hardcoded `SlackMetadata()` calls
- **Phase 3A**: BridgeServer WebSocket gateway - external platform adapters (DingTalk, WeChat, etc.) connect via WebSocket, implement `base.ChatAdapter`, participate in event pipeline

## Changes
- `chatapps/base/plugin.go` — `AdapterFactory` + `AdapterPluginRegistry` singleton
- `chatapps/base/stream_strategy.go` — `StreamStrategy` interface + factory
- `chatapps/slack/{factory,stream_strategy}.go` — self-registering implementations
- `chatapps/feishu/factory.go` — self-registering factory
- `chatapps/engine_handler.go` — uses `StreamStrategy` instead of Slack-specific code
- `chatapps/setup.go` — dynamic platform discovery via registry
- `chatapps/manager.go` — `RegisterOrReplace()` for bridge reconnect
- `internal/server/bridge.go` — full WebSocket gateway with `deliveryLoop`/`keepaliveLoop`
- `internal/server/bridge_test.go` — unit tests
- `internal/config/server_config.go` — `BridgePort` + `BridgeToken` config
- `cmd/hotplexd/main.go` — BridgeServer lifecycle management

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./chatapps/...` passes
- [x] `go test ./internal/server/...` passes

Refs #320