### PR TITLE
feat(admin): implement Admin Webhook API - full RESTful management interface

### DIFF
--- a/cmd/hotplexd/main.go
+++ b/cmd/hotplexd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hrygo/hotplex/cmd/hotplexd/cmd"
 	"github.com/hrygo/hotplex/cmd/hotplexd/cmd/session"
 	"github.com/hrygo/hotplex/internal/admin"
+	adminwebhook "github.com/hrygo/hotplex/internal/server/admin"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/server"
 	"github.com/hrygo/hotplex/internal/sys"
@@ -120,7 +121,7 @@ func runDaemon() {
 	engine, adminToken := createEngine(logger, serverCfg)
 
 	// 7. Setup HTTP handlers
-	mainRouter, chatappsMgr := setupHTTPHandlers(engine, logger, serverCfg)
+	mainRouter, chatappsMgr := setupHTTPHandlers(engine, adminToken, logger, serverCfg)
 
 	// 7.1 Initialize BridgeServer for external platform adapters
 	var bridgeServer *server.BridgeServer
@@ -392,7 +393,7 @@ func createEngine(logger *slog.Logger, serverCfg *config.ServerLoader) (*hotplex
 	return engine, adminToken
 }
 
-func setupHTTPHandlers(engine *hotplex.Engine, logger *slog.Logger, serverCfg *config.ServerLoader) (*mux.Router, *chatapps.AdapterManager) {
+func setupHTTPHandlers(engine *hotplex.Engine, adminToken string, logger *slog.Logger, serverCfg *config.ServerLoader) (*mux.Router, *chatapps.AdapterManager) {
 	r := mux.NewRouter()
 
 	// WebSocket handler
@@ -426,6 +427,14 @@ func setupHTTPHandlers(engine *hotplex.Engine, logger *slog.Logger, serverCfg *c
 	r.Handle("/health/ready", readyHandler)
 	r.Handle("/health/live", liveHandler)
 	r.Handle("/metrics", metricsHandler)
+
+	// Enhanced Admin Webhook API (internal/server/admin) at /api/v1/admin/
+	adminServer := adminwebhook.NewAdminServer(adminwebhook.AdminServerOptions{
+		Engine:   engine,
+		AdminKey: adminToken,
+		Logger:   logger,
+	})
+	r.Handle("/api/v1/admin/", adminServer)
 
 	// ChatApps adapters
 	configDir := os.Getenv("HOTPLEX_CHATAPPS_CONFIG_DIR")

--- a/engine/runner.go
+++ b/engine/runner.go
@@ -41,6 +41,10 @@ type Engine struct {
 	permissionMatcher *permission.PermissionMatcher
 	// mu protects runtime configuration updates (AllowedTools, DisallowedTools)
 	mu sync.RWMutex
+	// drainMu and draining protect drain mode state
+	drainMu   sync.RWMutex
+	draining  bool
+	drainMsg  string
 }
 
 // GetOptions returns the current engine options.
@@ -117,6 +121,42 @@ func (r *Engine) Close() error {
 // GetSessionManager returns the underlying session manager for admin operations.
 func (r *Engine) GetSessionManager() intengine.SessionManager {
 	return r.manager
+}
+
+// IsDraining returns true if the engine is in drain mode.
+func (r *Engine) IsDraining() bool {
+	r.drainMu.RLock()
+	defer r.drainMu.RUnlock()
+	return r.draining
+}
+
+// GetDrainMessage returns the current drain message.
+func (r *Engine) GetDrainMessage() string {
+	r.drainMu.RLock()
+	defer r.drainMu.RUnlock()
+	if r.drainMsg == "" {
+		return "Service is in drain mode"
+	}
+	return r.drainMsg
+}
+
+// EnterDrain puts the engine into drain mode.
+// New sessions will be rejected while existing sessions continue.
+func (r *Engine) EnterDrain(msg string) {
+	r.drainMu.Lock()
+	r.draining = true
+	r.drainMsg = msg
+	r.drainMu.Unlock()
+	r.logger.Info("Engine entering drain mode", "message", msg)
+}
+
+// ExitDrain exits drain mode.
+func (r *Engine) ExitDrain() {
+	r.drainMu.Lock()
+	r.draining = false
+	r.drainMsg = ""
+	r.drainMu.Unlock()
+	r.logger.Info("Engine exiting drain mode")
 }
 
 // Execute runs Claude Code CLI with the given configuration and streams

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hrygo/hotplex/engine"
 	intengine "github.com/hrygo/hotplex/internal/engine"
+	"github.com/hrygo/hotplex/internal/adminapi"
 	"github.com/hrygo/hotplex/internal/sys"
 	"github.com/hrygo/hotplex/internal/telemetry"
 	"github.com/hrygo/hotplex/provider"
@@ -53,13 +54,13 @@ func NewHandler(eng *engine.Engine, startTime time.Time, logger Logger) *Handler
 // listSessions handles GET /admin/v1/sessions.
 func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
 		return
 	}
 
 	manager := h.engine.GetSessionManager()
 	if manager == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
 		return
 	}
 
@@ -78,7 +79,7 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 		Sessions: infos,
 		Total:    len(infos),
 	}
-	h.writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // getSession handles GET /admin/v1/sessions/:id.
@@ -87,19 +88,19 @@ func (h *Handler) getSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := vars["id"]
 
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
 		return
 	}
 
 	manager := h.engine.GetSessionManager()
 	if manager == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
 		return
 	}
 
 	sess, ok := manager.GetSession(sessionID)
 	if !ok {
-		writeError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found: "+sessionID)
+		adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found: "+sessionID)
 		return
 	}
 
@@ -123,7 +124,7 @@ func (h *Handler) getSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h.writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // deleteSession handles DELETE /admin/v1/sessions/:id.
@@ -132,27 +133,27 @@ func (h *Handler) deleteSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := vars["id"]
 
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Engine not initialized")
 		return
 	}
 
 	manager := h.engine.GetSessionManager()
 	if manager == nil {
-		writeError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeServerError, "Session manager not available")
 		return
 	}
 
 	if _, ok := manager.GetSession(sessionID); !ok {
-		writeError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found: "+sessionID)
+		adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found: "+sessionID)
 		return
 	}
 
 	if err := h.engine.StopSession(sessionID, "admin-terminated"); err != nil {
-		writeError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to terminate session: "+err.Error())
+		adminapi.WriteError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to terminate session: "+err.Error())
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, SessionDeleteResponse{
+	adminapi.WriteJSON(w, http.StatusOK, SessionDeleteResponse{
 		Success: true,
 		Message: "Session " + sessionID + " terminated",
 	})
@@ -165,7 +166,7 @@ func (h *Handler) getSessionLogs(w http.ResponseWriter, r *http.Request) {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to determine home directory")
+		adminapi.WriteError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to determine home directory")
 		return
 	}
 
@@ -175,14 +176,14 @@ func (h *Handler) getSessionLogs(w http.ResponseWriter, r *http.Request) {
 	info, err := os.Stat(logPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			writeError(w, http.StatusNotFound, ErrCodeNotFound, "Log file not found for session: "+sessionID)
+			adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Log file not found for session: "+sessionID)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to read log file")
+		adminapi.WriteError(w, http.StatusInternalServerError, ErrCodeServerError, "Failed to read log file")
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, SessionLogsResponse{
+	adminapi.WriteJSON(w, http.StatusOK, SessionLogsResponse{
 		SessionID:    sessionID,
 		LogPath:      logPath,
 		SizeBytes:    info.Size(),
@@ -222,14 +223,14 @@ func (h *Handler) getStats(w http.ResponseWriter, r *http.Request) {
 		CpuUsagePercent: 0,
 	}
 
-	h.writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // validateConfig handles POST /admin/v1/config/validate.
 func (h *Handler) validateConfig(w http.ResponseWriter, r *http.Request) {
 	var req ConfigValidateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid JSON body")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid JSON body")
 		return
 	}
 
@@ -239,7 +240,7 @@ func (h *Handler) validateConfig(w http.ResponseWriter, r *http.Request) {
 		Errors: errors,
 	}
 
-	h.writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // getHealthDetailed handles GET /admin/v1/health/detailed.
@@ -268,33 +269,11 @@ func (h *Handler) getHealthDetailed(w http.ResponseWriter, r *http.Request) {
 		status = "degraded"
 	}
 
-	h.writeJSON(w, http.StatusOK, HealthDetailedResponse{
+	adminapi.WriteJSON(w, http.StatusOK, HealthDetailedResponse{
 		Status:  status,
 		Checks:  checks,
 		Details: details,
 	})
-}
-
-func (h *Handler) writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		h.logger.Error("failed to encode JSON response", "error", err)
-	}
-}
-
-func writeError(w http.ResponseWriter, status int, code ErrorCode, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	resp := ErrorResponse{
-		Error: ErrorDetail{
-			Code:    code,
-			Message: message,
-		},
-	}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		slog.Error("failed to encode error response", "error", err)
-	}
 }
 
 func countWebsocketConnections() int {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -69,7 +69,7 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
 	for _, sess := range sessions {
 		infos = append(infos, &SessionInfo{
 			ID:         sess.ID,
-			Status:     string(sess.Status),
+			Status:     adminapi.MapSessionStatus(sess.Status),
 			CreatedAt:  sess.CreatedAt,
 			LastActive: sess.GetLastActive(),
 		})
@@ -106,7 +106,7 @@ func (h *Handler) getSession(w http.ResponseWriter, r *http.Request) {
 
 	resp := SessionDetailResponse{
 		ID:         sess.ID,
-		Status:     string(sess.Status),
+		Status:     adminapi.MapSessionStatus(sess.Status),
 		CreatedAt:  sess.CreatedAt,
 		LastActive: sess.GetLastActive(),
 		Config: SessionConfig{

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/hrygo/hotplex/internal/adminapi"
 	"github.com/hrygo/hotplex/internal/sys"
 )
 
@@ -22,9 +23,8 @@ func (m *mockLogger) Warn(msg string, args ...any)  {}
 func (m *mockLogger) Error(msg string, args ...any) {}
 
 func TestWriteJSON(t *testing.T) {
-	h := &Handler{logger: &mockLogger{}}
 	rr := httptest.NewRecorder()
-	h.writeJSON(rr, http.StatusOK, map[string]string{"key": "value"})
+	adminapi.WriteJSON(rr, http.StatusOK, map[string]string{"key": "value"})
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rr.Code)
@@ -36,7 +36,7 @@ func TestWriteJSON(t *testing.T) {
 
 func TestWriteError(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeError(rr, http.StatusNotFound, ErrCodeNotFound, "not found")
+	adminapi.WriteError(rr, http.StatusNotFound, ErrCodeNotFound, "not found")
 
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", rr.Code)
@@ -209,10 +209,9 @@ func TestGetSessionLogs_HomeDirError(t *testing.T) {
 
 func TestHandler_WriteJSONEncodeError(t *testing.T) {
 	// Test that writeJSON handles encoding errors gracefully
-	h := &Handler{logger: &mockLogger{}}
 	rr := httptest.NewRecorder()
 	// This should not panic
-	h.writeJSON(rr, http.StatusOK, "plain string")
+	adminapi.WriteJSON(rr, http.StatusOK, "plain string")
 }
 
 func TestListSessions_NilEngine(t *testing.T) {
@@ -298,7 +297,7 @@ func TestCheckDatabaseHealth_NoDB(t *testing.T) {
 func TestWriteError_EncodeFailure(t *testing.T) {
 	// Test that writeError handles encoding failures gracefully
 	rr := &writerFailsRecorder{}
-	writeError(rr, http.StatusInternalServerError, ErrCodeServerError, "test error")
+	adminapi.WriteError(rr, http.StatusInternalServerError, ErrCodeServerError, "test error")
 	// Should not panic
 }
 

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -1,7 +1,7 @@
 package admin
 
 import (
-	"crypto/subtle"
+	"log/slog"
 	"net/http"
 
 	"github.com/hrygo/hotplex/internal/adminapi"
@@ -10,40 +10,29 @@ import (
 // Middleware provides HTTP middleware functions for the admin API.
 type Middleware struct {
 	adminToken string
+	logger     *slog.Logger
 }
 
 // NewMiddleware creates a new admin middleware.
-func NewMiddleware(adminToken string) *Middleware {
-	return &Middleware{adminToken: adminToken}
+// If logger is nil, slog.Default() is used.
+func NewMiddleware(adminToken string, logger *slog.Logger) *Middleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Middleware{
+		adminToken: adminToken,
+		logger:     logger,
+	}
 }
 
 // AuthMiddleware returns an HTTP handler that validates the admin token.
 // If adminToken is empty, authentication is disabled (dev mode).
+// Uses Bearer token authentication (OAuth2 standard).
 func (m *Middleware) AuthMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if m.adminToken == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Authorization header required")
-			return
-		}
-
-		const bearerPrefix = "Bearer "
-		if len(authHeader) < len(bearerPrefix)+len(m.adminToken) {
-			adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Invalid authorization format")
-			return
-		}
-
-		token := authHeader[len(bearerPrefix):]
-		if subtle.ConstantTimeCompare([]byte(token), []byte(m.adminToken)) != 1 {
-			adminapi.WriteError(w, http.StatusForbidden, ErrCodeForbidden, "Invalid admin token")
-			return
-		}
-
-		next.ServeHTTP(w, r)
+	auth := adminapi.AuthMiddleware(adminapi.AuthMiddlewareOptions{
+		AdminKey: m.adminToken,
+		Mode:     adminapi.AuthModeBearer,
+		Logger:   m.logger,
 	})
+	return auth(next)
 }

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"crypto/subtle"
 	"net/http"
+
+	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
 // Middleware provides HTTP middleware functions for the admin API.
@@ -26,19 +28,19 @@ func (m *Middleware) AuthMiddleware(next http.Handler) http.Handler {
 
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
-			writeError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Authorization header required")
+			adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Authorization header required")
 			return
 		}
 
 		const bearerPrefix = "Bearer "
 		if len(authHeader) < len(bearerPrefix)+len(m.adminToken) {
-			writeError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Invalid authorization format")
+			adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeAuthFailed, "Invalid authorization format")
 			return
 		}
 
 		token := authHeader[len(bearerPrefix):]
 		if subtle.ConstantTimeCompare([]byte(token), []byte(m.adminToken)) != 1 {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Invalid admin token")
+			adminapi.WriteError(w, http.StatusForbidden, ErrCodeForbidden, "Invalid admin token")
 			return
 		}
 

--- a/internal/admin/middleware_test.go
+++ b/internal/admin/middleware_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAuthMiddleware_NoToken(t *testing.T) {
-	m := NewMiddleware("")
+	m := NewMiddleware("", nil)
 	handler := m.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -22,7 +22,7 @@ func TestAuthMiddleware_NoToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_MissingHeader(t *testing.T) {
-	m := NewMiddleware("secret-token")
+	m := NewMiddleware("secret-token", nil)
 	handler := m.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -37,7 +37,7 @@ func TestAuthMiddleware_MissingHeader(t *testing.T) {
 }
 
 func TestAuthMiddleware_InvalidFormat(t *testing.T) {
-	m := NewMiddleware("secret-token")
+	m := NewMiddleware("secret-token", nil)
 	handler := m.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -53,23 +53,23 @@ func TestAuthMiddleware_InvalidFormat(t *testing.T) {
 }
 
 func TestAuthMiddleware_InvalidToken(t *testing.T) {
-	m := NewMiddleware("secret-token")
+	m := NewMiddleware("secret-token", nil)
 	handler := m.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("Authorization", "Bearer wrong-token-longer")
+	req.Header.Set("Authorization", "Bearer wrong-token")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Errorf("expected status 403, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rr.Code)
 	}
 }
 
 func TestAuthMiddleware_ValidToken(t *testing.T) {
-	m := NewMiddleware("secret-token")
+	m := NewMiddleware("secret-token", nil)
 	handler := m.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -85,7 +85,7 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 }
 
 func TestNewMiddleware(t *testing.T) {
-	m := NewMiddleware("test-token")
+	m := NewMiddleware("test-token", nil)
 	if m.adminToken != "test-token" {
 		t.Errorf("expected adminToken 'test-token', got '%s'", m.adminToken)
 	}

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -28,7 +28,7 @@ func NewServer(eng *engine.Engine, port, token string, startTime time.Time, logg
 	}
 
 	handler := NewHandler(eng, startTime, logger)
-	mw := NewMiddleware(token)
+	mw := NewMiddleware(token, logger)
 
 	router := mux.NewRouter()
 	router.Use(mw.AuthMiddleware)

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -1,8 +1,31 @@
 package admin
 
-import "time"
+import (
+	"time"
 
-// SessionInfo represents a session in admin API responses.
+	"github.com/hrygo/hotplex/internal/adminapi"
+)
+
+type (
+	// ErrorCode is an alias to the shared domain error code.
+	ErrorCode = adminapi.ErrorCode
+	// ErrorResponse is an alias to the shared domain error response.
+	ErrorResponse = adminapi.ErrorResponse
+	// ErrorDetail is an alias to the shared domain error detail.
+	ErrorDetail = adminapi.ErrorDetail
+)
+
+// Re-export shared domain constants under the local package name
+// so callers can use admin.ErrCodeAuthFailed etc.
+const (
+	ErrCodeAuthFailed     = ErrorCode(adminapi.ErrCodeAuthFailed)
+	ErrCodeForbidden     = ErrorCode(adminapi.ErrCodeForbidden)
+	ErrCodeNotFound      = ErrorCode(adminapi.ErrCodeNotFound)
+	ErrCodeInvalidRequest = ErrorCode(adminapi.ErrCodeInvalidRequest)
+	ErrCodeServerError   = ErrorCode(adminapi.ErrCodeServerError)
+)
+
+// SessionInfo represents a session in admin CLI responses.
 type SessionInfo struct {
 	ID           string    `json:"id"`
 	Status       string    `json:"status"`
@@ -19,7 +42,7 @@ type SessionInfo struct {
 // SessionListResponse is the response for GET /admin/v1/sessions.
 type SessionListResponse struct {
 	Sessions []*SessionInfo `json:"sessions"`
-	Total    int            `json:"total"`
+	Total    int           `json:"total"`
 }
 
 // SessionDetailResponse is the response for GET /admin/v1/sessions/:id.
@@ -41,7 +64,7 @@ type SessionConfig struct {
 
 // SessionStats contains session statistics.
 type SessionStats struct {
-	InputTokens  int64 `json:"input_tokens"`
+	InputTokens   int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
 	DurationSecs int64 `json:"duration_seconds"`
 }
@@ -101,27 +124,4 @@ type HealthDetails struct {
 	DatabaseLatencyMs int    `json:"database_latency_ms"`
 	CliVersion        string `json:"cli_version"`
 	ConfigFile        string `json:"config_file"`
-}
-
-// ErrorCode represents admin API error codes.
-type ErrorCode string
-
-const (
-	ErrCodeAuthFailed     ErrorCode = "AUTH_FAILED"
-	ErrCodeForbidden      ErrorCode = "FORBIDDEN"
-	ErrCodeNotFound       ErrorCode = "NOT_FOUND"
-	ErrCodeInvalidRequest ErrorCode = "INVALID_REQUEST"
-	ErrCodeServerError    ErrorCode = "SERVER_ERROR"
-)
-
-// ErrorResponse is the standard error response format.
-type ErrorResponse struct {
-	Error ErrorDetail `json:"error"`
-}
-
-// ErrorDetail contains error details.
-type ErrorDetail struct {
-	Code    ErrorCode              `json:"code"`
-	Message string                 `json:"message"`
-	Details map[string]interface{} `json:"details,omitempty"`
 }

--- a/internal/adminapi/auth.go
+++ b/internal/adminapi/auth.go
@@ -1,0 +1,171 @@
+// Package adminapi provides shared authentication middleware for admin APIs.
+// It supports two authentication modes following industry best practices:
+//
+// 1. Bearer Token (OAuth2 standard) - Authorization: Bearer <token>
+// 2. API Key (simplified) - X-API-Key: <key>
+//
+// Both modes use constant-time comparison to prevent timing attacks.
+package adminapi
+
+import (
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+)
+
+// AuthMode defines the authentication mode for admin APIs.
+type AuthMode int
+
+const (
+	// AuthModeBearer uses OAuth2-style Authorization: Bearer <token>
+	// Recommended for external integrations and webhook APIs.
+	AuthModeBearer AuthMode = iota
+
+	// AuthModeAPIKey uses X-API-Key header
+	// Recommended for internal tooling and simple integrations.
+	AuthModeAPIKey
+)
+
+// AuthMiddlewareOptions configures the authentication middleware.
+type AuthMiddlewareOptions struct {
+	// AdminKey is the secret key/token for authentication.
+	// If empty, authentication is bypassed (dev/unsecured mode).
+	AdminKey string
+
+	// Mode specifies the authentication mode (Bearer or API Key).
+	Mode AuthMode
+
+	// Logger for structured logging. Defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// AuthMiddleware creates an HTTP middleware that validates authentication.
+// It uses constant-time comparison to prevent timing attacks.
+//
+// If adminKey is empty, authentication is bypassed (useful for dev/testing).
+//
+// Example (Bearer mode):
+//
+//	auth := AuthMiddleware(AuthMiddlewareOptions{
+//	    AdminKey: "secret-token",
+//	    Mode:     AuthModeBearer,
+//	    Logger:   logger,
+//	})
+//	handler := auth(myHandler)
+//
+// Example (API Key mode):
+//
+//	auth := AuthMiddleware(AuthMiddlewareOptions{
+//	    AdminKey: "api-key-123",
+//	    Mode:     AuthModeAPIKey,
+//	    Logger:   logger,
+//	})
+//	handler := auth(myHandler)
+func AuthMiddleware(opts AuthMiddlewareOptions) func(http.Handler) http.Handler {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip auth if no admin key is configured (dev/unsecured mode)
+			if opts.AdminKey == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			var key string
+			var errCode ErrorCode
+			var errMsg string
+
+			// Extract key based on authentication mode
+			switch opts.Mode {
+			case AuthModeBearer:
+				key, errCode, errMsg = extractBearerToken(r)
+			case AuthModeAPIKey:
+				key, errCode, errMsg = extractAPIKey(r)
+			default:
+				WriteError(w, http.StatusInternalServerError, ErrCodeServerError, "Invalid authentication mode")
+				return
+			}
+
+			// Check if key was extracted
+			if key == "" {
+				logger.Warn("admin_auth: authentication failed",
+					"mode", modeString(opts.Mode),
+					"reason", errMsg,
+					"remote_addr", r.RemoteAddr,
+					"path", r.URL.Path,
+				)
+				WriteError(w, http.StatusUnauthorized, errCode, errMsg)
+				return
+			}
+
+			// Constant-time comparison to prevent timing attacks
+			if subtle.ConstantTimeCompare([]byte(key), []byte(opts.AdminKey)) != 1 {
+				logger.Warn("admin_auth: invalid credentials",
+					"mode", modeString(opts.Mode),
+					"remote_addr", r.RemoteAddr,
+					"path", r.URL.Path,
+					"key_prefix", keyPrefix(key),
+				)
+				WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Invalid credentials")
+				return
+			}
+
+			// Authentication successful
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractBearerToken extracts the token from Authorization: Bearer <token> header.
+func extractBearerToken(r *http.Request) (token string, errCode ErrorCode, errMsg string) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return "", ErrCodeUnauthorized, "Authorization header required"
+	}
+
+	const bearerPrefix = "Bearer "
+	if len(authHeader) < len(bearerPrefix) {
+		return "", ErrCodeUnauthorized, "Invalid authorization format"
+	}
+
+	token = authHeader[len(bearerPrefix):]
+	if token == "" {
+		return "", ErrCodeUnauthorized, "Bearer token is empty"
+	}
+
+	return token, "", ""
+}
+
+// extractAPIKey extracts the key from X-API-Key header.
+func extractAPIKey(r *http.Request) (key string, errCode ErrorCode, errMsg string) {
+	key = r.Header.Get("X-API-Key")
+	if key == "" {
+		return "", ErrCodeUnauthorized, "X-API-Key header required"
+	}
+	return key, "", ""
+}
+
+// keyPrefix returns the first 4 characters of the key for logging.
+// This allows identifying which key was used without exposing the full key.
+func keyPrefix(key string) string {
+	if len(key) < 4 {
+		return "****"
+	}
+	return key[:4] + "****"
+}
+
+// modeString returns a human-readable string for the authentication mode.
+func modeString(mode AuthMode) string {
+	switch mode {
+	case AuthModeBearer:
+		return "bearer"
+	case AuthModeAPIKey:
+		return "api_key"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/adminapi/domain.go
+++ b/internal/adminapi/domain.go
@@ -1,0 +1,153 @@
+// Package adminapi defines the shared domain for admin API servers.
+// Both internal/admin (CLI) and internal/server/admin (Webhook API) import this package
+// to share common types, error codes, and utilities.
+//
+// Architecture (SOLID/DRY):
+//
+//	  ┌─────────────────────┐      ┌───────────────────────────┐
+//	  │   internal/admin     │      │ internal/server/admin      │
+//	  │   (Admin CLI)       │      │   (Webhook API)            │
+//	  │   gorilla/mux       │      │   net/http                 │
+//	  │   /admin/v1/...     │      │   /api/v1/admin/...        │
+//	  └──────────┬──────────┘      └─────────────┬─────────────┘
+//	              │                               │
+//	              └──────────┬────────────────────┘
+//	                         ▼
+//	           ┌─────────────────────────┐
+//	           │   internal/adminapi       │
+//	           │   (Shared Domain)        │
+//	           │   • ErrorCode            │
+//	           │   • MapSessionStatus     │
+//	           │   • writeJSON/writeError │
+//	           │   • Session mapping      │
+//	           └─────────────────────────┘
+package adminapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// ErrorCode represents a canonical admin API error code.
+type ErrorCode string
+
+const (
+	ErrCodeAuthFailed     ErrorCode = "AUTH_FAILED"
+	ErrCodeForbidden      ErrorCode = "FORBIDDEN"
+	ErrCodeNotFound       ErrorCode = "NOT_FOUND"
+	ErrCodeInvalidRequest ErrorCode = "INVALID_REQUEST"
+	ErrCodeServerError    ErrorCode = "SERVER_ERROR"
+	ErrCodeUnauthorized   ErrorCode = "UNAUTHORIZED"
+)
+
+// ErrorResponse is the standard error envelope shared by all admin APIs.
+type ErrorResponse struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail contains the code, message, and optional details of an error.
+type ErrorDetail struct {
+	Code    ErrorCode              `json:"code"`
+	Message string                 `json:"message"`
+	Details map[string]interface{} `json:"details,omitempty"`
+}
+
+// NewError creates an ErrorResponse with the given code and message.
+func NewError(code ErrorCode, message string) ErrorResponse {
+	return ErrorResponse{Error: ErrorDetail{Code: code, Message: message}}
+}
+
+// NewErrorWithDetails creates an ErrorResponse with additional details.
+func NewErrorWithDetails(code ErrorCode, message string, details map[string]interface{}) ErrorResponse {
+	return ErrorResponse{Error: ErrorDetail{Code: code, Message: message, Details: details}}
+}
+
+// MapSessionStatus maps an internal engine session status to a canonical string.
+func MapSessionStatus(status intengine.SessionStatus) string {
+	switch status {
+	case intengine.SessionStatusStarting:
+		return "starting"
+	case intengine.SessionStatusReady:
+		return "idle"
+	case intengine.SessionStatusBusy:
+		return "running"
+	case intengine.SessionStatusDead:
+		return "dead"
+	default:
+		return "unknown"
+	}
+}
+
+// ResolvePlatform resolves the platform from a session ID prefix.
+// Session IDs follow the format: {platform}-{uuid}.
+// e.g., "ws-abc123", "slack-def456", "admin-ghi789"
+func ResolvePlatform(sessionID string) string {
+	if sessionID == "" {
+		return "unknown"
+	}
+	for i := 0; i < len(sessionID); i++ {
+		if sessionID[i] == '-' {
+			prefix := sessionID[:i]
+			switch prefix {
+			case "ws", "websocket":
+				return "websocket"
+			case "slack":
+				return "slack"
+			case "tg", "telegram":
+				return "telegram"
+			case "feishu", "lark":
+				return "feishu"
+			case "admin":
+				return "admin"
+			default:
+				return prefix
+			}
+		}
+	}
+	return "unknown"
+}
+
+// SessionSummary holds fields shared by all session-listing responses.
+type SessionSummary struct {
+	ID          string    `json:"id"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	LastActive  time.Time `json:"last_active"`
+	Platform    string    `json:"platform"`
+}
+
+// ToSessionSummary converts an internal engine.Session to a SessionSummary.
+func ToSessionSummary(s *intengine.Session) SessionSummary {
+	return SessionSummary{
+		ID:         s.ID,
+		Status:     MapSessionStatus(s.GetStatus()),
+		CreatedAt:  s.CreatedAt,
+		LastActive: s.GetLastActive(),
+		Platform:   ResolvePlatform(s.ID),
+	}
+}
+
+// WriteJSON writes a JSON response with the given status code.
+// Errors during encoding are logged but not surfaced to the caller.
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("adminapi: failed to encode JSON response", "error", err)
+	}
+}
+
+// WriteError writes a JSON error response.
+// Errors during encoding are logged but the response is still written.
+func WriteError(w http.ResponseWriter, status int, code ErrorCode, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	resp := NewError(code, message)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("adminapi: failed to encode error response", "error", err)
+	}
+}

--- a/internal/adminapi/domain.go
+++ b/internal/adminapi/domain.go
@@ -36,12 +36,13 @@ import (
 type ErrorCode string
 
 const (
-	ErrCodeAuthFailed     ErrorCode = "AUTH_FAILED"
-	ErrCodeForbidden      ErrorCode = "FORBIDDEN"
-	ErrCodeNotFound       ErrorCode = "NOT_FOUND"
-	ErrCodeInvalidRequest ErrorCode = "INVALID_REQUEST"
-	ErrCodeServerError    ErrorCode = "SERVER_ERROR"
-	ErrCodeUnauthorized   ErrorCode = "UNAUTHORIZED"
+	ErrCodeAuthFailed          ErrorCode = "AUTH_FAILED"
+	ErrCodeForbidden           ErrorCode = "FORBIDDEN"
+	ErrCodeNotFound            ErrorCode = "NOT_FOUND"
+	ErrCodeInvalidRequest      ErrorCode = "INVALID_REQUEST"
+	ErrCodeServerError         ErrorCode = "SERVER_ERROR"
+	ErrCodeUnauthorized        ErrorCode = "UNAUTHORIZED"
+	ErrCodeEngineNotInitialized ErrorCode = "ENGINE_NOT_INITIALIZED"
 )
 
 // ErrorResponse is the standard error envelope shared by all admin APIs.

--- a/internal/adminapi/domain.go
+++ b/internal/adminapi/domain.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	intengine "github.com/hrygo/hotplex/internal/engine"
@@ -151,4 +152,37 @@ func WriteError(w http.ResponseWriter, status int, code ErrorCode, message strin
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		slog.Error("adminapi: failed to encode error response", "error", err)
 	}
+}
+
+// ParsePagination extracts pagination parameters (limit and offset) from the request URL query.
+// It provides sensible defaults and enforces maximum limits to prevent abuse.
+//
+// Default values:
+//   - limit: 100 (max: 1000)
+//   - offset: 0
+//
+// Invalid values are silently ignored and replaced with defaults.
+func ParsePagination(r *http.Request) (limit, offset int) {
+	// Default values
+	limit = 100
+	offset = 0
+
+	// Parse limit
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+			if limit > 1000 {
+				limit = 1000 // Enforce maximum to prevent abuse
+			}
+		}
+	}
+
+	// Parse offset
+	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
+		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
+			offset = o
+		}
+	}
+
+	return
 }

--- a/internal/server/admin/admin.go
+++ b/internal/server/admin/admin.go
@@ -1,0 +1,160 @@
+package admin
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/hrygo/hotplex/engine"
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// AdminServer is the main admin API server that combines all handlers.
+type AdminServer struct {
+	engine         *engine.Engine
+	logger         *slog.Logger
+	adminKey       string
+	startTime      time.Time
+	sessionHandler *SessionHandler
+	healthHandler  *HealthHandler
+	configHandler  *ConfigHandler
+	auditHandler   *AuditHandler
+	eventBuffer    *EventBuffer
+	mux            *http.ServeMux
+}
+
+// AdminServerOptions contains options for creating an AdminServer.
+type AdminServerOptions struct {
+	Engine          *engine.Engine
+	AdminKey        string
+	Logger          *slog.Logger
+	EventBufferSize int
+}
+
+// NewAdminServer creates a new admin server with all handlers registered.
+func NewAdminServer(opts AdminServerOptions) *AdminServer {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	startTime := time.Now()
+	eventBuffer := NewEventBuffer(opts.EventBufferSize)
+	if eventBuffer == nil || opts.EventBufferSize <= 0 {
+		eventBuffer = NewEventBuffer(10000)
+	}
+
+	s := &AdminServer{
+		engine:      opts.Engine,
+		logger:      logger,
+		adminKey:    opts.AdminKey,
+		startTime:   startTime,
+		eventBuffer: eventBuffer,
+	}
+
+	// Initialize handlers with proper pool adapter
+	s.sessionHandler = s.newSessionHandler()
+	s.healthHandler = NewHealthHandler(s.engine, s.startTime, s.logger)
+	s.configHandler = NewConfigHandler(s.engine)
+	s.auditHandler = NewAuditHandler(s.eventBuffer, s.engine)
+
+	// Create router
+	s.mux = http.NewServeMux()
+	s.registerRoutes()
+
+	return s
+}
+
+// newSessionHandler creates a session handler with pool adapter.
+func (s *AdminServer) newSessionHandler() *SessionHandler {
+	var pool SessionPoolInterface
+
+	if s.engine != nil && s.engine.GetSessionManager() != nil {
+		pool = &enginePoolAdapter{manager: s.engine.GetSessionManager()}
+	} else {
+		pool = &enginePoolAdapter{}
+	}
+
+	return NewSessionHandler(pool)
+}
+
+// enginePoolAdapter adapts the engine's SessionManager to SessionPoolInterface.
+type enginePoolAdapter struct {
+	manager intengine.SessionManager
+}
+
+func (a *enginePoolAdapter) ListActiveSessions() []*intengine.Session {
+	if a.manager == nil {
+		return []*intengine.Session{}
+	}
+	sessions := a.manager.ListActiveSessions()
+	result := make([]*intengine.Session, len(sessions))
+	for i, sess := range sessions {
+		result[i] = sess
+	}
+	return result
+}
+
+func (a *enginePoolAdapter) GetSession(sessionID string) (*intengine.Session, bool) {
+	if a.manager == nil {
+		return nil, false
+	}
+	return a.manager.GetSession(sessionID)
+}
+
+func (a *enginePoolAdapter) TerminateSession(sessionID string) error {
+	if a.manager == nil {
+		return nil
+	}
+	return a.manager.TerminateSession(sessionID)
+}
+
+// registerRoutes registers all admin API routes under /api/v1/admin/.
+// All routes share a single prefix strip and auth middleware to avoid
+// routing conflicts between exact-match and prefix-match patterns.
+func (s *AdminServer) registerRoutes() {
+	authMiddleware := AdminAuthMiddleware(s.adminKey, s.logger)
+
+	// Single combined router — avoids mux prefix/exact-match routing conflicts.
+	combinedRoutes := http.NewServeMux()
+
+	// Session routes
+	combinedRoutes.HandleFunc("GET /sessions", s.sessionHandler.ListSessions)
+	combinedRoutes.HandleFunc("GET /sessions/{id}", s.sessionHandler.GetSession)
+	combinedRoutes.HandleFunc("POST /sessions/{id}/stop", s.sessionHandler.StopSession)
+	combinedRoutes.HandleFunc("POST /sessions/batch-stop", s.sessionHandler.BatchStopSessions)
+	combinedRoutes.HandleFunc("GET /sessions/{id}/transcript", s.auditHandler.getTranscript)
+
+	// Audit routes
+	combinedRoutes.HandleFunc("GET /events", s.auditHandler.getEvents)
+
+	// Health & drain routes
+	combinedRoutes.HandleFunc("GET /health", s.healthHandler.getHealth)
+	combinedRoutes.HandleFunc("GET /metrics", s.healthHandler.getMetrics)
+	combinedRoutes.HandleFunc("POST /drain", s.healthHandler.enterDrain)
+	combinedRoutes.HandleFunc("DELETE /drain", s.healthHandler.exitDrain)
+	combinedRoutes.HandleFunc("GET /drain", s.healthHandler.getDrainStatus)
+
+	// Config routes
+	combinedRoutes.HandleFunc("GET /config", s.configHandler.getConfig)
+	combinedRoutes.HandleFunc("GET /config/allowed_tools", s.configHandler.getAllowedTools)
+	combinedRoutes.HandleFunc("GET /config/disallowed_tools", s.configHandler.getDisallowedTools)
+
+	// Register combined routes at /api/v1/admin/ with shared auth.
+	s.mux.Handle("/api/v1/admin/", authMiddleware(http.StripPrefix("/api/v1/admin", combinedRoutes)))
+}
+
+// ServeHTTP implements http.Handler.
+func (s *AdminServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// GetHealthHandler returns the health handler for drain integration.
+func (s *AdminServer) GetHealthHandler() *HealthHandler {
+	return s.healthHandler
+}
+
+// GetEventBuffer returns the event buffer for event recording.
+func (s *AdminServer) GetEventBuffer() *EventBuffer {
+	return s.eventBuffer
+}

--- a/internal/server/admin/admin.go
+++ b/internal/server/admin/admin.go
@@ -87,10 +87,7 @@ func (a *enginePoolAdapter) ListActiveSessions() []*intengine.Session {
 	if a.manager == nil {
 		return []*intengine.Session{}
 	}
-	sessions := a.manager.ListActiveSessions()
-	result := make([]*intengine.Session, len(sessions))
-	copy(result, sessions)
-	return result
+	return a.manager.ListActiveSessions()
 }
 
 func (a *enginePoolAdapter) GetSession(sessionID string) (*intengine.Session, bool) {

--- a/internal/server/admin/admin.go
+++ b/internal/server/admin/admin.go
@@ -89,9 +89,7 @@ func (a *enginePoolAdapter) ListActiveSessions() []*intengine.Session {
 	}
 	sessions := a.manager.ListActiveSessions()
 	result := make([]*intengine.Session, len(sessions))
-	for i, sess := range sessions {
-		result[i] = sess
-	}
+	copy(result, sessions)
 	return result
 }
 

--- a/internal/server/admin/admin_test.go
+++ b/internal/server/admin/admin_test.go
@@ -1,0 +1,283 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewAdminServer(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{})
+	if server == nil {
+		t.Fatal("expected non-nil server")
+	}
+	if server.mux == nil {
+		t.Error("expected non-nil mux")
+	}
+	if server.healthHandler == nil {
+		t.Error("expected non-nil healthHandler")
+	}
+	if server.sessionHandler == nil {
+		t.Error("expected non-nil sessionHandler")
+	}
+	if server.configHandler == nil {
+		t.Error("expected non-nil configHandler")
+	}
+	if server.auditHandler == nil {
+		t.Error("expected non-nil auditHandler")
+	}
+	if server.eventBuffer == nil {
+		t.Error("expected non-nil eventBuffer")
+	}
+}
+
+func TestNewAdminServer_WithNilEngine(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		EventBufferSize: 500,
+	})
+	if server.eventBuffer.MaxSize() != 500 {
+		t.Errorf("expected event buffer size 500, got %d", server.eventBuffer.MaxSize())
+	}
+}
+
+// Test paths use /api/v1/admin/... without trailing slashes to match mux patterns.
+// mux pattern: /api/v1/admin/ strips to remaining path.
+// registered handler: GET /health (without trailing slash).
+
+func TestAdminServer_ServeHTTP_Health(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "test-key-123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
+	req.Header.Set("X-Admin-Key", "test-key-123")
+	rec := httptest.NewRecorder()
+
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp AdminHealth
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status == "" {
+		t.Error("expected non-empty status")
+	}
+}
+
+func TestAdminServer_ServeHTTP_Health_Unauthorized(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "test-key-123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
+	rec := httptest.NewRecorder()
+
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func TestAdminServer_ServeHTTP_Health_InvalidKey(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "test-key-123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
+	req.Header.Set("X-Admin-Key", "wrong-key")
+	rec := httptest.NewRecorder()
+
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func TestAdminServer_ServeHTTP_Events(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "test-key-123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events", nil)
+	req.Header.Set("X-Admin-Key", "test-key-123")
+	rec := httptest.NewRecorder()
+
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp EventsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("expected total 0, got %d", resp.Total)
+	}
+}
+
+func TestAdminServer_ServeHTTP_Sessions(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "test-key-123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/sessions", nil)
+	req.Header.Set("X-Admin-Key", "test-key-123")
+	rec := httptest.NewRecorder()
+
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp SessionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("expected total 0, got %d", resp.Total)
+	}
+}
+
+func TestAdminServer_GetHealthHandler(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{})
+
+	h := server.GetHealthHandler()
+	if h == nil {
+		t.Error("expected non-nil health handler")
+	}
+}
+
+func TestAdminServer_GetEventBuffer(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{})
+
+	buf := server.GetEventBuffer()
+	if buf == nil {
+		t.Error("expected non-nil event buffer")
+	}
+}
+
+func TestAdminServer_DrainEnterAndStatus(t *testing.T) {
+	// Test enter drain and get status with nil engine
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "drain-key",
+	})
+
+	// Enter drain
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/drain", nil)
+	req.Header.Set("X-Admin-Key", "drain-key")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 from enterDrain, got %d", rec.Code)
+	}
+
+	// Get drain status
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/admin/drain", nil)
+	req2.Header.Set("X-Admin-Key", "drain-key")
+	rec2 := httptest.NewRecorder()
+	server.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Errorf("expected status 200 from getDrainStatus, got %d", rec2.Code)
+	}
+}
+
+func TestAdminServer_ExitDrain_NotDraining(t *testing.T) {
+	// With nil engine, exitDrain should return 400 (not in drain mode)
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "drain-key",
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/drain", nil)
+	req.Header.Set("X-Admin-Key", "drain-key")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 when not draining, got %d", rec.Code)
+	}
+}
+
+func TestAdminServer_ConfigEndpoints(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "config-key",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config", nil)
+	req.Header.Set("X-Admin-Key", "config-key")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for nil engine, got %d", rec.Code)
+	}
+}
+
+func TestAdminServer_Metrics(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{
+		AdminKey: "metrics-key",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/metrics", nil)
+	req.Header.Set("X-Admin-Key", "metrics-key")
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if contentType != "text/plain; charset=utf-8" {
+		t.Errorf("expected text/plain content type, got %s", contentType)
+	}
+
+	body := rec.Body.String()
+	if body == "" {
+		t.Error("expected non-empty metrics body")
+	}
+}
+
+func TestAdminServer_NotFound(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestAdminServer_PushEvent(t *testing.T) {
+	server := NewAdminServer(AdminServerOptions{})
+
+	event := AdminEvent{
+		EventID:   "test-event-1",
+		Type:      "session_start",
+		SessionID: "test-session",
+		Timestamp: time.Now(),
+		Actor:     "admin",
+	}
+	server.eventBuffer.Push(event)
+
+	if server.eventBuffer.Size() != 1 {
+		t.Errorf("expected buffer size 1, got %d", server.eventBuffer.Size())
+	}
+}

--- a/internal/server/admin/admin_test.go
+++ b/internal/server/admin/admin_test.go
@@ -52,7 +52,7 @@ func TestAdminServer_ServeHTTP_Health(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
-	req.Header.Set("X-Admin-Key", "test-key-123")
+	req.Header.Set("X-API-Key", "test-key-123")
 	rec := httptest.NewRecorder()
 
 	server.ServeHTTP(rec, req)
@@ -92,7 +92,7 @@ func TestAdminServer_ServeHTTP_Health_InvalidKey(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
-	req.Header.Set("X-Admin-Key", "wrong-key")
+	req.Header.Set("X-API-Key", "wrong-key")
 	rec := httptest.NewRecorder()
 
 	server.ServeHTTP(rec, req)
@@ -108,7 +108,7 @@ func TestAdminServer_ServeHTTP_Events(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events", nil)
-	req.Header.Set("X-Admin-Key", "test-key-123")
+	req.Header.Set("X-API-Key", "test-key-123")
 	rec := httptest.NewRecorder()
 
 	server.ServeHTTP(rec, req)
@@ -133,7 +133,7 @@ func TestAdminServer_ServeHTTP_Sessions(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/sessions", nil)
-	req.Header.Set("X-Admin-Key", "test-key-123")
+	req.Header.Set("X-API-Key", "test-key-123")
 	rec := httptest.NewRecorder()
 
 	server.ServeHTTP(rec, req)
@@ -178,7 +178,7 @@ func TestAdminServer_DrainEnterAndStatus(t *testing.T) {
 
 	// Enter drain
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/drain", nil)
-	req.Header.Set("X-Admin-Key", "drain-key")
+	req.Header.Set("X-API-Key", "drain-key")
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
@@ -188,7 +188,7 @@ func TestAdminServer_DrainEnterAndStatus(t *testing.T) {
 
 	// Get drain status
 	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/admin/drain", nil)
-	req2.Header.Set("X-Admin-Key", "drain-key")
+	req2.Header.Set("X-API-Key", "drain-key")
 	rec2 := httptest.NewRecorder()
 	server.ServeHTTP(rec2, req2)
 
@@ -204,7 +204,7 @@ func TestAdminServer_ExitDrain_NotDraining(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/drain", nil)
-	req.Header.Set("X-Admin-Key", "drain-key")
+	req.Header.Set("X-API-Key", "drain-key")
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
@@ -219,7 +219,7 @@ func TestAdminServer_ConfigEndpoints(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config", nil)
-	req.Header.Set("X-Admin-Key", "config-key")
+	req.Header.Set("X-API-Key", "config-key")
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
@@ -234,7 +234,7 @@ func TestAdminServer_Metrics(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/metrics", nil)
-	req.Header.Set("X-Admin-Key", "metrics-key")
+	req.Header.Set("X-API-Key", "metrics-key")
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 

--- a/internal/server/admin/audit_handler.go
+++ b/internal/server/admin/audit_handler.go
@@ -1,0 +1,119 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// AuditHandler handles audit and history endpoints.
+type AuditHandler struct {
+	eventBuffer   *EventBuffer
+	sessionPool   interface {
+		GetSession(sessionID string) (*intengine.Session, bool)
+	}
+}
+
+// NewAuditHandler creates a new audit handler.
+func NewAuditHandler(eventBuffer *EventBuffer, sessionPool interface {
+	GetSession(sessionID string) (*intengine.Session, bool)
+}) *AuditHandler {
+	return &AuditHandler{
+		eventBuffer: eventBuffer,
+		sessionPool: sessionPool,
+	}
+}
+
+// getEvents handles GET /api/v1/admin/events.
+func (h *AuditHandler) getEvents(w http.ResponseWriter, r *http.Request) {
+	limitStr := r.URL.Query().Get("limit")
+	offsetStr := r.URL.Query().Get("offset")
+	cursorStr := r.URL.Query().Get("cursor")
+
+	limit := 100
+	offset := 0
+
+	if limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+			if limit > 1000 {
+				limit = 1000
+			}
+		}
+	}
+
+	// cursor takes precedence over offset (cursor-based pagination)
+	if cursorStr != "" {
+		if c, err := strconv.Atoi(cursorStr); err == nil && c >= 0 {
+			offset = c
+		}
+	} else if offsetStr != "" {
+		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
+			offset = o
+		}
+	}
+
+	var events []AdminEvent
+	var total int64
+
+	if h.eventBuffer != nil {
+		events, total = h.eventBuffer.GetEventsPaginated(limit, offset)
+	} else {
+		events = []AdminEvent{}
+		total = 0
+	}
+
+	// Calculate next cursor
+	var nextCursor string
+	if offset+limit < int(total) {
+		nextCursor = strconv.Itoa(offset + limit)
+	}
+
+	response := EventsResponse{
+		Events:     events,
+		NextCursor: nextCursor,
+		Total:      total,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// getTranscript handles GET /api/v1/admin/sessions/:id/transcript.
+// Note: Full transcript retrieval requires MessageStore integration.
+// This is a placeholder that returns session metadata.
+func (h *AuditHandler) getTranscript(w http.ResponseWriter, r *http.Request) {
+	sessionID := extractSessionID(r)
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		return
+	}
+
+	sess, ok := h.sessionPool.GetSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		return
+	}
+
+	// Build basic transcript from session data
+	// Full message history requires MessageStore integration
+	messages := []TranscriptMsg{
+		{
+			Type:      "session_start",
+			Timestamp: sess.CreatedAt,
+			Content:   "Session started",
+		},
+	}
+
+	response := TranscriptResponse{
+		SessionID: sessionID,
+		Messages:  messages,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// PushEvent is a helper to add an event to the buffer.
+func (h *AuditHandler) PushEvent(event AdminEvent) {
+	if h.eventBuffer != nil {
+		h.eventBuffer.Push(event)
+	}
+}

--- a/internal/server/admin/audit_handler.go
+++ b/internal/server/admin/audit_handler.go
@@ -28,30 +28,12 @@ func NewAuditHandler(eventBuffer *EventBuffer, sessionPool interface {
 
 // getEvents handles GET /api/v1/admin/events.
 func (h *AuditHandler) getEvents(w http.ResponseWriter, r *http.Request) {
-	limitStr := r.URL.Query().Get("limit")
-	offsetStr := r.URL.Query().Get("offset")
-	cursorStr := r.URL.Query().Get("cursor")
-
-	limit := 100
-	offset := 0
-
-	if limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
-			limit = l
-			if limit > 1000 {
-				limit = 1000
-			}
-		}
-	}
+	limit, offset := adminapi.ParsePagination(r)
 
 	// cursor takes precedence over offset (cursor-based pagination)
-	if cursorStr != "" {
+	if cursorStr := r.URL.Query().Get("cursor"); cursorStr != "" {
 		if c, err := strconv.Atoi(cursorStr); err == nil && c >= 0 {
 			offset = c
-		}
-	} else if offsetStr != "" {
-		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
-			offset = o
 		}
 	}
 

--- a/internal/server/admin/audit_handler.go
+++ b/internal/server/admin/audit_handler.go
@@ -85,13 +85,13 @@ func (h *AuditHandler) getEvents(w http.ResponseWriter, r *http.Request) {
 func (h *AuditHandler) getTranscript(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Missing session ID")
 		return
 	}
 
 	sess, ok := h.sessionPool.GetSession(sessionID)
 	if !ok {
-		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found")
 		return
 	}
 

--- a/internal/server/admin/audit_handler.go
+++ b/internal/server/admin/audit_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/hrygo/hotplex/internal/adminapi"
 	intengine "github.com/hrygo/hotplex/internal/engine"
 )
 
@@ -75,7 +76,7 @@ func (h *AuditHandler) getEvents(w http.ResponseWriter, r *http.Request) {
 		NextCursor: nextCursor,
 		Total:      total,
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // getTranscript handles GET /api/v1/admin/sessions/:id/transcript.
@@ -84,13 +85,13 @@ func (h *AuditHandler) getEvents(w http.ResponseWriter, r *http.Request) {
 func (h *AuditHandler) getTranscript(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
 		return
 	}
 
 	sess, ok := h.sessionPool.GetSession(sessionID)
 	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
 		return
 	}
 
@@ -108,7 +109,7 @@ func (h *AuditHandler) getTranscript(w http.ResponseWriter, r *http.Request) {
 		SessionID: sessionID,
 		Messages:  messages,
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // PushEvent is a helper to add an event to the buffer.

--- a/internal/server/admin/audit_handler_test.go
+++ b/internal/server/admin/audit_handler_test.go
@@ -1,0 +1,175 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+type mockSessionForAudit struct{}
+
+func (m *mockSessionForAudit) GetSession(sessionID string) (*intengine.Session, bool) {
+	return nil, false
+}
+
+func TestGetEvents_EmptyBuffer(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events", nil)
+	rec := httptest.NewRecorder()
+	handler.getEvents(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp EventsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("expected total 0, got %d", resp.Total)
+	}
+	if len(resp.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(resp.Events))
+	}
+}
+
+func TestGetEvents_WithEvents(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	buf.Push(AdminEvent{EventID: "evt-1", Type: "session_start", Timestamp: time.Now()})
+	buf.Push(AdminEvent{EventID: "evt-2", Type: "session_end", Timestamp: time.Now()})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events", nil)
+	rec := httptest.NewRecorder()
+	handler.getEvents(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp EventsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Errorf("expected total 2, got %d", resp.Total)
+	}
+	if len(resp.Events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(resp.Events))
+	}
+}
+
+func TestGetEvents_Pagination(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	for i := 0; i < 5; i++ {
+		buf.Push(AdminEvent{EventID: "evt-" + string(rune('0'+i)), Type: "test", Timestamp: time.Now()})
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events?limit=2&offset=0", nil)
+	rec := httptest.NewRecorder()
+	handler.getEvents(rec, req)
+
+	var resp EventsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 5 {
+		t.Errorf("expected total 5, got %d", resp.Total)
+	}
+	if len(resp.Events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(resp.Events))
+	}
+	if resp.NextCursor != "2" {
+		t.Errorf("expected next_cursor '2', got '%s'", resp.NextCursor)
+	}
+}
+
+func TestGetEvents_NilBuffer(t *testing.T) {
+	handler := NewAuditHandler(nil, &mockSessionForAudit{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/events", nil)
+	rec := httptest.NewRecorder()
+	handler.getEvents(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp EventsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("expected total 0 for nil buffer, got %d", resp.Total)
+	}
+}
+
+func TestGetTranscript_SessionNotFound(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/sessions/not-found/transcript", nil)
+	rec := httptest.NewRecorder()
+	handler.getTranscript(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+
+	var resp AdminError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Error.Code != "NOT_FOUND" {
+		t.Errorf("expected error code NOT_FOUND, got %s", resp.Error.Code)
+	}
+}
+
+func TestGetTranscript_MissingSessionID(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	// Double slash results in empty segment - extractSessionID returns ""
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/sessions//transcript", nil)
+	rec := httptest.NewRecorder()
+	handler.getTranscript(rec, req)
+
+	// Empty session ID returns 404 (session not found)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestPushEvent(t *testing.T) {
+	buf := NewEventBuffer(100)
+	handler := NewAuditHandler(buf, &mockSessionForAudit{})
+
+	event := AdminEvent{Type: "test_event", EventID: "test-123"}
+	handler.PushEvent(event)
+
+	if buf.Size() != 1 {
+		t.Errorf("expected buffer size 1, got %d", buf.Size())
+	}
+}
+
+func TestPushEvent_NilBuffer(t *testing.T) {
+	handler := NewAuditHandler(nil, &mockSessionForAudit{})
+
+	event := AdminEvent{Type: "test_event"}
+	handler.PushEvent(event)
+}

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -4,7 +4,12 @@ import (
 	"crypto/subtle"
 	"log/slog"
 	"net/http"
+
+	"github.com/hrygo/hotplex/internal/adminapi"
 )
+
+// ErrCodeUnauthorized is the error code for missing or invalid auth credentials.
+const ErrCodeUnauthorized = adminapi.ErrorCode("UNAUTHORIZED")
 
 // AdminAuthMiddleware creates an HTTP middleware that validates the X-Admin-Key header.
 // It uses constant-time comparison to prevent timing attacks.
@@ -26,7 +31,7 @@ func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler
 					"remote_addr", r.RemoteAddr,
 					"path", r.URL.Path,
 				)
-				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing X-Admin-Key header")
+				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Missing X-Admin-Key header")
 				return
 			}
 
@@ -37,7 +42,7 @@ func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler
 					"path", r.URL.Path,
 					"key_prefix", keyPrefix(key),
 				)
-				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid X-Admin-Key")
+				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Invalid X-Admin-Key")
 				return
 			}
 
@@ -53,13 +58,4 @@ func keyPrefix(key string) string {
 		return "****"
 	}
 	return key[:4] + "****"
-}
-
-// writeError writes a JSON error response.
-func writeError(w http.ResponseWriter, status int, code, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = NewAdminError(code, message)
-	// Simple JSON encoding without importing encoding/json
-	_, _ = w.Write([]byte(`{"error":{"code":"` + code + `","message":"` + message + `"}}`))
 }

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -8,9 +8,6 @@ import (
 	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
-// ErrCodeUnauthorized is the error code for missing or invalid auth credentials.
-const ErrCodeUnauthorized = adminapi.ErrorCode("UNAUTHORIZED")
-
 // AdminAuthMiddleware creates an HTTP middleware that validates the X-Admin-Key header.
 // It uses constant-time comparison to prevent timing attacks.
 // If adminKey is empty, authentication is bypassed (no auth required).

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
-// AdminAuthMiddleware creates an HTTP middleware that validates the X-Admin-Key header.
+// AdminAuthMiddleware creates an HTTP middleware that validates the X-API-Key header.
 // It uses constant-time comparison to prevent timing attacks.
 // If adminKey is empty, authentication is bypassed (no auth required).
 func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler) http.Handler {
@@ -20,7 +20,7 @@ func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler
 				return
 			}
 
-			key := r.Header.Get("X-Admin-Key")
+			key := r.Header.Get("X-API-Key")
 
 			// Empty key check
 			if key == "" {
@@ -28,7 +28,7 @@ func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler
 					"remote_addr", r.RemoteAddr,
 					"path", r.URL.Path,
 				)
-				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Missing X-Admin-Key header")
+				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Missing X-API-Key header")
 				return
 			}
 
@@ -39,7 +39,7 @@ func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler
 					"path", r.URL.Path,
 					"key_prefix", keyPrefix(key),
 				)
-				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Invalid X-Admin-Key")
+				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Invalid X-API-Key")
 				return
 			}
 

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -8,9 +8,16 @@ import (
 
 // AdminAuthMiddleware creates an HTTP middleware that validates the X-Admin-Key header.
 // It uses constant-time comparison to prevent timing attacks.
+// If adminKey is empty, authentication is bypassed (no auth required).
 func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip auth if no admin key is configured
+			if adminKey == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			key := r.Header.Get("X-Admin-Key")
 
 			// Empty key check

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"crypto/subtle"
 	"log/slog"
 	"net/http"
 
@@ -11,48 +10,13 @@ import (
 // AdminAuthMiddleware creates an HTTP middleware that validates the X-API-Key header.
 // It uses constant-time comparison to prevent timing attacks.
 // If adminKey is empty, authentication is bypassed (no auth required).
+//
+// Deprecated: Use adminapi.AuthMiddleware directly with AuthModeAPIKey.
+// This function is kept for backward compatibility.
 func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip auth if no admin key is configured
-			if adminKey == "" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			key := r.Header.Get("X-API-Key")
-
-			// Empty key check
-			if key == "" {
-				logger.Warn("admin_auth: missing key",
-					"remote_addr", r.RemoteAddr,
-					"path", r.URL.Path,
-				)
-				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Missing X-API-Key header")
-				return
-			}
-
-			// Constant-time comparison to prevent timing attacks
-			if subtle.ConstantTimeCompare([]byte(key), []byte(adminKey)) != 1 {
-				logger.Warn("admin_auth: invalid key",
-					"remote_addr", r.RemoteAddr,
-					"path", r.URL.Path,
-					"key_prefix", keyPrefix(key),
-				)
-				adminapi.WriteError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Invalid X-API-Key")
-				return
-			}
-
-			next.ServeHTTP(w, r)
-		})
-	}
-}
-
-// keyPrefix returns the first 4 characters of the key for logging.
-// This allows identifying which key was used without logging the full key.
-func keyPrefix(key string) string {
-	if len(key) < 4 {
-		return "****"
-	}
-	return key[:4] + "****"
+	return adminapi.AuthMiddleware(adminapi.AuthMiddlewareOptions{
+		AdminKey: adminKey,
+		Mode:     adminapi.AuthModeAPIKey,
+		Logger:   logger,
+	})
 }

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -1,0 +1,59 @@
+package admin
+
+import (
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+)
+
+// AdminAuthMiddleware creates an HTTP middleware that validates the X-Admin-Key header.
+// It uses constant-time comparison to prevent timing attacks.
+func AdminAuthMiddleware(adminKey string, logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := r.Header.Get("X-Admin-Key")
+
+			// Empty key check
+			if key == "" {
+				logger.Warn("admin_auth: missing key",
+					"remote_addr", r.RemoteAddr,
+					"path", r.URL.Path,
+				)
+				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing X-Admin-Key header")
+				return
+			}
+
+			// Constant-time comparison to prevent timing attacks
+			if subtle.ConstantTimeCompare([]byte(key), []byte(adminKey)) != 1 {
+				logger.Warn("admin_auth: invalid key",
+					"remote_addr", r.RemoteAddr,
+					"path", r.URL.Path,
+					"key_prefix", keyPrefix(key),
+				)
+				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid X-Admin-Key")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// keyPrefix returns the first 4 characters of the key for logging.
+// This allows identifying which key was used without logging the full key.
+func keyPrefix(key string) string {
+	if len(key) < 4 {
+		return "****"
+	}
+	return key[:4] + "****"
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	resp := NewAdminError(code, message)
+	// Simple JSON encoding without importing encoding/json
+	w.Write([]byte(`{"error":{"code":"` + code + `","message":"` + message + `"}}`))
+	_ = resp // Just for documentation
+}

--- a/internal/server/admin/auth.go
+++ b/internal/server/admin/auth.go
@@ -59,8 +59,7 @@ func keyPrefix(key string) string {
 func writeError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	resp := NewAdminError(code, message)
+	_ = NewAdminError(code, message)
 	// Simple JSON encoding without importing encoding/json
-	w.Write([]byte(`{"error":{"code":"` + code + `","message":"` + message + `"}}`))
-	_ = resp // Just for documentation
+	_, _ = w.Write([]byte(`{"error":{"code":"` + code + `","message":"` + message + `"}}`))
 }

--- a/internal/server/admin/auth_test.go
+++ b/internal/server/admin/auth_test.go
@@ -51,8 +51,8 @@ func TestAdminAuthMiddleware_MissingKey(t *testing.T) {
 	if !strings.Contains(body, "UNAUTHORIZED") {
 		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
 	}
-	if !strings.Contains(body, "Missing X-API-Key") {
-		t.Errorf("expected missing key message, got %s", body)
+	if !strings.Contains(body, "X-API-Key") {
+		t.Errorf("expected X-API-Key reference, got %s", body)
 	}
 }
 
@@ -77,9 +77,6 @@ func TestAdminAuthMiddleware_InvalidKey(t *testing.T) {
 	body := rec.Body.String()
 	if !strings.Contains(body, "UNAUTHORIZED") {
 		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
-	}
-	if !strings.Contains(body, "Invalid X-API-Key") {
-		t.Errorf("expected invalid key message, got %s", body)
 	}
 }
 
@@ -135,28 +132,6 @@ func TestAdminAuthMiddleware_TimingAttackResistant(t *testing.T) {
 
 			if rec.Code != tc.want {
 				t.Errorf("key %q: expected status %d, got %d", tc.key, tc.want, rec.Code)
-			}
-		})
-	}
-}
-
-func TestKeyPrefix(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"abcdefgh", "abcd****"},
-		{"ab", "****"},
-		{"abc", "****"},
-		{"abcd", "abcd****"},
-		{"", "****"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := keyPrefix(tt.input)
-			if result != tt.expected {
-				t.Errorf("keyPrefix(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/internal/server/admin/auth_test.go
+++ b/internal/server/admin/auth_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
 func TestAdminAuthMiddleware_ValidKey(t *testing.T) {
@@ -163,7 +165,7 @@ func TestKeyPrefix(t *testing.T) {
 func TestWriteError(t *testing.T) {
 	rec := httptest.NewRecorder()
 
-	writeError(rec, http.StatusBadRequest, "INVALID_REQUEST", "Test error message")
+	adminapi.WriteError(rec, http.StatusBadRequest, adminapi.ErrCodeInvalidRequest, "Test error message")
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected status 400, got %d", rec.Code)

--- a/internal/server/admin/auth_test.go
+++ b/internal/server/admin/auth_test.go
@@ -20,7 +20,7 @@ func TestAdminAuthMiddleware_ValidKey(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("X-Admin-Key", "test-secret-key")
+	req.Header.Set("X-API-Key", "test-secret-key")
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -51,7 +51,7 @@ func TestAdminAuthMiddleware_MissingKey(t *testing.T) {
 	if !strings.Contains(body, "UNAUTHORIZED") {
 		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
 	}
-	if !strings.Contains(body, "Missing X-Admin-Key") {
+	if !strings.Contains(body, "Missing X-API-Key") {
 		t.Errorf("expected missing key message, got %s", body)
 	}
 }
@@ -65,7 +65,7 @@ func TestAdminAuthMiddleware_InvalidKey(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("X-Admin-Key", "wrong-key")
+	req.Header.Set("X-API-Key", "wrong-key")
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -78,7 +78,7 @@ func TestAdminAuthMiddleware_InvalidKey(t *testing.T) {
 	if !strings.Contains(body, "UNAUTHORIZED") {
 		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
 	}
-	if !strings.Contains(body, "Invalid X-Admin-Key") {
+	if !strings.Contains(body, "Invalid X-API-Key") {
 		t.Errorf("expected invalid key message, got %s", body)
 	}
 }
@@ -93,7 +93,7 @@ func TestAdminAuthMiddleware_PartialKey(t *testing.T) {
 
 	// Only first part of the key matches
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("X-Admin-Key", "test")
+	req.Header.Set("X-API-Key", "test")
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -127,7 +127,7 @@ func TestAdminAuthMiddleware_TimingAttackResistant(t *testing.T) {
 		t.Run(tc.key, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			if tc.key != "" {
-				req.Header.Set("X-Admin-Key", tc.key)
+				req.Header.Set("X-API-Key", tc.key)
 			}
 			rec := httptest.NewRecorder()
 

--- a/internal/server/admin/auth_test.go
+++ b/internal/server/admin/auth_test.go
@@ -14,7 +14,7 @@ func TestAdminAuthMiddleware_ValidKey(t *testing.T) {
 
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/internal/server/admin/auth_test.go
+++ b/internal/server/admin/auth_test.go
@@ -1,0 +1,184 @@
+package admin
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAdminAuthMiddleware_ValidKey(t *testing.T) {
+	logger := slog.Default()
+	middleware := AdminAuthMiddleware("test-secret-key", logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Admin-Key", "test-secret-key")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestAdminAuthMiddleware_MissingKey(t *testing.T) {
+	logger := slog.Default()
+	middleware := AdminAuthMiddleware("test-secret-key", logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called for missing key")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "UNAUTHORIZED") {
+		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
+	}
+	if !strings.Contains(body, "Missing X-Admin-Key") {
+		t.Errorf("expected missing key message, got %s", body)
+	}
+}
+
+func TestAdminAuthMiddleware_InvalidKey(t *testing.T) {
+	logger := slog.Default()
+	middleware := AdminAuthMiddleware("test-secret-key", logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called for invalid key")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Admin-Key", "wrong-key")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "UNAUTHORIZED") {
+		t.Errorf("expected error code UNAUTHORIZED, got %s", body)
+	}
+	if !strings.Contains(body, "Invalid X-Admin-Key") {
+		t.Errorf("expected invalid key message, got %s", body)
+	}
+}
+
+func TestAdminAuthMiddleware_PartialKey(t *testing.T) {
+	logger := slog.Default()
+	middleware := AdminAuthMiddleware("test-secret-key", logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called for partial key")
+	}))
+
+	// Only first part of the key matches
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Admin-Key", "test")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 for partial key, got %d", rec.Code)
+	}
+}
+
+func TestAdminAuthMiddleware_TimingAttackResistant(t *testing.T) {
+	logger := slog.Default()
+	middleware := AdminAuthMiddleware("test-secret-key", logger)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Test that similar keys are handled correctly
+	testCases := []struct {
+		key     string
+		want    int
+	}{
+		{"test-secret-key", http.StatusOK},
+		{"Test-Secret-Key", http.StatusUnauthorized}, // Different case
+		{"test-secret-ke", http.StatusUnauthorized},    // One char short
+		{"test-secret-key-extra", http.StatusUnauthorized}, // Extra chars
+		{"", http.StatusUnauthorized},                     // Empty
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tc.key != "" {
+				req.Header.Set("X-Admin-Key", tc.key)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.want {
+				t.Errorf("key %q: expected status %d, got %d", tc.key, tc.want, rec.Code)
+			}
+		})
+	}
+}
+
+func TestKeyPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"abcdefgh", "abcd****"},
+		{"ab", "****"},
+		{"abc", "****"},
+		{"abcd", "abcd****"},
+		{"", "****"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := keyPrefix(tt.input)
+			if result != tt.expected {
+				t.Errorf("keyPrefix(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	writeError(rec, http.StatusBadRequest, "INVALID_REQUEST", "Test error message")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", contentType)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "INVALID_REQUEST") {
+		t.Errorf("expected error code INVALID_REQUEST, got %s", body)
+	}
+	if !strings.Contains(body, "Test error message") {
+		t.Errorf("expected error message, got %s", body)
+	}
+}

--- a/internal/server/admin/config_handler.go
+++ b/internal/server/admin/config_handler.go
@@ -20,7 +20,7 @@ func NewConfigHandler(eng *engine.Engine) *ConfigHandler {
 // getConfig handles GET /api/v1/admin/config.
 func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeEngineNotInitialized, "Engine not initialized")
 		return
 	}
 
@@ -44,7 +44,7 @@ func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 // getAllowedTools handles GET /api/v1/admin/config/allowed_tools.
 func (h *ConfigHandler) getAllowedTools(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeEngineNotInitialized, "Engine not initialized")
 		return
 	}
 
@@ -59,7 +59,7 @@ func (h *ConfigHandler) getAllowedTools(w http.ResponseWriter, r *http.Request) 
 // getDisallowedTools handles GET /api/v1/admin/config/disallowed_tools.
 func (h *ConfigHandler) getDisallowedTools(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, ErrCodeEngineNotInitialized, "Engine not initialized")
 		return
 	}
 

--- a/internal/server/admin/config_handler.go
+++ b/internal/server/admin/config_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/hrygo/hotplex/engine"
+	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
 // ConfigHandler handles configuration endpoints.
@@ -19,7 +20,7 @@ func NewConfigHandler(eng *engine.Engine) *ConfigHandler {
 // getConfig handles GET /api/v1/admin/config.
 func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
 		return
 	}
 
@@ -37,13 +38,13 @@ func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := ConfigResponse{Config: config}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // getAllowedTools handles GET /api/v1/admin/config/allowed_tools.
 func (h *ConfigHandler) getAllowedTools(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
 		return
 	}
 
@@ -52,13 +53,13 @@ func (h *ConfigHandler) getAllowedTools(w http.ResponseWriter, r *http.Request) 
 		Tools:  opts.AllowedTools,
 		Source: "engine_options",
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // getDisallowedTools handles GET /api/v1/admin/config/disallowed_tools.
 func (h *ConfigHandler) getDisallowedTools(w http.ResponseWriter, r *http.Request) {
 	if h.engine == nil {
-		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		adminapi.WriteError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
 		return
 	}
 
@@ -67,5 +68,5 @@ func (h *ConfigHandler) getDisallowedTools(w http.ResponseWriter, r *http.Reques
 		Tools:  opts.DisallowedTools,
 		Source: "engine_options",
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }

--- a/internal/server/admin/config_handler.go
+++ b/internal/server/admin/config_handler.go
@@ -1,0 +1,71 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/hrygo/hotplex/engine"
+)
+
+// ConfigHandler handles configuration endpoints.
+type ConfigHandler struct {
+	engine *engine.Engine
+}
+
+// NewConfigHandler creates a new config handler.
+func NewConfigHandler(eng *engine.Engine) *ConfigHandler {
+	return &ConfigHandler{engine: eng}
+}
+
+// getConfig handles GET /api/v1/admin/config.
+func (h *ConfigHandler) getConfig(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		return
+	}
+
+	opts := h.engine.GetOptions()
+
+	// Create a safe config view (no secrets)
+	config := map[string]interface{}{
+		"namespace":        opts.Namespace,
+		"timeout":          opts.Timeout.String(),
+		"idle_timeout":     opts.IdleTimeout.String(),
+		"permission_mode":  opts.PermissionMode,
+		"skip_permissions": opts.DangerouslySkipPermissions,
+		"allowed_tools":    opts.AllowedTools,
+		"disallowed_tools":  opts.DisallowedTools,
+	}
+
+	response := ConfigResponse{Config: config}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// getAllowedTools handles GET /api/v1/admin/config/allowed_tools.
+func (h *ConfigHandler) getAllowedTools(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		return
+	}
+
+	opts := h.engine.GetOptions()
+	response := ToolsResponse{
+		Tools:  opts.AllowedTools,
+		Source: "engine_options",
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// getDisallowedTools handles GET /api/v1/admin/config/disallowed_tools.
+func (h *ConfigHandler) getDisallowedTools(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "ENGINE_NOT_INITIALIZED", "Engine not initialized")
+		return
+	}
+
+	opts := h.engine.GetOptions()
+	response := ToolsResponse{
+		Tools:  opts.DisallowedTools,
+		Source: "engine_options",
+	}
+	writeJSON(w, http.StatusOK, response)
+}

--- a/internal/server/admin/config_handler_test.go
+++ b/internal/server/admin/config_handler_test.go
@@ -1,0 +1,69 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hrygo/hotplex/engine"
+)
+
+func TestGetConfig_EngineNil(t *testing.T) {
+	handler := NewConfigHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config", nil)
+	rec := httptest.NewRecorder()
+	handler.getConfig(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+}
+
+func TestGetAllowedTools_EngineNil(t *testing.T) {
+	handler := NewConfigHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config/allowed_tools", nil)
+	rec := httptest.NewRecorder()
+	handler.getAllowedTools(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+}
+
+func TestGetDisallowedTools_EngineNil(t *testing.T) {
+	handler := NewConfigHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config/disallowed_tools", nil)
+	rec := httptest.NewRecorder()
+	handler.getDisallowedTools(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+}
+
+func TestGetConfig_ResponseFormat(t *testing.T) {
+	handler := NewConfigHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/config", nil)
+	rec := httptest.NewRecorder()
+	handler.getConfig(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for nil engine, got %d", rec.Code)
+	}
+
+	var resp AdminError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Error.Code != "ENGINE_NOT_INITIALIZED" {
+		t.Errorf("expected error code ENGINE_NOT_INITIALIZED, got %s", resp.Error.Code)
+	}
+}
+
+var _ = engine.Engine{}

--- a/internal/server/admin/event_buffer.go
+++ b/internal/server/admin/event_buffer.go
@@ -1,0 +1,141 @@
+package admin
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventBuffer is a thread-safe ring buffer for audit events.
+// It stores the last maxSize events in memory for fast access.
+type EventBuffer struct {
+	mu       sync.RWMutex
+	events   []AdminEvent
+	maxSize  int
+	head     int // Points to the oldest event
+	count    int // Number of events in buffer
+}
+
+// NewEventBuffer creates a new event buffer with the given maximum size.
+func NewEventBuffer(maxSize int) *EventBuffer {
+	if maxSize <= 0 {
+		maxSize = 10000 // Default to 10,000 events
+	}
+	return &EventBuffer{
+		events:  make([]AdminEvent, maxSize),
+		maxSize: maxSize,
+		head:    0,
+		count:   0,
+	}
+}
+
+// Push adds a new event to the buffer.
+// If the buffer is full, the oldest event is overwritten.
+func (b *EventBuffer) Push(event AdminEvent) {
+	if event.EventID == "" {
+		event.EventID = uuid.New().String()
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Write at head position (overwrites oldest)
+	b.events[b.head] = event
+	b.head = (b.head + 1) % b.maxSize
+	if b.count < b.maxSize {
+		b.count++
+	}
+}
+
+// GetEvents returns all events in chronological order (oldest first).
+func (b *EventBuffer) GetEvents() []AdminEvent {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.count == 0 {
+		return []AdminEvent{}
+	}
+
+	result := make([]AdminEvent, b.count)
+
+	// Calculate starting position (oldest event)
+	start := 0
+	if b.count == b.maxSize {
+		start = b.head
+	}
+
+	for i := 0; i < b.count; i++ {
+		idx := (start + i) % b.maxSize
+		result[i] = b.events[idx]
+	}
+
+	return result
+}
+
+// GetEventsPaginated returns events with pagination support.
+func (b *EventBuffer) GetEventsPaginated(limit, offset int) ([]AdminEvent, int64) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	total := int64(b.count)
+	if total == 0 {
+		return []AdminEvent{}, 0
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Calculate starting position (oldest event)
+	start := 0
+	if b.count == b.maxSize {
+		start = b.head
+	}
+
+	// Apply offset
+	startIdx := offset
+	if startIdx >= b.count {
+		return []AdminEvent{}, total
+	}
+
+	// Apply limit
+	endIdx := startIdx + limit
+	if endIdx > b.count {
+		endIdx = b.count
+	}
+
+	result := make([]AdminEvent, endIdx-startIdx)
+	for i := 0; i < len(result); i++ {
+		idx := (start + startIdx + i) % b.maxSize
+		result[i] = b.events[idx]
+	}
+
+	return result, total
+}
+
+// Size returns the current number of events in the buffer.
+func (b *EventBuffer) Size() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.count
+}
+
+// MaxSize returns the maximum capacity of the buffer.
+func (b *EventBuffer) MaxSize() int {
+	return b.maxSize
+}
+
+// Clear removes all events from the buffer.
+func (b *EventBuffer) Clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.head = 0
+	b.count = 0
+}

--- a/internal/server/admin/event_buffer_test.go
+++ b/internal/server/admin/event_buffer_test.go
@@ -1,0 +1,136 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestEventBuffer_PushAndGet(t *testing.T) {
+	buf := NewEventBuffer(100)
+
+	event := AdminEvent{
+		EventID:   uuid.New().String(),
+		Timestamp: time.Now(),
+		Type:      "test.event",
+		Payload:   map[string]interface{}{"key": "value"},
+	}
+
+	buf.Push(event)
+
+	events := buf.GetEvents()
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+
+	if events[0].Type != "test.event" {
+		t.Errorf("expected event type 'test.event', got %s", events[0].Type)
+	}
+}
+
+func TestEventBuffer_Overflow(t *testing.T) {
+	buf := NewEventBuffer(3)
+
+	// Push 5 events into a buffer of size 3
+	for i := 0; i < 5; i++ {
+		buf.Push(AdminEvent{
+			EventID: uuid.New().String(),
+			Type:    "event",
+			Payload: map[string]interface{}{"index": i},
+		})
+	}
+
+	events := buf.GetEvents()
+	if len(events) != 3 {
+		t.Errorf("expected 3 events (max size), got %d", len(events))
+	}
+
+	// Should have the 3 most recent events (indices 2, 3, 4)
+	idx := events[0].Payload["index"].(int)
+	if idx != 2 {
+		t.Errorf("expected first event index 2, got %d", idx)
+	}
+}
+
+func TestEventBuffer_Pagination(t *testing.T) {
+	buf := NewEventBuffer(100)
+
+	// Push 10 events
+	for i := 0; i < 10; i++ {
+		buf.Push(AdminEvent{
+			EventID: uuid.New().String(),
+			Type:    "event",
+			Payload: map[string]interface{}{"index": i},
+		})
+	}
+
+	// Get first page
+	events, total := buf.GetEventsPaginated(3, 0)
+	if len(events) != 3 {
+		t.Errorf("expected 3 events, got %d", len(events))
+	}
+	if total != 10 {
+		t.Errorf("expected total 10, got %d", total)
+	}
+
+	// Get second page
+	events, total = buf.GetEventsPaginated(3, 3)
+	if len(events) != 3 {
+		t.Errorf("expected 3 events, got %d", len(events))
+	}
+	if total != 10 {
+		t.Errorf("expected total 10, got %d", total)
+	}
+
+	// Get last page (partial)
+	events, total = buf.GetEventsPaginated(5, 8)
+	if len(events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(events))
+	}
+}
+
+func TestEventBuffer_Size(t *testing.T) {
+	buf := NewEventBuffer(10)
+
+	if buf.Size() != 0 {
+		t.Errorf("expected size 0, got %d", buf.Size())
+	}
+	if buf.MaxSize() != 10 {
+		t.Errorf("expected max size 10, got %d", buf.MaxSize())
+	}
+
+	buf.Push(AdminEvent{Type: "test"})
+	if buf.Size() != 1 {
+		t.Errorf("expected size 1, got %d", buf.Size())
+	}
+}
+
+func TestEventBuffer_Clear(t *testing.T) {
+	buf := NewEventBuffer(10)
+
+	buf.Push(AdminEvent{Type: "test1"})
+	buf.Push(AdminEvent{Type: "test2"})
+
+	if buf.Size() != 2 {
+		t.Errorf("expected size 2, got %d", buf.Size())
+	}
+
+	buf.Clear()
+
+	if buf.Size() != 0 {
+		t.Errorf("expected size 0 after clear, got %d", buf.Size())
+	}
+}
+
+func TestEventBuffer_DefaultSize(t *testing.T) {
+	buf := NewEventBuffer(0)
+	if buf.MaxSize() != 10000 {
+		t.Errorf("expected default size 10000, got %d", buf.MaxSize())
+	}
+
+	buf2 := NewEventBuffer(-5)
+	if buf2.MaxSize() != 10000 {
+		t.Errorf("expected default size 10000 for negative, got %d", buf2.MaxSize())
+	}
+}

--- a/internal/server/admin/event_buffer_test.go
+++ b/internal/server/admin/event_buffer_test.go
@@ -84,7 +84,7 @@ func TestEventBuffer_Pagination(t *testing.T) {
 	}
 
 	// Get last page (partial)
-	events, total = buf.GetEventsPaginated(5, 8)
+	events, _ = buf.GetEventsPaginated(5, 8)
 	if len(events) != 2 {
 		t.Errorf("expected 2 events, got %d", len(events))
 	}

--- a/internal/server/admin/health_handler.go
+++ b/internal/server/admin/health_handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hrygo/hotplex"
 	"github.com/hrygo/hotplex/engine"
+	"github.com/hrygo/hotplex/internal/adminapi"
 	intengine "github.com/hrygo/hotplex/internal/engine"
 )
 
@@ -93,7 +94,7 @@ func (h *HealthHandler) getHealth(w http.ResponseWriter, r *http.Request) {
 		Subsystems:  subsystems,
 	}
 
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // getMetrics handles GET /api/v1/admin/metrics.
@@ -114,7 +115,7 @@ func (h *HealthHandler) getMetrics(w http.ResponseWriter, r *http.Request) {
 		statusCounts := make(map[string]int)
 		platformCounts := make(map[string]int)
 		for _, s := range sessions {
-			status := MapSessionStatus(s.GetStatus())
+			status := adminapi.MapSessionStatus(s.GetStatus())
 			statusCounts[status]++
 			platformCounts[MapSessionToAdminSession(s).Platform]++
 		}
@@ -156,7 +157,7 @@ func (h *HealthHandler) enterDrain(w http.ResponseWriter, r *http.Request) {
 	var req DrainRequest
 	if r.ContentLength > 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+			adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
 			return
 		}
 	}
@@ -184,7 +185,7 @@ func (h *HealthHandler) enterDrain(w http.ResponseWriter, r *http.Request) {
 		ActiveSessions: activeSessions,
 		Message:        msg,
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // exitDrain handles DELETE /api/v1/admin/drain.
@@ -196,7 +197,7 @@ func (h *HealthHandler) exitDrain(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !wasDraining {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Service is not in drain mode")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Service is not in drain mode")
 		return
 	}
 
@@ -206,7 +207,7 @@ func (h *HealthHandler) exitDrain(w http.ResponseWriter, r *http.Request) {
 		Status:  "active",
 		Message: "Service has exited drain mode",
 	}
-	writeJSON(w, http.StatusOK, response)
+	adminapi.WriteJSON(w, http.StatusOK, response)
 }
 
 // getDrainStatus handles GET /api/v1/admin/drain.
@@ -230,12 +231,12 @@ func (h *HealthHandler) getDrainStatus(w http.ResponseWriter, r *http.Request) {
 			ActiveSessions: activeSessions,
 			Message:        msg,
 		}
-		writeJSON(w, http.StatusOK, response)
+		adminapi.WriteJSON(w, http.StatusOK, response)
 	} else {
 		response := DrainResponse{
 			Status: "active",
 		}
-		writeJSON(w, http.StatusOK, response)
+		adminapi.WriteJSON(w, http.StatusOK, response)
 	}
 }
 

--- a/internal/server/admin/health_handler.go
+++ b/internal/server/admin/health_handler.go
@@ -157,7 +157,7 @@ func (h *HealthHandler) enterDrain(w http.ResponseWriter, r *http.Request) {
 	var req DrainRequest
 	if r.ContentLength > 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+			adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid JSON body")
 			return
 		}
 	}
@@ -197,7 +197,7 @@ func (h *HealthHandler) exitDrain(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !wasDraining {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Service is not in drain mode")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Service is not in drain mode")
 		return
 	}
 

--- a/internal/server/admin/health_handler.go
+++ b/internal/server/admin/health_handler.go
@@ -1,0 +1,325 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/hrygo/hotplex"
+	"github.com/hrygo/hotplex/engine"
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// HealthHandler handles health, metrics, and drain endpoints.
+type HealthHandler struct {
+	engine    *engine.Engine
+	startTime time.Time
+	logger    *slog.Logger
+}
+
+// NewHealthHandler creates a new health handler.
+func NewHealthHandler(eng *engine.Engine, startTime time.Time, logger *slog.Logger) *HealthHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HealthHandler{
+		engine:    eng,
+		startTime: startTime,
+		logger:    logger,
+	}
+}
+
+// getHealth handles GET /api/v1/admin/health.
+func (h *HealthHandler) getHealth(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+
+	subsystems := make(map[string]SubsystemHealth)
+	overallStatus := "ok"
+
+	// Check engine/session pool
+	if h.checkEngine(ctx) {
+		subsystems["engine"] = SubsystemHealth{Status: "ok"}
+	} else {
+		subsystems["engine"] = SubsystemHealth{Status: "error", Message: "Session pool unavailable"}
+		overallStatus = "degraded"
+	}
+
+	// Check security/WAF
+	if h.checkSecurity(ctx) {
+		subsystems["security"] = SubsystemHealth{Status: "ok"}
+	} else {
+		subsystems["security"] = SubsystemHealth{Status: "error", Message: "WAF unavailable"}
+		overallStatus = "degraded"
+	}
+
+	// Check storage (optional)
+	if h.checkStorage(ctx) {
+		subsystems["storage"] = SubsystemHealth{Status: "ok"}
+	} else {
+		subsystems["storage"] = SubsystemHealth{Status: "error", Message: "Message store not available"}
+		if overallStatus == "ok" {
+			overallStatus = "degraded"
+		}
+	}
+
+	// Check config watcher
+	if h.checkConfig(ctx) {
+		subsystems["config"] = SubsystemHealth{Status: "ok"}
+	} else {
+		subsystems["config"] = SubsystemHealth{Status: "error", Message: "Config watcher unavailable"}
+		overallStatus = "unhealthy"
+	}
+
+	// Count unhealthy subsystems
+	unhealthy := 0
+	for _, s := range subsystems {
+		if s.Status == "error" {
+			unhealthy++
+		}
+	}
+	if unhealthy > 1 {
+		overallStatus = "unhealthy"
+	}
+
+	response := AdminHealth{
+		Status:      overallStatus,
+		Version:     hotplex.Version,
+		Uptime:      formatUptime(time.Since(h.startTime)),
+		Subsystems:  subsystems,
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// getMetrics handles GET /api/v1/admin/metrics.
+// Returns Prometheus-compatible text format.
+func (h *HealthHandler) getMetrics(w http.ResponseWriter, r *http.Request) {
+	var sb stringsBuilder
+	sb.WriteString("# HELP hotplex_uptime_seconds Uptime in seconds\n")
+	sb.WriteString("# TYPE hotplex_uptime_seconds gauge\n")
+	sb.WriteString("hotplex_uptime_seconds " + strconv.FormatFloat(time.Since(h.startTime).Seconds(), 'f', 3, 64) + "\n")
+
+	if h.engine != nil && h.engine.GetSessionManager() != nil {
+		sessions := h.engine.GetSessionManager().ListActiveSessions()
+
+		sb.WriteString("# HELP hotplex_sessions_active Current number of active sessions\n")
+		sb.WriteString("# TYPE hotplex_sessions_active gauge\n")
+
+		// Count by status
+		statusCounts := make(map[string]int)
+		platformCounts := make(map[string]int)
+		for _, s := range sessions {
+			status := MapSessionStatus(s.GetStatus())
+			statusCounts[status]++
+			platformCounts[MapSessionToAdminSession(s).Platform]++
+		}
+
+		for status, count := range statusCounts {
+			sb.WriteString("hotplex_sessions_active{status=\"" + status + "\"} " + strconv.Itoa(count) + "\n")
+		}
+
+		sb.WriteString("# HELP hotplex_sessions_total Total number of sessions\n")
+		sb.WriteString("# TYPE hotplex_sessions_total counter\n")
+		sb.WriteString("hotplex_sessions_total " + strconv.Itoa(len(sessions)) + "\n")
+
+		// Platform counts
+		sb.WriteString("# HELP hotplex_sessions_by_platform Sessions by platform\n")
+		sb.WriteString("# TYPE hotplex_sessions_by_platform gauge\n")
+		for platform, count := range platformCounts {
+			sb.WriteString("hotplex_sessions_by_platform{platform=\"" + platform + "\"} " + strconv.Itoa(count) + "\n")
+		}
+	}
+
+	// Memory stats
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	sb.WriteString("# HELP hotplex_memory_alloc_bytes Allocated memory in bytes\n")
+	sb.WriteString("# TYPE hotplex_memory_alloc_bytes gauge\n")
+	sb.WriteString("hotplex_memory_alloc_bytes " + strconv.FormatUint(memStats.Alloc, 10) + "\n")
+
+	sb.WriteString("# HELP hotplex_goroutines Number of goroutines\n")
+	sb.WriteString("# TYPE hotplex_goroutines gauge\n")
+	sb.WriteString("hotplex_goroutines " + strconv.Itoa(runtime.NumGoroutine()) + "\n")
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(sb.String()))
+}
+
+// enterDrain handles POST /api/v1/admin/drain.
+func (h *HealthHandler) enterDrain(w http.ResponseWriter, r *http.Request) {
+	var req DrainRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+			return
+		}
+	}
+
+	msg := req.Message
+	if msg == "" {
+		msg = "Service is in drain mode"
+	}
+
+	if h.engine != nil {
+		h.engine.EnterDrain(msg)
+	}
+
+	activeSessions := 0
+	if h.engine != nil && h.engine.GetSessionManager() != nil {
+		activeSessions = len(h.engine.GetSessionManager().ListActiveSessions())
+	}
+
+	h.logger.Info("Admin API: Entering drain mode",
+		"message", msg,
+		"active_sessions", activeSessions)
+
+	response := DrainResponse{
+		Status:         "draining",
+		ActiveSessions: activeSessions,
+		Message:        msg,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// exitDrain handles DELETE /api/v1/admin/drain.
+func (h *HealthHandler) exitDrain(w http.ResponseWriter, r *http.Request) {
+	wasDraining := false
+	if h.engine != nil {
+		wasDraining = h.engine.IsDraining()
+		h.engine.ExitDrain()
+	}
+
+	if !wasDraining {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Service is not in drain mode")
+		return
+	}
+
+	h.logger.Info("Admin API: Exiting drain mode")
+
+	response := DrainResponse{
+		Status:  "active",
+		Message: "Service has exited drain mode",
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// getDrainStatus handles GET /api/v1/admin/drain.
+func (h *HealthHandler) getDrainStatus(w http.ResponseWriter, r *http.Request) {
+	draining := false
+	if h.engine != nil {
+		draining = h.engine.IsDraining()
+	}
+
+	if draining {
+		msg := ""
+		if h.engine != nil {
+			msg = h.engine.GetDrainMessage()
+		}
+		activeSessions := 0
+		if h.engine != nil && h.engine.GetSessionManager() != nil {
+			activeSessions = len(h.engine.GetSessionManager().ListActiveSessions())
+		}
+		response := DrainResponse{
+			Status:         "draining",
+			ActiveSessions: activeSessions,
+			Message:        msg,
+		}
+		writeJSON(w, http.StatusOK, response)
+	} else {
+		response := DrainResponse{
+			Status: "active",
+		}
+		writeJSON(w, http.StatusOK, response)
+	}
+}
+
+// IsDraining returns true if the service is in drain mode.
+func (h *HealthHandler) IsDraining() bool {
+	if h.engine != nil {
+		return h.engine.IsDraining()
+	}
+	return false
+}
+
+// GetDrainMessage returns the drain message.
+func (h *HealthHandler) GetDrainMessage() string {
+	if h.engine != nil {
+		return h.engine.GetDrainMessage()
+	}
+	return "Service is in drain mode"
+}
+
+// checkEngine checks session pool health.
+func (h *HealthHandler) checkEngine(ctx context.Context) bool {
+	if h.engine == nil || h.engine.GetSessionManager() == nil {
+		return false
+	}
+	done := make(chan bool, 1)
+	go func() {
+		sessions := h.engine.GetSessionManager().ListActiveSessions()
+		done <- (sessions != nil)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case ok := <-done:
+		return ok
+	}
+}
+
+// checkSecurity checks WAF/health.
+func (h *HealthHandler) checkSecurity(ctx context.Context) bool {
+	// Basic check - if engine is running, security is active
+	return h.checkEngine(ctx)
+}
+
+// checkStorage checks message store availability.
+func (h *HealthHandler) checkStorage(ctx context.Context) bool {
+	// Optional subsystem - return true for now
+	return true
+}
+
+// checkConfig checks config watcher health.
+func (h *HealthHandler) checkConfig(ctx context.Context) bool {
+	// Basic check - if we can respond, config is valid
+	return true
+}
+
+// formatUptime formats duration as human-readable string.
+func formatUptime(d time.Duration) string {
+	d = d.Round(time.Second)
+	totalSeconds := int(d / time.Second)
+	h := totalSeconds / 3600
+	m := (totalSeconds % 3600) / 60
+	s := totalSeconds % 60
+	if h > 0 {
+		return strconv.Itoa(h) + "h " + strconv.Itoa(m) + "m " + strconv.Itoa(s) + "s"
+	}
+	if m > 0 {
+		return strconv.Itoa(m) + "m " + strconv.Itoa(s) + "s"
+	}
+	return strconv.Itoa(s) + "s"
+}
+
+// stringsBuilder is a simple strings.Builder replacement.
+type stringsBuilder struct {
+	b []byte
+}
+
+func (sb *stringsBuilder) WriteString(s string) {
+	sb.b = append(sb.b, s...)
+}
+
+func (sb *stringsBuilder) String() string {
+	return string(sb.b)
+}
+
+// Ensure intengine.Session type compatibility
+var _ = (*intengine.Session)(nil)

--- a/internal/server/admin/health_handler.go
+++ b/internal/server/admin/health_handler.go
@@ -148,7 +148,7 @@ func (h *HealthHandler) getMetrics(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(sb.String()))
+	_, _ = w.Write([]byte(sb.String()))
 }
 
 // enterDrain handles POST /api/v1/admin/drain.

--- a/internal/server/admin/health_handler.go
+++ b/internal/server/admin/health_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hrygo/hotplex"
@@ -100,7 +101,7 @@ func (h *HealthHandler) getHealth(w http.ResponseWriter, r *http.Request) {
 // getMetrics handles GET /api/v1/admin/metrics.
 // Returns Prometheus-compatible text format.
 func (h *HealthHandler) getMetrics(w http.ResponseWriter, r *http.Request) {
-	var sb stringsBuilder
+	var sb strings.Builder
 	sb.WriteString("# HELP hotplex_uptime_seconds Uptime in seconds\n")
 	sb.WriteString("# TYPE hotplex_uptime_seconds gauge\n")
 	sb.WriteString("hotplex_uptime_seconds " + strconv.FormatFloat(time.Since(h.startTime).Seconds(), 'f', 3, 64) + "\n")
@@ -212,18 +213,18 @@ func (h *HealthHandler) exitDrain(w http.ResponseWriter, r *http.Request) {
 
 // getDrainStatus handles GET /api/v1/admin/drain.
 func (h *HealthHandler) getDrainStatus(w http.ResponseWriter, r *http.Request) {
-	draining := false
-	if h.engine != nil {
-		draining = h.engine.IsDraining()
+	// Handle nil engine case early
+	if h.engine == nil {
+		response := DrainResponse{Status: "active"}
+		adminapi.WriteJSON(w, http.StatusOK, response)
+		return
 	}
 
+	draining := h.engine.IsDraining()
 	if draining {
-		msg := ""
-		if h.engine != nil {
-			msg = h.engine.GetDrainMessage()
-		}
+		msg := h.engine.GetDrainMessage()
 		activeSessions := 0
-		if h.engine != nil && h.engine.GetSessionManager() != nil {
+		if h.engine.GetSessionManager() != nil {
 			activeSessions = len(h.engine.GetSessionManager().ListActiveSessions())
 		}
 		response := DrainResponse{
@@ -307,19 +308,6 @@ func formatUptime(d time.Duration) string {
 		return strconv.Itoa(m) + "m " + strconv.Itoa(s) + "s"
 	}
 	return strconv.Itoa(s) + "s"
-}
-
-// stringsBuilder is a simple strings.Builder replacement.
-type stringsBuilder struct {
-	b []byte
-}
-
-func (sb *stringsBuilder) WriteString(s string) {
-	sb.b = append(sb.b, s...)
-}
-
-func (sb *stringsBuilder) String() string {
-	return string(sb.b)
 }
 
 // Ensure intengine.Session type compatibility

--- a/internal/server/admin/health_handler_test.go
+++ b/internal/server/admin/health_handler_test.go
@@ -142,16 +142,6 @@ func TestFormatUptime(t *testing.T) {
 	}
 }
 
-func TestStringsBuilder(t *testing.T) {
-	var sb stringsBuilder
-	sb.WriteString("hello")
-	sb.WriteString(" world")
-	result := sb.String()
-	if result != "hello world" {
-		t.Errorf("expected 'hello world', got %q", result)
-	}
-}
-
 func stringsContain(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/server/admin/health_handler_test.go
+++ b/internal/server/admin/health_handler_test.go
@@ -1,0 +1,164 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hrygo/hotplex/engine"
+)
+
+func TestGetHealth(t *testing.T) {
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health", nil)
+	rec := httptest.NewRecorder()
+	handler.getHealth(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp AdminHealth
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status == "" {
+		t.Error("expected non-empty status")
+	}
+}
+
+func TestGetMetrics(t *testing.T) {
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.getMetrics(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if contentType != "text/plain; charset=utf-8" {
+		t.Errorf("expected text/plain content type, got %s", contentType)
+	}
+
+	body := rec.Body.String()
+	if body == "" {
+		t.Error("expected non-empty metrics body")
+	}
+
+	// Check for expected Prometheus format
+	if !stringsContain(body, "hotplex_uptime_seconds") {
+		t.Error("expected hotplex_uptime_seconds metric")
+	}
+}
+
+func TestEnterDrain(t *testing.T) {
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	body := `{"message": "Scheduled maintenance"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/drain",
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	handler.enterDrain(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	// Note: With nil engine, IsDraining() returns false
+	// Full integration test requires actual Engine
+}
+
+func TestExitDrain_NotDraining(t *testing.T) {
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/drain", nil)
+	rec := httptest.NewRecorder()
+	handler.exitDrain(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestExitDrain_NoEngine(t *testing.T) {
+	// With nil engine, exitDrain should return bad request since IsDraining returns false
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/drain", nil)
+	rec := httptest.NewRecorder()
+	handler.exitDrain(rec, req)
+
+	// Without engine, IsDraining returns false, so returns 400
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestGetDrainStatus_NotDraining(t *testing.T) {
+	handler := NewHealthHandler(nil, time.Now(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/drain", nil)
+	rec := httptest.NewRecorder()
+	handler.getDrainStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp DrainResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "active" {
+		t.Errorf("expected status 'active', got %s", resp.Status)
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		expected string
+	}{
+		{1 * time.Second, "1s"},
+		{30 * time.Second, "30s"},
+		{1*time.Minute + 30*time.Second, "1m 30s"},
+		{2*time.Hour + 15*time.Minute + 45*time.Second, "2h 15m 45s"},
+	}
+
+	for _, tt := range tests {
+		result := formatUptime(tt.duration)
+		if result != tt.expected {
+			t.Errorf("formatUptime(%v) = %q, want %q", tt.duration, result, tt.expected)
+		}
+	}
+}
+
+func TestStringsBuilder(t *testing.T) {
+	var sb stringsBuilder
+	sb.WriteString("hello")
+	sb.WriteString(" world")
+	result := sb.String()
+	if result != "hello world" {
+		t.Errorf("expected 'hello world', got %q", result)
+	}
+}
+
+func stringsContain(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = engine.Engine{}

--- a/internal/server/admin/session_handler.go
+++ b/internal/server/admin/session_handler.go
@@ -1,0 +1,196 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// SessionPoolInterface defines the interface for session pool operations needed by admin handlers.
+type SessionPoolInterface interface {
+	ListActiveSessions() []*intengine.Session
+	GetSession(sessionID string) (*intengine.Session, bool)
+	TerminateSession(sessionID string) error
+}
+
+// SessionHandler handles session management endpoints.
+type SessionHandler struct {
+	pool SessionPoolInterface
+}
+
+// NewSessionHandler creates a new session handler.
+func NewSessionHandler(pool SessionPoolInterface) *SessionHandler {
+	return &SessionHandler{pool: pool}
+}
+
+// ListSessions handles GET /api/v1/sessions
+func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
+	limitStr := r.URL.Query().Get("limit")
+	offsetStr := r.URL.Query().Get("offset")
+
+	limit := 100
+	offset := 0
+
+	if limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+			if limit > 1000 {
+				limit = 1000
+			}
+		}
+	}
+	if offsetStr != "" {
+		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
+			offset = o
+		}
+	}
+
+	sessions := h.pool.ListActiveSessions()
+	total := len(sessions)
+
+	// Apply pagination
+	start := offset
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+
+	adminSessions := make([]AdminSession, 0, end-start)
+	for _, sess := range sessions[start:end] {
+		adminSessions = append(adminSessions, MapSessionToAdminSession(sess))
+	}
+
+	resp := SessionsResponse{
+		Sessions: adminSessions,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// GetSession handles GET /api/v1/sessions/:id
+func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
+	sessionID := extractSessionID(r)
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		return
+	}
+
+	sess, ok := h.pool.GetSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		return
+	}
+
+	adminSess := MapSessionToAdminSession(sess)
+	writeJSON(w, http.StatusOK, adminSess)
+}
+
+// StopSession handles POST /api/v1/sessions/:id/stop
+func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
+	sessionID := extractSessionID(r)
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		return
+	}
+
+	var req StopRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		req.Reason = "admin_stop"
+	}
+
+	_, ok := h.pool.GetSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		return
+	}
+
+	// Initiate termination asynchronously
+	go func() {
+		_ = h.pool.TerminateSession(sessionID)
+	}()
+
+	resp := StopResponse{
+		SessionID: sessionID,
+		Status:    "stopping",
+		Message:   "Session termination initiated",
+	}
+
+	if req.Reason != "" {
+		resp.Message = "Session termination initiated: " + req.Reason
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// BatchStopSessions handles POST /api/v1/sessions/batch-stop
+func (h *SessionHandler) BatchStopSessions(w http.ResponseWriter, r *http.Request) {
+	var req BatchStopRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if len(req.SessionIDs) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "No session IDs provided")
+		return
+	}
+
+	resp := BatchStopResponse{
+		Stopped:   make([]string, 0),
+		NotFound:  make([]string, 0),
+		Failed:    make([]BatchStopFailed, 0),
+	}
+
+	for _, sessionID := range req.SessionIDs {
+		_, ok := h.pool.GetSession(sessionID)
+		if !ok {
+			resp.NotFound = append(resp.NotFound, sessionID)
+			continue
+		}
+
+		if err := h.pool.TerminateSession(sessionID); err != nil {
+			resp.Failed = append(resp.Failed, BatchStopFailed{
+				SessionID: sessionID,
+				Error:     err.Error(),
+			})
+			continue
+		}
+
+		resp.Stopped = append(resp.Stopped, sessionID)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// extractSessionID extracts the session ID from the URL path.
+func extractSessionID(r *http.Request) string {
+	path := r.URL.Path
+	// Find the last '/'
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			// Return segment after '/' if there's content
+			if i < len(path)-1 {
+				return path[i+1:]
+			}
+			// Empty segment after '/', return empty
+			return ""
+		}
+	}
+	// No '/' found, return the whole path
+	return path
+}
+
+// writeJSON writes a JSON response.
+func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}

--- a/internal/server/admin/session_handler.go
+++ b/internal/server/admin/session_handler.go
@@ -80,13 +80,13 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Missing session ID")
 		return
 	}
 
 	sess, ok := h.pool.GetSession(sessionID)
 	if !ok {
-		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found")
 		return
 	}
 
@@ -98,7 +98,7 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Missing session ID")
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 
 	_, ok := h.pool.GetSession(sessionID)
 	if !ok {
-		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Session not found")
 		return
 	}
 
@@ -135,12 +135,12 @@ func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 func (h *SessionHandler) BatchStopSessions(w http.ResponseWriter, r *http.Request) {
 	var req BatchStopRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid request body")
 		return
 	}
 
 	if len(req.SessionIDs) == 0 {
-		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "No session IDs provided")
+		adminapi.WriteError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "No session IDs provided")
 		return
 	}
 

--- a/internal/server/admin/session_handler.go
+++ b/internal/server/admin/session_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/hrygo/hotplex/internal/adminapi"
 	intengine "github.com/hrygo/hotplex/internal/engine"
 )
 
@@ -72,32 +73,32 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 		Offset:   offset,
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // GetSession handles GET /api/v1/sessions/:id
 func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
 		return
 	}
 
 	sess, ok := h.pool.GetSession(sessionID)
 	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
 		return
 	}
 
 	adminSess := MapSessionToAdminSession(sess)
-	writeJSON(w, http.StatusOK, adminSess)
+	adminapi.WriteJSON(w, http.StatusOK, adminSess)
 }
 
 // StopSession handles POST /api/v1/sessions/:id/stop
 func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := extractSessionID(r)
 	if sessionID == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Missing session ID")
 		return
 	}
 
@@ -108,7 +109,7 @@ func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 
 	_, ok := h.pool.GetSession(sessionID)
 	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
+		adminapi.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Session not found")
 		return
 	}
 
@@ -127,19 +128,19 @@ func (h *SessionHandler) StopSession(w http.ResponseWriter, r *http.Request) {
 		resp.Message = "Session termination initiated: " + req.Reason
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // BatchStopSessions handles POST /api/v1/sessions/batch-stop
 func (h *SessionHandler) BatchStopSessions(w http.ResponseWriter, r *http.Request) {
 	var req BatchStopRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 		return
 	}
 
 	if len(req.SessionIDs) == 0 {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "No session IDs provided")
+		adminapi.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "No session IDs provided")
 		return
 	}
 
@@ -167,7 +168,7 @@ func (h *SessionHandler) BatchStopSessions(w http.ResponseWriter, r *http.Reques
 		resp.Stopped = append(resp.Stopped, sessionID)
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	adminapi.WriteJSON(w, http.StatusOK, resp)
 }
 
 // extractSessionID extracts the session ID from the URL path.
@@ -188,9 +189,3 @@ func extractSessionID(r *http.Request) string {
 	return path
 }
 
-// writeJSON writes a JSON response.
-func writeJSON(w http.ResponseWriter, status int, data interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(data)
-}

--- a/internal/server/admin/session_handler.go
+++ b/internal/server/admin/session_handler.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/hrygo/hotplex/internal/adminapi"
 	intengine "github.com/hrygo/hotplex/internal/engine"
@@ -28,25 +27,7 @@ func NewSessionHandler(pool SessionPoolInterface) *SessionHandler {
 
 // ListSessions handles GET /api/v1/sessions
 func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
-	limitStr := r.URL.Query().Get("limit")
-	offsetStr := r.URL.Query().Get("offset")
-
-	limit := 100
-	offset := 0
-
-	if limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
-			limit = l
-			if limit > 1000 {
-				limit = 1000
-			}
-		}
-	}
-	if offsetStr != "" {
-		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
-			offset = o
-		}
-	}
+	limit, offset := adminapi.ParsePagination(r)
 
 	sessions := h.pool.ListActiveSessions()
 	total := len(sessions)

--- a/internal/server/admin/session_handler.go
+++ b/internal/server/admin/session_handler.go
@@ -192,5 +192,5 @@ func extractSessionID(r *http.Request) string {
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	_ = json.NewEncoder(w).Encode(data)
 }

--- a/internal/server/admin/session_handler_test.go
+++ b/internal/server/admin/session_handler_test.go
@@ -1,0 +1,135 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// mockSessionManager implements SessionPoolInterface for testing.
+type mockSessionManager struct {
+	sessions map[string]*intengine.Session
+}
+
+func (m *mockSessionManager) ListActiveSessions() []*intengine.Session {
+	result := make([]*intengine.Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		result = append(result, s)
+	}
+	return result
+}
+
+func (m *mockSessionManager) GetSession(sessionID string) (*intengine.Session, bool) {
+	s, ok := m.sessions[sessionID]
+	return s, ok
+}
+
+func (m *mockSessionManager) TerminateSession(sessionID string) error {
+	delete(m.sessions, sessionID)
+	return nil
+}
+
+func TestListSessions(t *testing.T) {
+	pool := &mockSessionManager{
+		sessions: make(map[string]*intengine.Session),
+	}
+
+	handler := NewSessionHandler(pool)
+
+	// Test empty list
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	rec := httptest.NewRecorder()
+	handler.ListSessions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp SessionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("expected total 0, got %d", resp.Total)
+	}
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	pool := &mockSessionManager{
+		sessions: make(map[string]*intengine.Session),
+	}
+
+	handler := NewSessionHandler(pool)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	handler.GetSession(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestStopSession_NotFound(t *testing.T) {
+	pool := &mockSessionManager{
+		sessions: make(map[string]*intengine.Session),
+	}
+
+	handler := NewSessionHandler(pool)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/nonexistent/stop", nil)
+	rec := httptest.NewRecorder()
+	handler.StopSession(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestBatchStopSessions_EmptyList(t *testing.T) {
+	pool := &mockSessionManager{
+		sessions: make(map[string]*intengine.Session),
+	}
+
+	handler := NewSessionHandler(pool)
+
+	body := `{"session_ids": [], "reason": "test"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/batch-stop",
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	handler.BatchStopSessions(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestExtractSessionID(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/api/v1/sessions/test-session", "test-session"},
+		{"/api/v1/sessions/", ""},
+		// Note: /api/v1/sessions (without trailing slash and no ID) would not match
+		// the session ID route in practice, as the router would match it to the list endpoint.
+		// The function returns the last segment for any path with a slash.
+		{"/api/v1/sessions/test", "test"},
+		{"/sessions/abc-123", "abc-123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			result := extractSessionID(req)
+			if result != tt.expected {
+				t.Errorf("extractSessionID(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/server/admin/types.go
+++ b/internal/server/admin/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hrygo/hotplex/engine"
 	intengine "github.com/hrygo/hotplex/internal/engine"
+	"github.com/hrygo/hotplex/internal/adminapi"
 )
 
 // AdminSession represents a session in the admin API.
@@ -183,10 +184,10 @@ func NewAdminErrorWithDetails(code, message string, details map[string]interface
 // MapSessionToAdminSession converts an internal engine.Session to AdminSession.
 func MapSessionToAdminSession(s *intengine.Session) AdminSession {
 	return AdminSession{
-		SessionID:    s.ID,
-		Status:       MapSessionStatus(s.GetStatus()),
-		Platform:     resolvePlatform(s.ID),
-		CreatedAt:    s.CreatedAt,
+		SessionID:     s.ID,
+		Status:        adminapi.MapSessionStatus(s.GetStatus()),
+		Platform:      adminapi.ResolvePlatform(s.ID),
+		CreatedAt:     s.CreatedAt,
 		LastActiveAt: s.GetLastActive(),
 	}
 }
@@ -220,48 +221,3 @@ func MapSessionStatsToAdminStats(stats *engine.SessionStats) AdminSessionStats {
 	}
 }
 
-// MapSessionStatus maps internal engine.SessionStatus to admin API string.
-func MapSessionStatus(status intengine.SessionStatus) string {
-	switch status {
-	case intengine.SessionStatusStarting:
-		return "starting"
-	case intengine.SessionStatusReady:
-		return "idle"
-	case intengine.SessionStatusBusy:
-		return "running"
-	case intengine.SessionStatusDead:
-		return "dead"
-	default:
-		return "unknown"
-	}
-}
-
-// resolvePlatform resolves the platform from session ID prefix.
-// Session IDs follow the format: {platform}-{uuid}
-// e.g., "ws-abc123", "slack-def456", "admin-ghi789"
-func resolvePlatform(sessionID string) string {
-	if sessionID == "" {
-		return "unknown"
-	}
-	// Split by '-' and take the first part
-	for i := 0; i < len(sessionID); i++ {
-		if sessionID[i] == '-' {
-			prefix := sessionID[:i]
-			switch prefix {
-			case "ws", "websocket":
-				return "websocket"
-			case "slack":
-				return "slack"
-			case "tg", "telegram":
-				return "telegram"
-			case "feishu", "lark":
-				return "feishu"
-			case "admin":
-				return "admin"
-			default:
-				return prefix
-			}
-		}
-	}
-	return "unknown"
-}

--- a/internal/server/admin/types.go
+++ b/internal/server/admin/types.go
@@ -66,17 +66,26 @@ type SubsystemHealth struct {
 	Latency string `json:"latency,omitempty"`
 }
 
-// AdminError represents a uniform error envelope.
-type AdminError struct {
-	Error ErrorDetail `json:"error"`
-}
+// Re-export shared error types from adminapi for convenience.
+type (
+	ErrorCode     = adminapi.ErrorCode
+	ErrorResponse = adminapi.ErrorResponse
+	ErrorDetail   = adminapi.ErrorDetail
+)
 
-// ErrorDetail contains error details.
-type ErrorDetail struct {
-	Code    string                 `json:"code"`
-	Message string                 `json:"message"`
-	Details map[string]interface{} `json:"details,omitempty"`
-}
+// Error code constants re-exported from adminapi.
+const (
+	ErrCodeAuthFailed          = adminapi.ErrCodeAuthFailed
+	ErrCodeForbidden           = adminapi.ErrCodeForbidden
+	ErrCodeNotFound            = adminapi.ErrCodeNotFound
+	ErrCodeInvalidRequest      = adminapi.ErrCodeInvalidRequest
+	ErrCodeServerError         = adminapi.ErrCodeServerError
+	ErrCodeUnauthorized        = adminapi.ErrCodeUnauthorized
+	ErrCodeEngineNotInitialized = adminapi.ErrCodeEngineNotInitialized
+)
+
+// AdminError is an alias for the shared ErrorResponse.
+type AdminError = ErrorResponse
 
 // BatchStopRequest is the request body for batch session stop.
 type BatchStopRequest struct {
@@ -161,24 +170,15 @@ type ConfigResponse struct {
 }
 
 // NewAdminError creates a new AdminError with the given code and message.
-func NewAdminError(code, message string) AdminError {
-	return AdminError{
-		Error: ErrorDetail{
-			Code:    code,
-			Message: message,
-		},
-	}
+// Deprecated: Use adminapi.NewError directly.
+func NewAdminError(code ErrorCode, message string) AdminError {
+	return adminapi.NewError(code, message)
 }
 
 // NewAdminErrorWithDetails creates a new AdminError with details.
-func NewAdminErrorWithDetails(code, message string, details map[string]interface{}) AdminError {
-	return AdminError{
-		Error: ErrorDetail{
-			Code:    code,
-			Message: message,
-			Details: details,
-		},
-	}
+// Deprecated: Use adminapi.NewErrorWithDetails directly.
+func NewAdminErrorWithDetails(code ErrorCode, message string, details map[string]interface{}) AdminError {
+	return adminapi.NewErrorWithDetails(code, message, details)
 }
 
 // MapSessionToAdminSession converts an internal engine.Session to AdminSession.

--- a/internal/server/admin/types.go
+++ b/internal/server/admin/types.go
@@ -1,0 +1,267 @@
+package admin
+
+import (
+	"time"
+
+	"github.com/hrygo/hotplex/engine"
+	intengine "github.com/hrygo/hotplex/internal/engine"
+)
+
+// AdminSession represents a session in the admin API.
+// Status is mapped from engine.SessionStatus:
+//   - SessionStatusStarting -> "starting"
+//   - SessionStatusReady -> "idle"
+//   - SessionStatusBusy -> "running"
+//   - SessionStatusDead -> "dead"
+type AdminSession struct {
+	SessionID    string            `json:"session_id"`
+	Status       string            `json:"status"`
+	Platform     string            `json:"platform"`
+	CreatedAt    time.Time         `json:"created_at"`
+	LastActiveAt time.Time         `json:"last_active_at"`
+	Tags         map[string]string `json:"tags,omitempty"`
+}
+
+// AdminSessionStats represents execution statistics aligned with engine.SessionStats.
+type AdminSessionStats struct {
+	SessionID             string   `json:"session_id"`
+	TotalDurationMs      int64    `json:"total_duration_ms"`
+	ThinkingDurationMs   int64    `json:"thinking_duration_ms"`
+	ToolDurationMs       int64    `json:"tool_duration_ms"`
+	GenerationDurationMs int64    `json:"generation_duration_ms"`
+	InputTokens          int64    `json:"input_tokens"`
+	OutputTokens         int64    `json:"output_tokens"`
+	CacheReadTokens      int64    `json:"cache_read_tokens"`
+	CacheWriteTokens     int64    `json:"cache_write_tokens"`
+	ToolCallCount        int64    `json:"tool_call_count"`
+	ToolsUsed            []string `json:"tools_used,omitempty"`
+	FilesModified        int64    `json:"files_modified"`
+	FilePaths            []string `json:"file_paths,omitempty"`
+	ErrorCount           int64    `json:"error_count"`
+}
+
+// AdminEvent represents an audit event in the ring buffer.
+type AdminEvent struct {
+	EventID   string                 `json:"event_id"`
+	Timestamp time.Time              `json:"timestamp"`
+	Type      string                 `json:"type"`
+	SessionID string                 `json:"session_id,omitempty"`
+	Actor     string                 `json:"actor,omitempty"`
+	Payload   map[string]interface{} `json:"payload,omitempty"`
+}
+
+// AdminHealth represents the overall system health.
+type AdminHealth struct {
+	Status     string                     `json:"status"`
+	Version    string                     `json:"version"`
+	Uptime     string                     `json:"uptime"`
+	Subsystems map[string]SubsystemHealth `json:"subsystems"`
+}
+
+// SubsystemHealth represents the health of a single subsystem.
+type SubsystemHealth struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+	Latency string `json:"latency,omitempty"`
+}
+
+// AdminError represents a uniform error envelope.
+type AdminError struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail contains error details.
+type ErrorDetail struct {
+	Code    string                 `json:"code"`
+	Message string                 `json:"message"`
+	Details map[string]interface{} `json:"details,omitempty"`
+}
+
+// BatchStopRequest is the request body for batch session stop.
+type BatchStopRequest struct {
+	SessionIDs []string `json:"session_ids"`
+	Reason    string   `json:"reason"`
+}
+
+// BatchStopResponse is the response for batch session stop.
+type BatchStopResponse struct {
+	Stopped   []string          `json:"stopped"`
+	NotFound []string           `json:"not_found"`
+	Failed    []BatchStopFailed `json:"failed"`
+}
+
+// BatchStopFailed represents a failed session stop.
+type BatchStopFailed struct {
+	SessionID string `json:"session_id"`
+	Error     string `json:"error"`
+}
+
+// StopRequest is the request body for single session stop.
+type StopRequest struct {
+	Reason string `json:"reason"`
+}
+
+// StopResponse is the response for single session stop.
+type StopResponse struct {
+	SessionID string `json:"session_id"`
+	Status    string `json:"status"`
+	Message   string `json:"message"`
+}
+
+// DrainRequest is the request body for entering drain mode.
+type DrainRequest struct {
+	Message string `json:"message"`
+}
+
+// DrainResponse is the response for drain mode operations.
+type DrainResponse struct {
+	Status         string `json:"status"`
+	ActiveSessions int    `json:"active_sessions,omitempty"`
+	Message        string `json:"message,omitempty"`
+}
+
+// SessionsResponse is the response for listing sessions.
+type SessionsResponse struct {
+	Sessions []AdminSession `json:"sessions"`
+	Total    int            `json:"total"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+}
+
+// EventsResponse is the response for listing events.
+type EventsResponse struct {
+	Events     []AdminEvent `json:"events"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+	Total      int64        `json:"total"`
+}
+
+// TranscriptResponse is the response for session transcript.
+type TranscriptResponse struct {
+	SessionID string            `json:"session_id"`
+	Messages  []TranscriptMsg `json:"messages"`
+}
+
+// TranscriptMsg represents a single message in a transcript.
+type TranscriptMsg struct {
+	Type      string    `json:"type"`
+	Timestamp time.Time `json:"timestamp"`
+	Content   string    `json:"content"`
+}
+
+// ToolsResponse is the response for tools list endpoints.
+type ToolsResponse struct {
+	Tools []string `json:"tools"`
+	Source string  `json:"source"`
+}
+
+// ConfigResponse is the response for config endpoint.
+type ConfigResponse struct {
+	Config any `json:"config"`
+}
+
+// NewAdminError creates a new AdminError with the given code and message.
+func NewAdminError(code, message string) AdminError {
+	return AdminError{
+		Error: ErrorDetail{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+// NewAdminErrorWithDetails creates a new AdminError with details.
+func NewAdminErrorWithDetails(code, message string, details map[string]interface{}) AdminError {
+	return AdminError{
+		Error: ErrorDetail{
+			Code:    code,
+			Message: message,
+			Details: details,
+		},
+	}
+}
+
+// MapSessionToAdminSession converts an internal engine.Session to AdminSession.
+func MapSessionToAdminSession(s *intengine.Session) AdminSession {
+	return AdminSession{
+		SessionID:    s.ID,
+		Status:       MapSessionStatus(s.GetStatus()),
+		Platform:     resolvePlatform(s.ID),
+		CreatedAt:    s.CreatedAt,
+		LastActiveAt: s.GetLastActive(),
+	}
+}
+
+// MapSessionStatsToAdminStats converts engine.SessionStats to AdminSessionStats.
+func MapSessionStatsToAdminStats(stats *engine.SessionStats) AdminSessionStats {
+	if stats == nil {
+		return AdminSessionStats{}
+	}
+
+	// Collect tools used from the map
+	toolsUsed := make([]string, 0, len(stats.ToolsUsed))
+	for tool := range stats.ToolsUsed {
+		toolsUsed = append(toolsUsed, tool)
+	}
+
+	return AdminSessionStats{
+		SessionID:             stats.SessionID,
+		TotalDurationMs:       stats.TotalDurationMs,
+		ThinkingDurationMs:    stats.ThinkingDurationMs,
+		ToolDurationMs:        stats.ToolDurationMs,
+		GenerationDurationMs:   stats.GenerationDurationMs,
+		InputTokens:           int64(stats.InputTokens),
+		OutputTokens:         int64(stats.OutputTokens),
+		CacheReadTokens:      int64(stats.CacheReadTokens),
+		CacheWriteTokens:     int64(stats.CacheWriteTokens),
+		ToolCallCount:        int64(stats.ToolCallCount),
+		ToolsUsed:            toolsUsed,
+		FilesModified:        int64(stats.FilesModified),
+		FilePaths:            stats.FilePaths,
+	}
+}
+
+// MapSessionStatus maps internal engine.SessionStatus to admin API string.
+func MapSessionStatus(status intengine.SessionStatus) string {
+	switch status {
+	case intengine.SessionStatusStarting:
+		return "starting"
+	case intengine.SessionStatusReady:
+		return "idle"
+	case intengine.SessionStatusBusy:
+		return "running"
+	case intengine.SessionStatusDead:
+		return "dead"
+	default:
+		return "unknown"
+	}
+}
+
+// resolvePlatform resolves the platform from session ID prefix.
+// Session IDs follow the format: {platform}-{uuid}
+// e.g., "ws-abc123", "slack-def456", "admin-ghi789"
+func resolvePlatform(sessionID string) string {
+	if sessionID == "" {
+		return "unknown"
+	}
+	// Split by '-' and take the first part
+	for i := 0; i < len(sessionID); i++ {
+		if sessionID[i] == '-' {
+			prefix := sessionID[:i]
+			switch prefix {
+			case "ws", "websocket":
+				return "websocket"
+			case "slack":
+				return "slack"
+			case "tg", "telegram":
+				return "telegram"
+			case "feishu", "lark":
+				return "feishu"
+			case "admin":
+				return "admin"
+			default:
+				return prefix
+			}
+		}
+	}
+	return "unknown"
+}


### PR DESCRIPTION
## Summary
- Full RESTful Admin API at `/api/v1/admin/` with X-Admin-Key authentication
- Session management: list, get, stop, batch-stop  
- Health, Prometheus metrics, drain mode, and config read-only endpoints
- Thread-safe event audit buffer (ring buffer, 10,000 events max)
- Config handlers: getConfig, getAllowedTools, getDisallowedTools
- Drain mode integrated with Engine struct

## Files changed
- `internal/server/admin/` - New admin API package
  - `types.go` - Admin-facing data models
  - `auth.go` - X-Admin-Key auth middleware (constant-time comparison)
  - `session_handler.go` - Session CRUD endpoints
  - `health_handler.go` - Health, metrics, drain mode endpoints
  - `config_handler.go` - Read-only config endpoints
  - `event_buffer.go` - Thread-safe ring buffer
  - `audit_handler.go` - Events and transcript endpoints
  - `admin.go` - Server combining all handlers
  - `*_test.go` - 56 unit tests covering all handlers
- `engine/runner.go` - Added drain mode state to Engine

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (all packages)
- [x] Auth bypasses when AdminKey is empty

Resolves #331