### PR TITLE
feat(install): 一键安装脚本实现

### DIFF
--- a/install/INSTALL.md
+++ b/install/INSTALL.md
@@ -1,0 +1,504 @@
+# HotPlex Agent 安装指南
+
+本文档面向 AI Agent 工具，用于自动执行 HotPlex 系统安装。文档包含完整的安装流程、参数说明和错误处理。
+
+## 目录
+
+- [前置条件](#前置条件)
+- [快速安装](#快速安装)
+- [安装模式](#安装模式)
+- [参数详解](#参数详解)
+- [配置说明](#配置说明)
+- [安装后验证](#安装后验证)
+- [卸载方法](#卸载方法)
+- [故障排除](#故障排除)
+
+---
+
+## 前置条件
+
+### 系统要求
+
+| 平台 | 架构 | 支持状态 |
+|------|------|---------|
+| Linux | amd64, arm64 | ✅ 支持 |
+| macOS | amd64 (Intel), arm64 (Apple Silicon) | ✅ 支持 |
+| Windows | WSL2 | ✅ 支持 |
+
+### 必需依赖
+
+**二进制模式**:
+- `curl` 或 `wget`
+- `tar`
+- `jq` (用于 JSON 解析)
+- `sha256sum` / `shasum` (用于校验)
+
+**Docker 模式**:
+- `docker` (版本 ≥ 20.10)
+- `docker compose` 或 `docker-compose`
+
+### 权限要求
+
+- 安装到系统目录 (`/usr/local/bin`): 需要 `sudo` 权限
+- 安装到用户目录 (`~/.local/bin`): 普通用户权限
+- 配置 systemd 服务: 需要 `sudo` 权限
+
+---
+
+## 快速安装
+
+### 标准安装 (Linux/macOS)
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash
+```
+
+### 指定版本
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- -v v0.35.0
+```
+
+### Docker 模式安装
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- docker
+```
+
+### 非交互式安装 (Agent 专用)
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- \
+  --non-interactive \
+  --slack-bot-token "xoxb-xxx" \
+  --slack-app-token "xapp-xxx" \
+  --slack-bot-user-id "U123456" \
+  --github-token "ghp_xxx"
+```
+
+---
+
+## 安装模式
+
+### 1. Binary 模式 (默认)
+
+直接下载并安装 hotplexd 二进制文件到本地系统。
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- --mode binary
+```
+
+### 2. Docker 模式
+
+使用 Docker 容器运行 HotPlex。
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- --mode docker
+```
+
+或使用子命令:
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- docker
+```
+
+Docker 模式会生成:
+- `docker-compose.yml` - 容器编排配置
+- `.env` - 环境变量配置
+- `data/` - 数据目录
+- `projects/` - 项目目录
+- `logs/` - 日志目录
+
+管理命令:
+
+```bash
+cd ~/.hotplex
+docker compose up -d      # 启动
+docker compose logs -f    # 查看日志
+docker compose down       # 停止
+docker compose restart    # 重启
+```
+
+### 3. 配置仅生成模式
+
+仅生成配置文件，不执行实际安装。
+
+```bash
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- --config-only
+```
+
+---
+
+## 参数详解
+
+### 安装选项
+
+| 参数 | 说明 | 默认值 | 必填 |
+|------|------|--------|------|
+| `-v, --version <ver>` | 指定安装版本 | latest | 否 |
+| `-d, --dir <path>` | 安装目录 | `/usr/local/bin` | 否 |
+| `--mode <mode>` | 安装模式: binary/docker | `binary` | 否 |
+| `-c, --config-only` | 仅生成配置 | false | 否 |
+| `-f, --force` | 强制覆盖安装 | false | 否 |
+| `-n, --dry-run` | 预览模式 (不执行) | false | 否 |
+| `-q, --quiet` | 静默模式 | false | 否 |
+| `-V, --verbose` | 详细输出 | false | 否 |
+| `-h, --help` | 显示帮助 | - | 否 |
+
+### 跳过选项
+
+| 参数 | 说明 |
+|------|------|
+| `--skip-health-check` | 跳过安装后健康检查 |
+| `--skip-autostart` | 跳过 systemd/launchd 配置 |
+| `--skip-verify` | 跳过 SHA256 校验 |
+| `--skip-wizard` | 跳过安装向导 |
+
+### Slack 配置参数 (非交互式安装必填)
+
+| 参数 | 环境变量 | 说明 | 示例 |
+|------|----------|------|------|
+| `--slack-bot-token` | `HOTPLEX_SLACK_BOT_TOKEN` | Slack Bot Token | `xoxb-xxx` |
+| `--slack-app-token` | `HOTPLEX_SLACK_APP_TOKEN` | Slack App Token | `xapp-xxx` |
+| `--slack-bot-user-id` | `HOTPLEX_SLACK_BOT_USER_ID` | Bot User ID | `U123456` |
+| `--slack-primary-owner` | `HOTPLEX_SLACK_PRIMARY_OWNER` | 主管理员 User ID | `U123456` |
+
+### 其他配置参数
+
+| 参数 | 环境变量 | 说明 | 默认值 |
+|------|----------|------|--------|
+| `--github-token` | `GITHUB_TOKEN` | GitHub Token | - |
+| `--port` | `HOTPLEX_PORT` | 服务端口 | `8080` |
+| `--admin-port` | `HOTPLEX_ADMIN_PORT` | 管理端口 | `9080` |
+| `--data-dir` | `HOTPLEX_DATA_DIR` | 数据目录 | `~/.hotplex` |
+
+---
+
+## 配置说明
+
+### 配置文件位置
+
+HotPlex 按以下顺序查找配置文件:
+
+1. `--env-file` 参数指定路径
+2. `HOTPLEX_ENV_FILE` 环境变量
+3. 当前目录 `.env`
+4. `~/.config/hotplex/.env` (XDG 标准路径)
+5. `~/.hotplex/.env`
+
+### 必需配置项
+
+安装后需在配置文件中设置以下项:
+
+```bash
+# API 安全密钥 (必填，生产环境)
+HOTPLEX_API_KEY=your-secure-api-key-min-32-chars
+
+# Slack Bot 配置 (必填)
+HOTPLEX_SLACK_PRIMARY_OWNER=UXXXXXXXXXX    # 主管理员的 Slack User ID
+HOTPLEX_SLACK_BOT_USER_ID=UXXXXXXXXXX       # Bot 的 User ID
+HOTPLEX_SLACK_BOT_TOKEN=xoxb-your-bot-token # Bot Token
+HOTPLEX_SLACK_APP_TOKEN=xapp-your-app-token # App Level Token
+
+# GitHub Token (用于 Git 操作，可选)
+GITHUB_TOKEN=ghp_your-token
+
+# 服务端口 (可选)
+HOTPLEX_PORT=8080
+HOTPLEX_ADMIN_PORT=9080
+```
+
+### 获取 Slack 配置的方法
+
+1. **Bot Token**: Slack App 设置 → OAuth & Permissions → Bot User OAuth Token
+2. **App Token**: Slack App 设置 → Basic Information → App-Level Tokens
+3. **Bot User ID**: 在 Slack 中 @ 机器人 → 查看用户档案 → ID
+4. **Primary Owner**: 主管理员的 Slack User ID (格式: U开头的字符串)
+
+---
+
+## 安装后验证
+
+### 1. 检查安装
+
+```bash
+# 检查二进制是否存在
+which hotplexd
+hotplexd version
+
+# 检查服务状态
+hotplexd status
+```
+
+### 2. 健康检查
+
+```bash
+# HTTP 健康检查
+curl http://localhost:8080/health
+
+# 完整诊断
+hotplexd doctor
+```
+
+### 3. 启动服务
+
+```bash
+# 使用默认配置启动
+hotplexd start
+
+# 使用指定配置启动
+hotplexd start --env-file ~/.config/hotplex/.env
+```
+
+### 4. 验证日志
+
+```bash
+# 查看安装日志
+cat ~/.hotplex/install.log
+
+# 查看服务日志 (journald)
+journalctl -u hotplexd -f
+```
+
+---
+
+## 多 Bot 支持
+
+HotPlex 支持在一台服务器上运行多个独立的 Bot 实例，适合复杂组织结构。
+
+### 交互式配置多 Bot
+
+```bash
+# 在安装菜单中选择 "8) 多 Bot 配置"
+./hotplex-install.sh
+```
+
+### Docker 模式多 Bot
+
+```bash
+# 安装时启用多 Bot
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- --mode docker
+
+# 在安装菜单中选择 "8) 多 Bot 配置" 添加更多 Bot
+```
+
+### 多 Bot 配置文件
+
+每个 Bot 有独立的配置文件:
+
+```
+~/.hotplex/
+├── .env                 # 主配置 (可选)
+├── bot-01.env          # Bot 1 配置
+├── bot-02.env          # Bot 2 配置
+├── bot-03.env          # Bot 3 配置
+└── docker-compose.yml  # Docker 编排 (多 Bot 时)
+```
+
+### Bot 配置结构
+
+```bash
+# bot-01.env 示例
+BOT_NAME=bot-01
+HOTPLEX_PORT=8080
+HOTPLEX_SLACK_BOT_TOKEN=xoxb-bot1-token
+HOTPLEX_SLACK_BOT_USER_ID=U001
+HOTPLEX_MESSAGE_STORE_SQLITE_PATH=/app/data/chatapp_messages_01.db
+```
+
+---
+
+## 日志管理
+
+### 日志位置
+
+| 类型 | 路径 |
+|------|------|
+| 安装日志 | `~/.hotplex/install.log` |
+| 服务日志 | `~/.hotplex/hotplexd.log` |
+| Docker 日志 | `~/.hotplex/logs/` |
+
+### 配置日志轮转
+
+```bash
+# 交互式配置
+./hotplex-install.sh
+# 选择 "9) 日志管理" → "1) 配置日志轮转"
+```
+
+默认规则:
+- 每天轮转
+- 保留 5 份
+- 大小超过 10MB 触发轮转
+- 自动压缩旧日志
+
+### 手动清理日志
+
+```bash
+# 在安装菜单中选择 "9) 日志管理" → "2) 手动清理日志"
+./hotplex-install.sh
+```
+
+或手动清理:
+
+```bash
+# 清空主日志
+: > ~/.hotplex/hotplexd.log
+
+# 删除所有日志文件
+find ~/.hotplex/logs -name "*.log" -delete
+```
+
+---
+
+## 卸载方法
+
+### 自动卸载
+
+```bash
+# 使用安装脚本卸载
+curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install/hotplex-install.sh | bash -s -- --uninstall
+```
+
+### 手动卸载
+
+```bash
+# 停止服务
+hotplexd stop
+
+# 删除二进制
+sudo rm /usr/local/bin/hotplexd
+
+# 删除配置 (可选)
+rm -rf ~/.config/hotplex
+rm -rf ~/.hotplex
+
+# 删除 systemd 服务 (Linux)
+sudo rm /etc/systemd/system/hotplexd.service
+sudo systemctl daemon-reload
+
+# 删除 launchd 服务 (macOS)
+launchctl unload ~/Library/LaunchAgents/com.hotplexd.plist
+rm ~/Library/LaunchAgents/com.hotplexd.plist
+```
+
+---
+
+## 故障排除
+
+### 常见错误
+
+#### 1. "curl: command not found"
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install curl
+
+# macOS
+brew install curl
+```
+
+#### 2. "sha256sum: command not found"
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install coreutils
+
+# macOS (shasum 支持 -a 256)
+shasum -a 256 hotplexd
+```
+
+#### 3. "jq: command not found"
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install jq
+
+# macOS
+brew install jq
+```
+
+#### 4. "Permission denied" 安装到 /usr/local/bin
+
+```bash
+# 使用 sudo
+curl ... | sudo bash
+
+# 或安装到用户目录
+curl ... | bash -s -- -d ~/.local/bin
+```
+
+#### 5. "Slack Token validation failed"
+
+- 检查 Token 格式是否正确 (xoxb- 开头)
+- 确认 Token 未过期或被撤销
+- 验证 Slack App 已启用必要的 OAuth Scopes
+- 使用 Slack API 测试: `curl -H "Authorization: Bearer <token>" https://slack.com/api/auth.test`
+
+#### 6. "Port already in use"
+
+```bash
+# 查看端口占用
+lsof -i :8080
+
+# 使用其他端口
+curl ... | bash -s -- --port 8081
+```
+
+### 调试模式
+
+```bash
+# 启用详细输出
+curl ... | bash -s -- -V
+
+# 干运行模式 (仅预览，不执行)
+curl ... | bash -s -- -n
+```
+
+### 获取诊断信息
+
+```bash
+# 运行诊断命令
+hotplexd doctor
+
+# 收集日志
+tar -czf hotplex-debug.tar.gz ~/.hotplex/*.log
+```
+
+---
+
+## Agent 执行检查清单
+
+使用本文档执行安装时，Agent 应按以下顺序检查:
+
+### 安装前
+
+- [ ] 检测操作系统和架构
+- [ ] 检查必需命令 (curl, tar, jq, sha256sum)
+- [ ] 检查权限 (sudo/普通用户)
+- [ ] 验证网络连接 (curl -I https://github.com)
+
+### 安装中
+
+- [ ] 下载安装脚本
+- [ ] 校验脚本 SHA256 (可选)
+- [ ] 执行安装脚本
+- [ ] 收集用户提供的配置值
+- [ ] 生成配置文件
+
+### 安装后
+
+- [ ] 验证二进制安装: `which hotplexd && hotplexd version`
+- [ ] 验证配置生成: `ls -la ~/.config/hotplex/`
+- [ ] 检查端口可用: `lsof -i :8080`
+- [ ] 执行健康检查: `curl http://localhost:8080/health`
+- [ ] 配置开机自启 (systemd/launchd)
+
+---
+
+## 参考链接
+
+- [设计文档](https://github.com/hrygo/hotplex/blob/main/docs/superpowers/specs/2026-03-24-one-click-install-design.md)
+- [Releases 页面](https://github.com/hrygo/hotplex/releases)
+- [Slack API 文档](https://api.slack.com/)
+- [Docker 安装指南](https://docs.docker.com/get-docker/)

--- a/install/hotplex-install.ps1
+++ b/install/hotplex-install.ps1
@@ -1,0 +1,623 @@
+#Requires -RunAsAdministrator
+# ==============================================================================
+# HotPlex 一键安装脚本 (Windows PowerShell)
+# Phase 2-4: 完整实现
+# 支持: Windows 10/11, Windows Server 2019+
+# ==============================================================================
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Install", "Upgrade", "Status", "Uninstall", "Purge", "")]
+    [string]$Action = "",
+    [string]$Version = "",
+    [string]$InstallDir = "$env:ProgramFiles\HotPlex",
+    [string]$ConfigDir = "$env:USERPROFILE\.hotplex",
+    [switch]$SkipHealthCheck,
+    [switch]$SkipAutostart,
+    [switch]$SkipVerify,
+    [switch]$Force,
+    [switch]$NonInteractive
+)
+
+# ==============================================================================
+# 全局变量
+# ==============================================================================
+
+$Script:Repo = "hrygo/hotplex"
+$Script:BinaryName = "hotplexd.exe"
+$Script:ServiceName = "HotPlex"
+$Script:ScriptVersion = "3.0.0"
+$Script:ApiBase = "https://api.github.com/repos"
+$Script:DownloadBase = "https://github.com/hrygo/hotplex/releases/download"
+
+$Script:Colors = @{
+    Red=""; Green=""; Yellow=""; Cyan=""; Magenta=""; Bold=""; Dim=""; NC=""
+    if ($Host.UI.SupportsVirtualTerminal) {
+        $Script:Colors.Red="`e[0;31m"; $Script:Colors.Green="`e[0;32m"
+        $Script:Colors.Yellow="`e[1;33m"; $Script:Colors.Cyan="`e[0;36m"
+        $Script:Colors.Magenta="`e[0;35m"; $Script:Colors.Bold="`e[1m"
+        $Script:Colors.Dim="`e[2m"; $Script:Colors.NC="`e[0m"
+    }
+}
+
+# ==============================================================================
+# 工具函数
+# ==============================================================================
+
+function Write-Banner { param([string]$Title) $l="  $($Script:Colors.Bold)===============================================================$($Script:Colors.NC)"; Write-Host ""; Write-Host $l; Write-Host "  $($Script:Colors.Cyan)$($Script:Colors.Bold)$Title$($Script:Colors.NC)"; Write-Host $l; Write-Host "" }
+function Write-Info { param([string]$M) { Write-Host "$($Script:Colors.Cyan)▸$($Script:Colors.NC) $M" } }
+function Write-Success { param([string]$M) { Write-Host "$($Script:Colors.Green)✓$($Script:Colors.NC) $M" } }
+function Write-Warn { param([string]$M) { Write-Host "$($Script:Colors.Yellow)!$($Script:Colors.NC) $M" } }
+function Write-Err { param([string]$M) { Write-Host "$($Script:Colors.Red)✗$($Script:Colors.NC) $M" } }
+function Write-Debug { param([string]$M) { if ($VerbosePreference -eq "Continue") { Write-Host "$($Script:Colors.Dim)[DEBUG]$($Script:Colors.NC) $M" } } }
+
+function Mask-Token {
+    param([string]$Token, [int]$Visible = 4)
+    if ([string]::IsNullOrEmpty($Token) -or $Token.Length -le ($Visible * 2)) { return "****" }
+    return "$($Token.Substring(0, $Visible))...$($Token.Substring($Token.Length - $Visible))"
+}
+
+function Confirm-Action {
+    param([string]$Prompt, [string]$Default = "n")
+    if ($NonInteractive) { return ($Default -eq "y") }
+    $choices = if ($Default -eq "y") { "[Y/n]" } else { "[y/N]" }
+    Write-Host "$($Script:Colors.Bold)?$($Script:Colors.NC) $Prompt $choices: " -NoNewline
+    $resp = Read-Host
+    if ([string]::IsNullOrEmpty($resp)) { $resp = $Default }
+    return ($resp -eq "y" -or $resp -eq "Y")
+}
+
+function Read-InputPrompt {
+    param([string]$Prompt, [string]$Default = "", [bool]$Secret = $false)
+    if ($NonInteractive) { return $Default }
+    Write-Host "$($Script:Colors.Bold)?$($Script:Colors.NC) $Prompt" -NoNewline
+    if (![string]::IsNullOrEmpty($Default)) { Write-Host " [$Default]" -NoNewline }
+    Write-Host ": " -NoNewline
+    if ($Secret) {
+        $resp = Read-Host -AsSecureString
+        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($resp)
+        $resp = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        Write-Host ""
+    } else { $resp = Read-Host }
+    return if ([string]::IsNullOrEmpty($resp)) { $Default } else { $resp }
+}
+
+function Invoke-HttpGet {
+    param([string]$Url)
+    try {
+        return (Invoke-WebRequest -Uri $Url -UserAgent "HotPlex-Installer/$($Script:ScriptVersion)" -TimeoutSec 30 -ErrorAction Stop).Content
+    } catch { return $null }
+}
+
+function Test-HttpGet {
+    param([string]$Url, [string]$OutputFile = "")
+    try {
+        if (![string]::IsNullOrEmpty($OutputFile)) {
+            Invoke-WebRequest -Uri $Url -OutFile $OutputFile -UserAgent "HotPlex-Installer/$($Script:ScriptVersion)" -TimeoutSec 120 -ErrorAction Stop | Out-Null
+            return $true
+        } else {
+            Invoke-WebRequest -Uri $Url -UserAgent "HotPlex-Installer/$($Script:ScriptVersion)" -TimeoutSec 30 -ErrorAction Stop | Out-Null
+            return $true
+        }
+    } catch { return $false }
+}
+
+function Download-WithRetry {
+    param([string]$Url, [string]$OutputPath, [int]$MaxRetries = 3)
+    $retry = 0
+    while ($retry -lt $MaxRetries) {
+        if (Test-HttpGet -Url $Url -OutputFile $OutputPath) {
+            if (Test-Path $OutputPath -PathType Leaf -and (Get-Item $OutputPath).Length -gt 0) { return $true }
+        }
+        $retry++
+        if ($retry -lt $MaxRetries) {
+            Write-Warn "下载失败，${retry}秒后重试..."
+            Start-Sleep -Seconds $retry
+        }
+    }
+    return $false
+}
+
+function Get-Platform {
+    $os = $PSVersionTable.Platform
+    switch ($os) {
+        "Win32NT" { $os = "windows" }
+        $null { $os = "windows" }
+        "Unix" {
+            if ($IsMacOS) { $os = "darwin" }
+            elseif ($IsLinux) { $os = "linux" }
+        }
+    }
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { $arch = "amd64" }
+        "ARM64" { $arch = "arm64" }
+    }
+    return @{ OS = $os; Arch = $arch }
+}
+
+# ==============================================================================
+# Phase 2: 端口冲突检测
+# ==============================================================================
+
+function Get-PortStatus {
+    param([int]$Port)
+    $conn = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
+    if ($conn) {
+        $proc = Get-Process -Id $conn[0].OwningProcess -ErrorAction SilentlyContinue
+        return @{ InUse = $true; PID = $conn[0].OwningProcess; ProcessName = if ($proc) { $proc.ProcessName } else { "unknown" } }
+    }
+    return @{ InUse = $false }
+}
+
+function Resolve-PortConflict {
+    param([int]$Port)
+    $status = Get-PortStatus -Port $Port
+    if (-not $status.InUse) { return $Port }
+    Write-Warn "端口 ${Port} 已被占用 (PID: $($status.PID) - $($status.ProcessName))"
+    Write-Host ""
+    Write-Host "  请选择解决方案:"
+    Write-Host "    1) 终止现有进程 (PID: $($status.PID))"
+    Write-Host "    2) 使用备用端口 ($($Port + 1))"
+    Write-Host "    3) 取消安装"
+    Write-Host ""
+    $choice = Read-InputPrompt "选择解决方案" "1"
+    switch ($choice) {
+        "1" {
+            Write-Info "正在终止进程..."
+            try {
+                Stop-Process -Id $status.PID -Force -ErrorAction Stop
+                Start-Sleep -Seconds 1
+                if (-not (Get-PortStatus -Port $Port).InUse) { Write-Success "进程已终止"; return $Port }
+            } catch {
+                Write-Warn "需要管理员权限，尝试提升..."
+                Start-Process powershell -Verb RunAs -ArgumentList "-Command", "Stop-Process -Id $($status.PID) -Force" -Wait
+            }
+            if (-not (Get-PortStatus -Port $Port).InUse) { Write-Success "进程已终止"; return $Port }
+            Write-Err "无法终止进程"; return -1
+        }
+        "2" {
+            $newPort = $Port + 1
+            while ((Get-PortStatus -Port $newPort).InUse) { $newPort++ }
+            Write-Info "将使用备用端口: $newPort"; return $newPort
+        }
+        default { Write-Err "安装已取消"; return -1 }
+    }
+}
+
+# ==============================================================================
+# Phase 1: SHA256 校验
+# ==============================================================================
+
+function Get-Checksums { param([string]$Version, [string]$OutFile) return Test-HttpGet -Url "$Script:DownloadBase/v${Version}/SHA256SUMS" -OutputFile $OutFile }
+
+function Test-Checksum {
+    param([string]$FilePath, [string]$ChecksumsFile)
+    if (-not (Test-Path $ChecksumsFile)) { Write-Warn "校验和文件不存在，跳过验证"; return $true }
+    $fileName = Split-Path $FilePath -Leaf
+    $expected = $null
+    Get-Content $ChecksumsFile | ForEach-Object { if ($_ -match $fileName) { $expected = ($_ -split '\s+')[0] } }
+    if ([string]::IsNullOrEmpty($expected)) { Write-Warn "未找到 $fileName 的校验和，跳过验证"; return $true }
+    $actual = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLower()
+    $expected = $expected.ToLower()
+    if ($expected -eq $actual) { return $true }
+    Write-Err "SHA256 校验失败! 期望: $expected 实际: $actual"; return $false
+}
+
+# ==============================================================================
+# Phase 1: Slack Token 验证
+# ==============================================================================
+
+function Test-SlackToken {
+    param([string]$Token)
+    if ([string]::IsNullOrEmpty($Token)) { return $false }
+    try {
+        $headers = @{ "Authorization" = "Bearer $Token"; "Content-Type" = "application/json" }
+        $resp = Invoke-RestMethod -Uri "https://slack.com/api/auth.test" -Headers $headers -Method Post -TimeoutSec 10 -ErrorAction Stop
+        return $resp.ok -eq $true
+    } catch { return $false }
+}
+
+function Test-SlackTokenFormat { param([string]$Token) return $Token -match "^xox[baprs]-[a-zA-Z0-9_-]+$" -and $Token.Length -ge 20 }
+
+# ==============================================================================
+# Phase 1: 配置生成 (原子写入)
+# ==============================================================================
+
+function New-ConfigFile {
+    param([string]$Path, [hashtable]$Values)
+    $content = @"
+# HotPlex 环境配置 - $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+HOTPLEX_PORT=$($Values.Port)
+HOTPLEX_LOG_LEVEL=INFO
+HOTPLEX_API_KEY=$($Values.ApiKey)
+HOTPLEX_DATA_DIR=$($Values.ConfigDir)
+HOTPLEX_PROVIDER_TYPE=claude-code
+HOTPLEX_PROVIDER_MODEL=sonnet
+HOTPLEX_SLACK_BOT_USER_ID=$($Values.BotUserId)
+HOTPLEX_SLACK_BOT_TOKEN=$($Values.BotToken)
+HOTPLEX_SLACK_APP_TOKEN=$($Values.AppToken)
+HOTPLEX_MESSAGE_STORE_ENABLED=true
+HOTPLEX_MESSAGE_STORE_TYPE=sqlite
+HOTPLEX_MESSAGE_STORE_SQLITE_PATH=$($Values.ConfigDir)\chatapp_messages.db
+GITHUB_TOKEN=
+"@
+    $dir = Split-Path $Path -Parent
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $tempFile = "$env:TEMP\hotplex-env-$([System.Guid]::NewGuid().ToString('N')).tmp"
+    $content | Out-File -FilePath $tempFile -Encoding UTF8 -Force
+    Move-Item -Path $tempFile -Destination $Path -Force
+    $acl = Get-Acl $Path; $acl.SetAccessRuleProtection($true, $false)
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $acl.AddAccessRule([System.Security.Principal.FileSystemAccessRule]::new($identity, "FullControl", "Allow"))
+    $acl.AddAccessRule([System.Security.Principal.FileSystemAccessRule]::new($identity, "ReadAndExecute", "InheritOnly", "Allow"))
+    Set-Acl -Path $Path -AclObject $acl
+    Write-Success "已生成配置文件: $Path"
+}
+
+# ==============================================================================
+# Phase 1: Windows Service 管理
+# ==============================================================================
+
+function Install-WindowsService {
+    param([string]$BinaryPath, [string]$ServiceName, [string]$ConfigDir, [int]$Port)
+    Write-Info "安装 Windows 服务..."
+    $existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if ($existing) {
+        if ($Force) { Stop-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue; $null = & sc.exe delete $ServiceName 2>$null; Start-Sleep -Seconds 1 }
+        else { Write-Warn "服务 $ServiceName 已存在 (使用 -Force 覆盖)"; return }
+    }
+    $envFile = Join-Path $ConfigDir ".env"
+    $binPath = "$BinaryPath start --port $Port --env `"$envFile`""
+    $null = & sc.exe create $ServiceName binPath= "$binPath" start= auto DisplayName= "HotPlex AI Agent" 2>$null
+    $null = & sc.exe description $ServiceName "HotPlex AI Agent Control Plane" 2>$null
+    Start-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    $svc = Get-Service -Name $ServiceName
+    if ($svc.Status -eq "Running") { Write-Success "Windows 服务已安装并启动" } else { Write-Warn "服务安装完成但未自动启动" }
+}
+
+function Uninstall-WindowsService {
+    param([string]$ServiceName)
+    $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) { Write-Info "服务 $ServiceName 未安装"; return }
+    Write-Info "停止并移除服务..."
+    Stop-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue
+    $null = & sc.exe delete $ServiceName 2>$null
+    Write-Success "服务已移除"
+}
+
+# ==============================================================================
+# Phase 2: 交互式主菜单
+# ==============================================================================
+
+function Show-MainMenu {
+    Write-Host ""
+    Write-Host "$($Script:Colors.Bold)$($Script:Colors.Cyan)╭─ HotPlex 安装程序 ──────────────────────────────╮$($Script:Colors.NC)"
+    Write-Host "$($Script:Colors.Bold)$($Script:Colors.Cyan)╰───────────────────────────────────────────────────╯$($Script:Colors.NC)"
+    Write-Host ""
+    Write-Host "  $($Script:Colors.Bold)请选择操作:$($Script:Colors.NC)"
+    Write-Host ""
+    Write-Host "    1) 安装 HotPlex         (Quick Start - 二进制模式)"
+    Write-Host "    2) 升级 HotPlex         (保留配置，替换二进制)"
+    Write-Host "    3) 卸载 HotPlex         (移除二进制，保留配置)"
+    Write-Host "    4) 完全清理            (删除所有数据)"
+    Write-Host "    5) 查看状态            (检查安装和运行状态)"
+    Write-Host "    6) 仅配置              (运行配置向导)"
+    Write-Host "    7) 退出"
+    Write-Host ""
+}
+
+function Invoke-MenuChoice {
+    param([string]$Choice)
+    switch ($Choice) {
+        "1" { Invoke-Install }
+        "2" { Invoke-Upgrade }
+        "3" { Invoke-Uninstall }
+        "4" { Invoke-Purge }
+        "5" { Invoke-Status }
+        "6" { Invoke-ConfigWizard }
+        "7" { Write-Host ""; Write-Info "再见!"; exit 0 }
+        default { Write-Err "无效选择: $Choice" }
+    }
+}
+
+# ==============================================================================
+# Phase 2: 配置向导
+# ==============================================================================
+
+function Invoke-ConfigWizard {
+    Write-Banner "配置向导"
+    $envFile = Join-Path $ConfigDir ".env"
+    if (-not (Test-Path $envFile)) { Write-Err "配置文件不存在，请先运行安装"; return }
+    $content = Get-Content $envFile -Raw
+    $botToken = $appToken = $botUserId = ""
+    if ($content -match "HOTPLEX_SLACK_BOT_TOKEN=(.+)") { $botToken = $Matches[1].Trim() }
+    if ($content -match "HOTPLEX_SLACK_APP_TOKEN=(.+)") { $appToken = $Matches[1].Trim() }
+    if ($content -match "HOTPLEX_SLACK_BOT_USER_ID=(.+)") { $botUserId = $Matches[1].Trim() }
+    Write-Host "  Bot Token:  $(if($botToken){"$($Script:Colors.Green)✓ $(Mask-Token -Token $botToken -Visible 6)"}else{"$($Script:Colors.Yellow)○ 未配置"})"
+    Write-Host "  App Token:  $(if($appToken){"$($Script:Colors.Green)✓ $(Mask-Token -Token $appToken -Visible 6)"}else{"$($Script:Colors.Yellow)○ 未配置"})"
+    Write-Host "  Bot User ID: $(if($botUserId){"$($Script:Colors.Green)✓ $botUserId"}else{"$($Script:Colors.Yellow)○ 未配置"})"
+    Write-Host ""
+    if (-not (Confirm-Action "是否重新配置 Slack?" "n")) { Write-Success "配置保持不变"; return }
+    Write-Host ""
+    $newBotToken = Read-InputPrompt "Bot Token (xoxb-...)" $botToken
+    if (-not [string]::IsNullOrEmpty($newBotToken) -and (Test-SlackTokenFormat -Token $newBotToken)) {
+        if (Test-SlackToken -Token $newBotToken) { Write-Success "Token 验证成功" } else { Write-Warn "Token 验证失败" }
+        $content = $content -replace "HOTPLEX_SLACK_BOT_TOKEN=.+", "HOTPLEX_SLACK_BOT_TOKEN=$newBotToken"
+    }
+    $newAppToken = Read-InputPrompt "App Token (xapp-...)" $appToken
+    if (-not [string]::IsNullOrEmpty($newAppToken)) { $content = $content -replace "HOTPLEX_SLACK_APP_TOKEN=.+", "HOTPLEX_SLACK_APP_TOKEN=$newAppToken" }
+    $newBotUserId = Read-InputPrompt "Bot User ID (U... 或 B...)" $botUserId
+    if (-not [string]::IsNullOrEmpty($newBotUserId)) { $content = $content -replace "HOTPLEX_SLACK_BOT_USER_ID=.+", "HOTPLEX_SLACK_BOT_USER_ID=$newBotUserId" }
+    $tempFile = "$env:TEMP\hotplex-env-wizard-$([System.Guid]::NewGuid().ToString('N')).tmp"
+    $content | Out-File -FilePath $tempFile -Encoding UTF8 -Force
+    Move-Item -Path $tempFile -Destination $envFile -Force
+    Write-Success "配置已更新: $envFile"
+}
+
+# ==============================================================================
+# Phase 2-3: 安装
+# ==============================================================================
+
+function Invoke-Install {
+    Write-Banner "安装 HotPlex"
+    $plat = Get-Platform; $os = $plat.OS; $arch = $plat.Arch
+    Write-Info "平台: $os / $arch"
+
+    if ([string]::IsNullOrEmpty($Version)) {
+        Write-Info "获取最新版本..."
+        $json = Invoke-HttpGet -Url "$Script:ApiBase/$Script:Repo/releases/latest"
+        if ($json) { $obj = $json | ConvertFrom-Json; $Version = $obj[0].tag_name -replace "^v", "" } else { $Version = "0.35.4" }
+    }
+    if (-not $Version.StartsWith("v")) { $Version = "v$Version" }
+    Write-Info "目标版本: $($Script:Colors.Green)${Version}$($Script:Colors.NC)"
+
+    $binaryPath = Join-Path $InstallDir $Script:BinaryName
+    if ((Test-Path $binaryPath) -and -not $Force) {
+        try {
+            $current = & $binaryPath -version 2>$null | Select-Object -First 1
+            if ($current) { Write-Warn "已安装版本: $current"; if (Confirm-Action "是否强制重新安装?" "n") { $Force = $true } else { return } }
+        } catch { }
+    }
+
+    $port = 8080
+    $portStatus = Get-PortStatus -Port $port
+    if ($portStatus.InUse) { $port = Resolve-PortConflict -Port $port; if ($port -lt 0) { return } }
+
+    $archiveName = "hotplex_$($Version.Substring(1))_${os}_${arch}"
+    if ($os -eq "windows") { $archiveName += ".zip" } else { $archiveName += ".tar.gz" }
+    $archiveUrl = "$Script:DownloadBase/${Version}/$archiveName"
+
+    $tempDir = "$env:TEMP\hotplex-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $archivePath = Join-Path $tempDir $archiveName
+
+    Write-Info "正在下载..."
+    if (-not (Download-WithRetry -Url $archiveUrl -OutputPath $archivePath)) { Write-Err "下载失败"; Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+    Write-Success "下载完成"
+
+    if (-not $SkipVerify) {
+        $checksumsFile = Join-Path $tempDir "SHA256SUMS"
+        if (Get-Checksums -Version $Version.Substring(1) -OutFile $checksumsFile) {
+            if (-not (Test-Checksum -FilePath $archivePath -ChecksumsFile $checksumsFile)) { Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+        } else { Write-Warn "无法下载校验和，跳过验证" }
+    }
+
+    Write-Info "解压..."
+    $extractDir = Join-Path $tempDir "extract"
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+    if (-not (Test-Path $InstallDir)) { New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null }
+
+    $extractedBinary = Get-ChildItem $extractDir -Filter "*.exe" | Select-Object -First 1
+    if (-not $extractedBinary) { $extractedBinary = Get-ChildItem $extractDir -Recurse -Filter "*.exe" | Select-Object -First 1 }
+    if ($extractedBinary) { Copy-Item $extractedBinary.FullName $binaryPath -Force; Write-Success "已安装: $binaryPath" }
+    else { Write-Err "未找到可执行文件"; Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+
+    Write-Host ""; Write-Banner "配置 Slack 凭据"
+    $botToken = Read-InputPrompt "Bot User OAuth Token (xoxb-...)" ""
+    if ([string]::IsNullOrEmpty($botToken)) { Write-Err "Bot Token 不能为空"; Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+    if (Test-SlackTokenFormat -Token $botToken) { if (Test-SlackToken -Token $botToken) { Write-Success "Token 验证成功" } else { Write-Warn "Token 验证失败，但继续安装" } }
+    $appToken = Read-InputPrompt "App-Level Token (xapp-...)" ""
+    $botUserId = Read-InputPrompt "Bot User ID (U... 或 B...)" ""
+    $apiKey = [Convert]::ToBase64String([byte[]]::new(32) | ForEach-Object { Get-Random -Maximum 256 })
+
+    Write-Host ""
+    New-ConfigFile -Path (Join-Path $ConfigDir ".env") -Values @{ Port=$port; BotToken=$botToken; AppToken=$appToken; BotUserId=$botUserId; ApiKey=$apiKey; ConfigDir=$ConfigDir }
+
+    if (-not $SkipAutostart) { Install-WindowsService -BinaryPath $binaryPath -ServiceName $Script:ServiceName -ConfigDir $ConfigDir -Port $port }
+
+    if (-not $SkipHealthCheck) {
+        Write-Info "健康检查 (超时: 15s)..."
+        $healthUrl = "http://localhost:${port}/health"; $ok = $false
+        for ($i = 0; $i -lt 15; $i++) {
+            try { $resp = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 2 -EA SilentlyContinue; if ($resp.Content -match "ok|OK|healthy") { Write-Success "健康检查通过"; $ok = $true; break } } catch { }
+            Start-Sleep -Seconds 1
+        }
+        if (-not $ok) { Write-Warn "健康检查超时 - 服务可能仍在启动" }
+    }
+
+    Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue
+    Write-Host ""; Write-Success "安装完成!"; Write-Host "  二进制: $binaryPath"; Write-Host "  配置: $(Join-Path $ConfigDir ".env")"; Write-Host "  端口: $port"
+}
+
+# ==============================================================================
+# Phase 3: 升级
+# ==============================================================================
+
+function Invoke-Upgrade {
+    Write-Banner "升级 HotPlex"
+    $binaryPath = Join-Path $InstallDir $Script:BinaryName
+    if (-not (Test-Path $binaryPath)) { Write-Err "未检测到已安装的 HotPlex，请先运行安装"; return }
+    try { $current = & $binaryPath -version 2>$null | Select-Object -First 1 } catch { $current = "unknown" }
+    Write-Info "当前版本: $current"
+
+    if ([string]::IsNullOrEmpty($Version)) {
+        $json = Invoke-HttpGet -Url "$Script:ApiBase/$Script:Repo/releases/latest"
+        if ($json) { $obj = $json | ConvertFrom-Json; $Version = $obj[0].tag_name }
+    }
+    if (-not $Version.StartsWith("v")) { $Version = "v$Version" }
+    Write-Info "目标版本: $Version"
+
+    $targetVersion = $Version.Substring(1)
+    if ($current -match "v?([\d\.]+)") { if ($Matches[1] -eq $targetVersion) { Write-Success "已是最新版本 ($current)"; return } }
+
+    if (-not (Confirm-Action "确认升级?" "y")) { Write-Info "升级已取消"; return }
+
+    $svc = Get-Service -Name $Script:ServiceName -EA SilentlyContinue
+    if ($svc -and $svc.Status -eq "Running") { Write-Info "停止服务..."; Stop-Service -Name $Script:ServiceName -Force }
+
+    $plat = Get-Platform; $os = $plat.OS; $arch = $plat.Arch
+    $archiveName = "hotplex_${targetVersion}_${os}_${arch}"
+    if ($os -eq "windows") { $archiveName += ".zip" } else { $archiveName += ".tar.gz" }
+    $archiveUrl = "$Script:DownloadBase/${Version}/$archiveName"
+
+    $tempDir = "$env:TEMP\hotplex-upgrade-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $archivePath = Join-Path $tempDir $archiveName
+
+    Write-Info "正在下载 v${targetVersion}..."
+    if (-not (Download-WithRetry -Url $archiveUrl -OutputPath $archivePath)) { Write-Err "下载失败"; Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+
+    if (-not $SkipVerify) {
+        $checksumsFile = Join-Path $tempDir "SHA256SUMS"
+        if (Get-Checksums -Version $targetVersion -OutFile $checksumsFile) {
+            if (-not (Test-Checksum -FilePath $archivePath -ChecksumsFile $checksumsFile)) { Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue; return }
+        }
+    }
+
+    $extractDir = Join-Path $tempDir "extract"
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+    $extractedBinary = Get-ChildItem $extractDir -Filter "*.exe" | Select-Object -First 1
+    if (-not $extractedBinary) { $extractedBinary = Get-ChildItem $extractDir -Recurse -Filter "*.exe" | Select-Object -First 1 }
+    if ($extractedBinary) { Copy-Item $extractedBinary.FullName $binaryPath -Force }
+
+    if (-not $SkipAutostart) { $svc = Get-Service -Name $Script:ServiceName -EA SilentlyContinue; if ($svc) { Write-Info "重启服务..."; Start-Service -Name $Script:ServiceName } }
+
+    try { $newVersion = & $binaryPath -version 2>$null | Select-Object -First 1 } catch { $newVersion = "unknown" }
+    Write-Success "升级完成: $newVersion"
+    Remove-Item $tempDir -Recurse -Force -EA SilentlyContinue
+}
+
+# ==============================================================================
+# Phase 3: 状态检查
+# ==============================================================================
+
+function Invoke-Status {
+    Write-Banner "HotPlex 状态"
+    $binaryPath = Join-Path $InstallDir $Script:BinaryName
+    $envFile = Join-Path $ConfigDir ".env"
+
+    Write-Host "  $($Script:Colors.Bold)二进制文件:$($Script:Colors.NC)"
+    if (Test-Path $binaryPath) {
+        try { $current = & $binaryPath -version 2>$null | Select-Object -First 1 } catch { $current = "unknown" }
+        Write-Host "    $($Script:Colors.Green)✓$($Script:Colors.NC) 已安装: $current"
+        Write-Host "    $($Script:Colors.Dim)   路径: $binaryPath$($Script:Colors.NC)"
+    } else { Write-Host "    $($Script:Colors.Red)✗$($Script:Colors.NC) 未安装" }
+
+    Write-Host ""; Write-Host "  $($Script:Colors.Bold)配置文件:$($Script:Colors.NC)"
+    if (Test-Path $envFile) {
+        Write-Host "    $($Script:Colors.Green)✓$($Script:Colors.NC) 已配置: $envFile"
+        $content = Get-Content $envFile -Raw
+        if ($content -match "HOTPLEX_SLACK_BOT_TOKEN=(.+)") { Write-Host "    $($Script:Colors.Dim)   Bot Token: $($Script:Colors.Green)$(Mask-Token -Token $Matches[1].Trim() -Visible 8)$($Script:Colors.NC)" }
+        if ($content -match "HOTPLEX_PORT=(\d+)") { Write-Host "    $($Script:Colors.Dim)   端口: $($Script:Colors.Green)$($Matches[1])$($Script:Colors.NC)" }
+    } else { Write-Host "    $($Script:Colors.Yellow)○$($Script:Colors.NC) 未配置" }
+
+    Write-Host ""; Write-Host "  $($Script:Colors.Bold)服务状态:$($Script:Colors.NC)"
+    $svc = Get-Service -Name $Script:ServiceName -EA SilentlyContinue
+    if ($svc) {
+        Write-Host "    $($Script:Colors.Green)✓$($Script:Colors.NC) 服务: $($svc.Status)"
+        if ($svc.Status -eq "Running") {
+            $port = 8080; if (Test-Path $envFile) { $c = Get-Content $envFile -Raw; if ($c -match "HOTPLEX_PORT=(\d+)") { $port = $Matches[1] } }
+            try { $resp = Invoke-WebRequest -Uri "http://localhost:${port}/health" -TimeoutSec 3 -EA SilentlyContinue; if ($resp.Content -match "ok|OK|healthy") { Write-Host "    $($Script:Colors.Green)✓$($Script:Colors.NC) 健康检查: 通过" } else { Write-Host "    $($Script:Colors.Yellow)○$($Script:Colors.NC) 健康检查: 未通过" } } catch { Write-Host "    $($Script:Colors.Yellow)○$($Script:Colors.NC) 健康检查: 无法访问" }
+        }
+    } else { Write-Host "    $($Script:Colors.Yellow)○$($Script:Colors.NC) 服务未安装" }
+
+    Write-Host ""; Write-Host "  $($Script:Colors.Bold)进程:$($Script:Colors.NC)"
+    $proc = Get-Process -Name "hotplexd" -EA SilentlyContinue
+    if ($proc) { Write-Host "    $($Script:Colors.Green)✓$($Script:Colors.NC) 运行中 (PID: $($proc.Id))"; Write-Host "    $($Script:Colors.Dim)   内存: $([math]::Round($proc.WorkingSet64 / 1MB, 1)) MB$($Script:Colors.NC)" }
+    else { Write-Host "    $($Script:Colors.Yellow)○$($Script:Colors.NC) 未运行" }
+    Write-Host ""
+}
+
+# ==============================================================================
+# Phase 3: 卸载
+# ==============================================================================
+
+function Invoke-Uninstall {
+    Write-Banner "卸载 HotPlex"
+    $binaryPath = Join-Path $InstallDir $Script:BinaryName
+    if (-not (Test-Path $binaryPath) -and -not (Test-Path $ConfigDir)) { Write-Warn "HotPlex 未安装，无需卸载"; return }
+    if (-not (Confirm-Action "确认卸载 (保留配置)?" "n")) { Write-Info "卸载已取消"; return }
+
+    $svc = Get-Service -Name $Script:ServiceName -EA SilentlyContinue
+    if ($svc) { Write-Info "停止服务..."; Stop-Service -Name $Script:ServiceName -Force -EA SilentlyContinue; $null = & sc.exe delete $Script:ServiceName 2>$null }
+
+    if (Test-Path $binaryPath) { Write-Info "删除二进制..."; Remove-Item $binaryPath -Force; Write-Success "已删除: $binaryPath" }
+    Write-Success "卸载完成 (配置保留在 $ConfigDir)"
+}
+
+# ==============================================================================
+# Phase 3: 完全清理
+# ==============================================================================
+
+function Invoke-Purge {
+    Write-Banner "完全清理 HotPlex"
+    if (-not (Test-Path (Join-Path $InstallDir $Script:
+
+function Invoke-Purge {
+    Write-Banner "完全清理 HotPlex"
+    if (-not (Test-Path (Join-Path $InstallDir $Script:BinaryName)) -and -not (Test-Path $ConfigDir)) { Write-Warn "HotPlex 未安装，无需清理"; return }
+    if (-not (Confirm-Action "确认完全清理 (删除所有数据)?" "n")) { Write-Info "清理已取消"; return }
+
+    $svc = Get-Service -Name $Script:ServiceName -EA SilentlyContinue
+    if ($svc) { Write-Info "停止服务..."; Stop-Service -Name $Script:ServiceName -Force -EA SilentlyContinue; $null = & sc.exe delete $Script:ServiceName 2>$null }
+
+    $binaryPath = Join-Path $InstallDir $Script:BinaryName
+    if (Test-Path $binaryPath) { Write-Info "删除二进制..."; Remove-Item $binaryPath -Force; Write-Success "已删除: $binaryPath" }
+    if (Test-Path $InstallDir) { Write-Info "删除安装目录..."; Remove-Item $InstallDir -Recurse -Force; Write-Success "已删除: $InstallDir" }
+    if (Test-Path $ConfigDir) { Write-Info "删除配置目录..."; Remove-Item $ConfigDir -Recurse -Force; Write-Success "已删除: $ConfigDir" }
+    Write-Success "完全清理完成"
+}
+
+# ==============================================================================
+# 主入口
+# ==============================================================================
+
+Write-Banner "HotPlex 安装程序 v${Script:ScriptVersion}"
+
+# 处理 Action 参数
+if (-not [string]::IsNullOrEmpty($Action)) {
+    switch ($Action) {
+        "Install"   { Invoke-Install }
+        "Upgrade"   { Invoke-Upgrade }
+        "Status"    { Invoke-Status }
+        "Uninstall" { Invoke-Uninstall }
+        "Purge"     { Invoke-Purge }
+        default { Write-Err "未知操作: $Action"; exit 1 }
+    }
+    exit 0
+}
+
+# 交互模式: 显示主菜单
+if ($NonInteractive -or -not $Host.UI.Interactive) {
+    if (-not $SkipHealthCheck -or -not $SkipAutostart -or -not [string]::IsNullOrEmpty($Version) -or $Force) {
+        Invoke-Install
+    } else {
+        Write-Err "非交互模式需要指定 -Action 参数"
+        Write-Host "用法: .\hotplex-install.ps1 -Action Install|Upgrade|Status|Uninstall|Purge"
+        exit 1
+    }
+    exit 0
+}
+
+# 显示主菜单循环
+while ($true) {
+    Show-MainMenu
+    $choice = Read-InputPrompt "请选择 [1-7]" ""
+    if ([string]::IsNullOrEmpty($choice)) { $choice = "1" }
+    Invoke-MenuChoice -Choice $choice
+}

--- a/install/hotplex-install.sh
+++ b/install/hotplex-install.sh
@@ -48,6 +48,8 @@ INTERACTIVE=true
 INSTALL_MODE="binary"  # binary | docker
 MULTI_BOT_ENABLED=false
 BOT_COUNT=1
+INSTALL_OPENCODE=false
+INSTALL_CLAUDE_CODE=false
 
 # Docker 相关
 DOCKER_COMPOSE_PATH="${CONFIG_DIR}/docker-compose.yml"
@@ -2396,7 +2398,9 @@ show_main_menu() {
     echo "    7) 仅配置              (运行配置向导)"
     echo "    8) 多 Bot 配置         (添加/管理多个 Bot)"
     echo "    9) 日志管理           (配置日志轮转)"
-    echo "   10) 退出"
+    echo "   11) 安装 OpenCode       (可选组件)"
+    echo "   12) 安装 Claude Code    (可选组件)"
+    echo "   13) 退出"
     echo ""
 }
 
@@ -2446,7 +2450,17 @@ handle_menu_choice() {
             echo ""
             configure_logrotate
             ;;
-        10|q|Q)
+        11)
+            echo ""
+            info "开始安装 OpenCode..."
+            install_opencode
+            ;;
+        12)
+            echo ""
+            info "开始安装 Claude Code..."
+            install_claude_code
+            ;;
+        13|q|Q)
             echo ""
             info "再见!"
             exit 0
@@ -2455,6 +2469,107 @@ handle_menu_choice() {
             error "无效选择: $choice"
             ;;
     esac
+}
+
+# ==============================================================================
+# 可选组件安装
+# ==============================================================================
+
+install_opencode() {
+    step "安装 OpenCode..."
+
+    local opencode_dir="${HOME}/.opencode"
+    local opencode_bin="${opencode_dir}/bin/opencode"
+
+    if [[ -f "$opencode_bin" ]]; then
+        info "OpenCode 已安装 (${opencode_bin})"
+        if confirm "是否重新安装?" "n"; then
+            rm -rf "$opencode_bin"
+        else
+            return 0
+        fi
+    fi
+
+    mkdir -p "${opencode_dir}/bin"
+
+    # 检测平台
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64) arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+    esac
+
+    local version
+    version=$(curl -sL "https://api.github.com/repos/opencode-ai/opencode/releases/latest" 2>/dev/null | grep '"tag_name"' | cut -d'"' -f4 || echo "v2.0.0")
+    local download_url="https://github.com/opencode-ai/opencode/releases/download/${version}/opencode-${os}-${arch}"
+
+    info "下载 OpenCode ${version} (${os}/${arch})..."
+    if curl -fsSL "$download_url" -o "$opencode_bin"; then
+        chmod +x "$opencode_bin"
+        success "OpenCode 安装成功: ${opencode_bin}"
+
+        # 添加到 PATH 提示
+        echo ""
+        echo -e "  ${BOLD}请确保 PATH 包含 ${opencode_dir}/bin${NC}"
+        echo -e "  ${DIM}建议添加到 ~/.bashrc 或 ~/.zshrc:${NC}"
+        echo -e "    ${GREEN}export PATH=\"${opencode_dir}/bin:\$PATH\"${NC}"
+    else
+        error "OpenCode 下载失败"
+    fi
+}
+
+install_claude_code() {
+    step "安装 Claude Code..."
+
+    local cc_dir="${HOME}/.claude"
+    local cc_bin="${cc_dir}/bin/claude"
+
+    if command_exists claude; then
+        info "Claude Code 已安装 ($(claude --version 2>/dev/null || echo "unknown version"))"
+        if confirm "是否重新安装?" "n"; then
+            sudo rm -f "$(which claude)"
+        else
+            return 0
+        fi
+    fi
+
+    # 检测平台
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64) arch="x86_64" ;;
+        aarch64|arm64) arch="arm64" ;;
+    esac
+
+    local version="latest"
+    info "安装 Claude Code ${version} (${os}/${arch})..."
+
+    if [[ "$os" == "darwin" ]]; then
+        if command_exists brew; then
+            info "使用 Homebrew 安装..."
+            brew install claude-code 2>/dev/null && success "Claude Code 安装成功" || error "Homebrew 安装失败"
+        else
+            error "macOS 推荐使用 Homebrew: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        fi
+    elif [[ "$os" == "linux" ]]; then
+        # 使用 npm 安装
+        if command_exists npm; then
+            info "使用 npm 安装..."
+            npm install -g @anthropic-ai/claude-code 2>/dev/null && success "Claude Code 安装成功" || error "npm 安装失败"
+        else
+            error "需要 npm。请安装 Node.js: https://nodejs.org/"
+        fi
+    else
+        error "不支持的平台: ${os}"
+    fi
+
+    if command_exists claude; then
+        echo ""
+        info "Claude Code 版本: $(claude --version 2>/dev/null || echo "unknown")"
+    fi
 }
 
 # ==============================================================================

--- a/install/hotplex-install.sh
+++ b/install/hotplex-install.sh
@@ -2478,45 +2478,33 @@ handle_menu_choice() {
 install_opencode() {
     step "安装 OpenCode..."
 
-    local opencode_dir="${HOME}/.opencode"
-    local opencode_bin="${opencode_dir}/bin/opencode"
-
-    if [[ -f "$opencode_bin" ]]; then
-        info "OpenCode 已安装 (${opencode_bin})"
+    if command_exists opencode; then
+        info "OpenCode 已安装 ($(opencode --version 2>/dev/null || echo "unknown version"))"
         if confirm "是否重新安装?" "n"; then
-            rm -rf "$opencode_bin"
+            step "卸载旧版本..."
+            sudo rm -f "$(which opencode)"
         else
             return 0
         fi
     fi
 
-    mkdir -p "${opencode_dir}/bin"
+    info "使用官方安装脚本..."
+    info "curl -fsSL https://opencode.ai/install | bash"
 
-    # 检测平台
-    local os arch
-    os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    arch=$(uname -m)
-    case "$arch" in
-        x86_64) arch="amd64" ;;
-        aarch64|arm64) arch="arm64" ;;
-    esac
+    if curl -fsSL https://opencode.ai/install | bash; then
+        success "OpenCode 安装成功"
 
-    local version
-    version=$(curl -sL "https://api.github.com/repos/opencode-ai/opencode/releases/latest" 2>/dev/null | grep '"tag_name"' | cut -d'"' -f4 || echo "v2.0.0")
-    local download_url="https://github.com/opencode-ai/opencode/releases/download/${version}/opencode-${os}-${arch}"
-
-    info "下载 OpenCode ${version} (${os}/${arch})..."
-    if curl -fsSL "$download_url" -o "$opencode_bin"; then
-        chmod +x "$opencode_bin"
-        success "OpenCode 安装成功: ${opencode_bin}"
-
-        # 添加到 PATH 提示
-        echo ""
-        echo -e "  ${BOLD}请确保 PATH 包含 ${opencode_dir}/bin${NC}"
-        echo -e "  ${DIM}建议添加到 ~/.bashrc 或 ~/.zshrc:${NC}"
-        echo -e "    ${GREEN}export PATH=\"${opencode_dir}/bin:\$PATH\"${NC}"
+        if command_exists opencode; then
+            echo ""
+            info "版本: $(opencode --version 2>/dev/null || echo "unknown")"
+        fi
     else
-        error "OpenCode 下载失败"
+        error "OpenCode 安装失败"
+        echo ""
+        echo -e "  ${DIM}备选安装方式:${NC}"
+        echo -e "  ${CYAN}npm:${NC} npm install -g opencode-ai"
+        echo -e "  ${CYAN}Homebrew:${NC} brew install opencode-ai/tap/opencode"
+        echo -e "  ${CYAN}Go:${NC} go install github.com/opencode-ai/opencode@latest"
     fi
 }
 

--- a/install/hotplex-install.sh
+++ b/install/hotplex-install.sh
@@ -2511,52 +2511,45 @@ install_opencode() {
 install_claude_code() {
     step "安装 Claude Code..."
 
-    local cc_dir="${HOME}/.claude"
-    local cc_bin="${cc_dir}/bin/claude"
-
     if command_exists claude; then
         info "Claude Code 已安装 ($(claude --version 2>/dev/null || echo "unknown version"))"
         if confirm "是否重新安装?" "n"; then
+            step "卸载旧版本..."
             sudo rm -f "$(which claude)"
         else
             return 0
         fi
     fi
 
-    # 检测平台
-    local os arch
+    local os
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    arch=$(uname -m)
-    case "$arch" in
-        x86_64) arch="x86_64" ;;
-        aarch64|arm64) arch="arm64" ;;
-    esac
 
-    local version="latest"
-    info "安装 Claude Code ${version} (${os}/${arch})..."
+    info "使用官方安装脚本..."
 
-    if [[ "$os" == "darwin" ]]; then
-        if command_exists brew; then
-            info "使用 Homebrew 安装..."
-            brew install claude-code 2>/dev/null && success "Claude Code 安装成功" || error "Homebrew 安装失败"
+    if [[ "$os" == "darwin" ]] || [[ "$os" == "linux" ]]; then
+        info "curl -fsSL https://claude.ai/install.sh | bash"
+        if curl -fsSL https://claude.ai/install.sh | bash; then
+            success "Claude Code 安装成功"
+            if command_exists claude; then
+                echo ""
+                info "版本: $(claude --version 2>/dev/null || echo "unknown")"
+            fi
         else
-            error "macOS 推荐使用 Homebrew: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+            error "Claude Code 安装失败"
+            echo ""
+            echo -e "  ${DIM}备选安装方式:${NC}"
+            echo -e "  ${CYAN}npm:${NC} npm install -g @anthropic-ai/claude-code"
+            echo -e "  ${CYAN}Homebrew:${NC} brew install claude-code"
         fi
-    elif [[ "$os" == "linux" ]]; then
-        # 使用 npm 安装
-        if command_exists npm; then
-            info "使用 npm 安装..."
-            npm install -g @anthropic-ai/claude-code 2>/dev/null && success "Claude Code 安装成功" || error "npm 安装失败"
+    elif [[ "$os" == "mingw"* ]] || [[ "$os" == "msys"* ]] || [[ "$os" == "cygwin"* ]]; then
+        info "Windows: irm https://claude.ai/install.ps1 | iex"
+        if powershell -Command "irm https://claude.ai/install.ps1 | iex"; then
+            success "Claude Code 安装成功"
         else
-            error "需要 npm。请安装 Node.js: https://nodejs.org/"
+            error "Claude Code 安装失败"
         fi
     else
         error "不支持的平台: ${os}"
-    fi
-
-    if command_exists claude; then
-        echo ""
-        info "Claude Code 版本: $(claude --version 2>/dev/null || echo "unknown")"
     fi
 }
 

--- a/install/hotplex-install.sh
+++ b/install/hotplex-install.sh
@@ -1,0 +1,2533 @@
+#!/bin/bash
+# ==============================================================================
+# HotPlex 一键安装脚本 v2.1
+# ==============================================================================
+# 用法:
+#   curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install.sh | bash
+#   curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install.sh | bash -s -- -v v0.21.0
+#
+# 参考: https://github.com/hrygo/hotplex/blob/main/docs/superpowers/specs/2026-03-24-one-click-install-design.md
+# ==============================================================================
+
+set -euo pipefail
+
+# ==============================================================================
+# 全局变量
+# ==============================================================================
+readonly REPO="hrygo/hotplex"
+readonly BINARY_NAME="hotplexd"
+readonly SCRIPT_VERSION="3.0.0"
+readonly DEFAULT_INSTALL_DIR="/usr/local/bin"
+readonly CONFIG_DIR="${HOME}/.hotplex"
+readonly GITHUB_API="https://api.github.com/repos"
+readonly LOG_FILE="${CONFIG_DIR}/install.log"
+
+setup_secure_logging() {
+    mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || sudo mkdir -p "$(dirname "$LOG_FILE")"
+    touch "$LOG_FILE" 2>/dev/null || sudo touch "$LOG_FILE"
+    chmod 600 "$LOG_FILE" 2>/dev/null || sudo chmod 600 "$LOG_FILE"
+}
+
+# 可配置变量
+VERSION=""
+INSTALL_DIR=""
+CONFIG_ONLY=false
+UNINSTALL=false
+DO_UPGRADE=false
+DO_STATUS=false
+DO_PURGE=false
+DRY_RUN=false
+VERBOSE=false
+QUIET=false
+SKIP_VERIFY=false
+SKIP_HEALTH_CHECK=false
+SKIP_AUTOSTART=false
+SKIP_WIZARD=false
+FORCE=false
+INTERACTIVE=true
+INSTALL_MODE="binary"  # binary | docker
+MULTI_BOT_ENABLED=false
+BOT_COUNT=1
+
+# Docker 相关
+DOCKER_COMPOSE_PATH="${CONFIG_DIR}/docker-compose.yml"
+DOCKER_ENV_PATH="${CONFIG_DIR}/.env.docker"
+
+# 日志轮转
+LOGROTATE_PATH="/etc/logrotate.d/hotplex"
+MAX_LOG_SIZE="10M"
+MAX_LOG_FILES=5
+
+# 颜色定义 (非 readonly，允许 init_colors 修改)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+BOLD='\033[1m'
+DIM='\033[2m'
+UNDERLINE='\033[4m'
+NC='\033[0m'
+
+# 临时文件
+TEMP_DIR=""
+CLEANUP_PENDING=true
+
+# ==============================================================================
+# 工具函数
+# ==============================================================================
+
+# 初始化颜色
+init_colors() {
+    if [[ ! -t 1 ]] || [[ "${NO_COLOR:-}" == "true" ]]; then
+        RED="" GREEN="" YELLOW="" BLUE="" CYAN="" MAGENTA="" BOLD="" DIM="" UNDERLINE="" NC=""
+    fi
+}
+
+# 日志函数
+log() {
+    local level="$1"; shift
+    local msg="$*"
+    local timestamp=$(date '+%H:%M:%S')
+
+    case "$level" in
+        info)    [[ "$QUIET" == "true" ]] && return; echo -e "${BLUE}▸${NC} $msg" ;;
+        success) [[ "$QUIET" == "true" ]] && return; echo -e "${GREEN}✓${NC} $msg" ;;
+        warn)    echo -e "${YELLOW}!${NC} $msg" >&2 ;;
+        error)   echo -e "${RED}✗${NC} $msg" >&2 ;;
+        debug)   [[ "$VERBOSE" == "true" ]] && echo -e "${DIM}[DEBUG]${NC} $msg" ;;
+        raw)     [[ "$QUIET" == "true" ]] && return; echo -e "$msg" ;;
+        step)    [[ "$QUIET" == "true" ]] && return; echo -e "${CYAN}→${NC} $msg" ;;
+    esac
+
+    # 写入日志文件
+    if [[ -d "$(dirname "$LOG_FILE")" ]] || mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null; then
+        echo "[$timestamp] [$level] $msg" >> "$LOG_FILE" 2>/dev/null || true
+    fi
+}
+
+info()    { log info "$*"; }
+success() { log success "$*"; }
+warn()    { log warn "$*"; }
+error()   { log error "$*"; exit 1; }
+debug()   { log debug "$*"; }
+raw()     { log raw "$*"; }
+step()    { log step "$*"; }
+
+# 静默执行命令（忽略错误）
+silent_run() {
+    "$@" 2>/dev/null || true
+}
+
+# Docker Compose 封装（自动降级）
+docker_compose() {
+    if docker compose "$@" 2>/dev/null; then
+        return 0
+    elif docker-compose "$@" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# 进度指示器
+show_spinner() {
+    local pid=$1
+    local msg="$2"
+    local spin='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+    local i=0
+
+    while kill -0 $pid 2>/dev/null; do
+        i=$(( (i+1) % 10 ))
+        printf "\r${CYAN}${spin:$i:1}${NC} ${msg}..."
+        sleep 0.1
+    done
+    printf "\r"
+}
+
+# 清理函数
+cleanup() {
+    if [[ -n "$TEMP_DIR" ]] && [[ -d "$TEMP_DIR" ]] && [[ "$CLEANUP_PENDING" == "true" ]]; then
+        rm -rf "$TEMP_DIR"
+        debug "已清理临时目录: $TEMP_DIR"
+    fi
+}
+
+# 错误处理
+on_error() {
+    local exit_code=$?
+    local line_no=$1
+    echo ""
+    error "安装失败 (第 ${line_no} 行, 退出码: ${exit_code})"
+    echo ""
+    echo "  故障排除:"
+    echo "    1. 检查网络连接"
+    echo "    2. 使用 -V 查看详细日志"
+    echo "    3. 查看日志: ${LOG_FILE}"
+    echo ""
+}
+
+# 设置 trap
+setup_traps() {
+    trap cleanup EXIT
+    trap 'on_error $LINENO' ERR
+}
+
+# 检查命令是否存在
+command_exists() {
+    command -v "$1" &>/dev/null
+}
+
+# 用户确认
+confirm() {
+    local prompt="$1"
+    local default="${2:-n}"
+
+    if [[ "$INTERACTIVE" != "true" ]] || [[ ! -t 0 ]]; then
+        [[ "$default" == "y" ]] && return 0 || return 1
+    fi
+
+    local choices
+    [[ "$default" == "y" ]] && choices="[Y/n]" || choices="[y/N]"
+
+    echo -ne "${BOLD}?${NC} ${prompt} ${choices}: "
+    read -r response
+    response=${response:-$default}
+
+    [[ "$response" =~ ^[Yy] ]]
+}
+
+# 用户输入
+prompt_input() {
+    local prompt="$1"
+    local default="${2:-}"
+    local secret="${3:-false}"
+
+    if [[ "$INTERACTIVE" != "true" ]] || [[ ! -t 0 ]]; then
+        echo "$default"
+        return
+    fi
+
+    echo -ne "${BOLD}?${NC} ${prompt}"
+    [[ -n "$default" ]] && echo -ne " [${default}]"
+    echo -ne ": "
+
+    if [[ "$secret" == "true" ]]; then
+        read -rs response
+        echo
+    else
+        read -r response
+    fi
+
+    echo "${response:-$default}"
+}
+
+# ==============================================================================
+# Phase 2: 敏感信息打码
+# ==============================================================================
+
+# 打码敏感信息（Token、密码等）
+mask_token() {
+    local token="$1"
+    local visible="${2:-4}"
+
+    if [[ -z "$token" ]] || [[ ${#token} -le $((visible * 2)) ]]; then
+        echo "****"
+        return
+    fi
+
+    local prefix="${token:0:$visible}"
+    local suffix="${token: -$visible}"
+    echo "${prefix}...${suffix}"
+}
+
+# 带打码的调试日志
+debug_token() {
+    local label="$1"
+    local token="$2"
+
+    if [[ "$VERBOSE" == "true" ]]; then
+        debug "${label}: $(mask_token "$token")"
+    fi
+}
+
+# ==============================================================================
+# Phase 2: 端口冲突检测与解决
+# ==============================================================================
+
+# 检查端口是否被占用
+check_port() {
+    local port="${1:-8080}"
+
+    if command_exists lsof; then
+        silent_run lsof -ti ":${port}"
+    elif command_exists ss; then
+        silent_run ss -tlnp | grep ":${port}" | grep -oE 'pid=[0-9]+' | cut -d= -f2
+    elif command_exists netstat; then
+        silent_run netstat -tlnp | grep ":${port}" | grep -oE '[0-9]+/' | cut -d/ -f1
+    fi
+}
+
+# 解决端口冲突
+resolve_port_conflict() {
+    local port="${1:-8080}"
+    local pid
+    pid=$(check_port "$port")
+
+    if [[ -z "$pid" ]]; then
+        return 0
+    fi
+
+    warn "端口 ${port} 已被占用 (PID: $pid)"
+
+    local process_name
+    if command_exists ps; then
+        process_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")
+    fi
+
+    echo ""
+    echo -e "  ${BOLD}请选择解决方案:${NC}"
+    echo ""
+    echo "    1) 终止现有进程 (PID: $pid - $process_name)"
+    echo "    2) 使用备用端口 (${port}+1)"
+    echo "    3) 取消安装"
+    echo ""
+
+    local choice
+    choice=$(prompt_input "选择解决方案" "1")
+
+    case "$choice" in
+        1)
+            info "正在终止进程 PID $pid..."
+            if kill "$pid" 2>/dev/null; then
+                sleep 1
+                # 验证是否已终止
+                if check_port "$port" &>/dev/null; then
+                    warn "进程未能终止，尝试强制终止..."
+                    kill -9 "$pid" 2>/dev/null || true
+                    sleep 1
+                fi
+                if check_port "$port" &>/dev/null; then
+                    error "无法终止进程"
+                else
+                    success "进程已终止"
+                fi
+            else
+                sudo kill "$pid" 2>/dev/null || error "无法终止进程 (需要 sudo 权限)"
+            fi
+            HOTPLEX_PORT="$port"
+            ;;
+        2)
+            local new_port=$((port + 1))
+            while check_port "$new_port" &>/dev/null; do
+                new_port=$((new_port + 1))
+            done
+            HOTPLEX_PORT="$new_port"
+            info "将使用备用端口: ${HOTPLEX_PORT}"
+            ;;
+        3|*)
+            error "安装已取消"
+            ;;
+    esac
+
+    return 0
+}
+
+# 检查依赖
+check_dependencies() {
+    local missing=()
+    local optional_missing=()
+
+    # 必需工具
+    if ! command_exists curl && ! command_exists wget; then
+        missing+=("curl 或 wget")
+    fi
+
+    if ! command_exists tar && ! command_exists unzip; then
+        missing+=("tar 或 unzip")
+    fi
+
+    # 可选工具（用于向导）
+    command_exists jq || optional_missing+=("jq (API 验证)")
+    command_exists openssl || optional_missing+=("openssl (生成密钥)")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        error "缺少必需依赖: ${missing[*]}\n请安装后重试"
+    fi
+
+    if [[ ${#optional_missing[@]} -gt 0 ]] && [[ "$VERBOSE" == "true" ]]; then
+        warn "可选依赖未安装: ${optional_missing[*]}"
+    fi
+
+    debug "依赖检查通过"
+}
+
+# 检测操作系统
+detect_os() {
+    local os
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        CYGWIN*|MINGW*|MSYS*) os="windows" ;;
+        *) error "不支持的操作系统: $(uname -s)" ;;
+    esac
+    echo "$os"
+}
+
+# 检测架构
+detect_arch() {
+    local arch
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="amd64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *) error "不支持的架构: $(uname -m)" ;;
+    esac
+    echo "$arch"
+}
+
+# HTTP 请求
+http_get() {
+    local url="$1"
+    local output="${2:-}"
+
+    debug "HTTP GET: $url"
+
+    if command_exists curl; then
+        local curl_opts=(-fsSL --connect-timeout 30 --max-time 300)
+        [[ "$VERBOSE" == "true" ]] && curl_opts+=(-v)
+
+        if [[ -n "$output" ]]; then
+            curl "${curl_opts[@]}" -o "$output" "$url"
+        else
+            curl "${curl_opts[@]}" "$url"
+        fi
+    elif command_exists wget; then
+        local wget_opts=(-q --timeout=30)
+        [[ "$VERBOSE" == "true" ]] && wget_opts=()
+
+        if [[ -n "$output" ]]; then
+            wget "${wget_opts[@]}" -O "$output" "$url"
+        else
+            wget "${wget_opts[@]}" -O- "$url"
+        fi
+    fi
+}
+
+# 下载文件（带重试和进度）
+download_with_retry() {
+    local url="$1"
+    local output="$2"
+    local max_retries="${3:-3}"
+    local retry=0
+
+    while [[ $retry -lt $max_retries ]]; do
+        debug "下载尝试 $((retry + 1))/$max_retries: $url"
+
+        if http_get "$url" "$output"; then
+            [[ -f "$output" ]] && [[ -s "$output" ]] && return 0
+        fi
+
+        retry=$((retry + 1))
+        if [[ $retry -lt $max_retries ]]; then
+            warn "下载失败，${retry}秒后重试..."
+            sleep $retry
+        fi
+    done
+
+    error "下载失败 (重试 $max_retries 次后): $url"
+}
+
+# 获取最新版本
+get_latest_version() {
+    local version
+
+    # 方法1: GitHub API
+    if command_exists curl; then
+        version=$(curl -fsSL "${GITHUB_API}/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/v//' || true)
+        if [[ -n "$version" ]]; then
+            echo "$version"
+            return 0
+        fi
+    fi
+
+
+    # 方法2: 重定向解析（使用 http_get）
+    version=$(http_get "https://github.com/${REPO}/releases/latest" | grep -oE 'tag/v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's|tag/||' | sed 's|^v||' || true)
+    [[ -n "$version" ]] && { echo "$version"; return 0; }
+
+    # 方法3: curl 头信息
+    if command_exists curl; then
+        version=$(curl -sIo- "https://github.com/${REPO}/releases/latest" 2>/dev/null | grep -i "location:" | sed -E 's/.*\/v?([^\/]+).*/\1/' | tr -d '\r' || true)
+        [[ -n "$version" ]] && { echo "$version"; return 0; }
+    fi
+
+    return 1
+}
+
+# 获取已安装版本
+get_installed_version() {
+    local binary="${1:-${INSTALL_DIR}}/${BINARY_NAME}"
+
+    if [[ -x "$binary" ]]; then
+        "$binary" -version 2>/dev/null | head -1 | sed -E 's/v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/' || echo "unknown"
+    fi
+}
+
+# 下载校验和文件
+download_checksums() {
+    local version="$1"
+    local output="$2"
+    local url="https://github.com/${REPO}/releases/download/v${version}/SHA256SUMS"
+
+    debug "下载校验和: $url"
+    http_get "$url" "$output" 2>/dev/null || return 1
+    [[ -f "$output" ]] && [[ -s "$output" ]]
+}
+
+# 验证校验和
+verify_checksum() {
+    local archive="$1"
+    local checksums_file="$2"
+    local archive_name=$(basename "$archive")
+
+    if ! command_exists sha256sum && ! command_exists shasum; then
+        warn "无法验证校验和: 缺少 sha256sum 或 shasum"
+        return 0
+    fi
+
+    debug "验证校验和: $archive_name"
+
+    local expected checksum
+    if command_exists sha256sum; then
+        expected=$(grep "$archive_name" "$checksums_file" | awk '{print $1}')
+        checksum=$(sha256sum "$archive" | awk '{print $1}')
+    else
+        expected=$(grep "$archive_name" "$checksums_file" | awk '{print $1}')
+        checksum=$(shasum -a 256 "$archive" | awk '{print $1}')
+    fi
+
+    if [[ "$expected" == "$checksum" ]]; then
+        debug "校验和验证通过"
+        return 0
+    else
+        error "校验和验证失败!\n期望: $expected\n实际: $checksum"
+    fi
+}
+
+# 备份现有安装
+backup_existing() {
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
+
+    if [[ -f "$binary" ]]; then
+        local backup="${CONFIG_DIR}/backups/${BINARY_NAME}.$(date +%Y%m%d%H%M%S)"
+        mkdir -p "${CONFIG_DIR}/backups"
+        info "备份现有安装..."
+        cp "$binary" "$backup"
+        success "备份保存到: $backup"
+    fi
+}
+
+# 检查已安装版本
+check_existing_installation() {
+    local current_version
+    current_version=$(get_installed_version)
+
+    if [[ -n "$current_version" ]] && [[ "$current_version" != "unknown" ]]; then
+        info "检测到已安装版本: ${GREEN}$current_version${NC}"
+
+        if [[ "$FORCE" != "true" ]]; then
+            if [[ "$VERSION" == "$current_version" ]] || [[ "$VERSION" == "v${current_version}" ]]; then
+                warn "版本 $VERSION 已安装"
+                if confirm "是否强制重新安装?" "n"; then
+                    FORCE=true
+                else
+                    echo ""
+                    info "使用 ${BINARY_NAME} -version 查看版本"
+                    exit 0
+                fi
+            fi
+        fi
+    fi
+}
+
+# ==============================================================================
+# 验证函数
+# ==============================================================================
+
+# 验证 Slack Token 格式
+# 格式: xoxb-{team_id}-{app_id}-{secret} 或 xoxb-{team_id}-{secret}
+# 长度要求: >= 20 字符
+validate_slack_token() {
+    local token="$1"
+    # 放宽验证：只检查前缀和基本结构
+    [[ "$token" =~ ^xoxb-[a-zA-Z0-9_-]+$ ]] && [[ ${#token} -ge 20 ]]
+}
+
+# 验证 Slack App Token 格式
+# 格式: xapp-1-{install_id}-{secret}
+# 长度要求: >= 30 字符
+validate_slack_app_token() {
+    local token="$1"
+    # 放宽验证：检查前缀、版本号和基本结构
+    [[ "$token" =~ ^xapp-[0-9]+-[a-zA-Z0-9]+$ ]] && [[ ${#token} -ge 30 ]]
+}
+
+# 验证 Slack User ID 格式
+# 前缀: U (用户), B (Bot), W (Enterprise/Workspace 用户)
+# 长度要求: 9-15 字符
+validate_slack_user_id() {
+    local user_id="$1"
+    # 放宽验证：支持 U/B/W 前缀 + 字母数字，长度 9-15
+    [[ "$user_id" =~ ^[UBW][A-Z0-9]+$ ]] && [[ ${#user_id} -ge 9 ]] && [[ ${#user_id} -le 15 ]]
+}
+
+# 验证 GitHub Token 格式
+validate_github_token() {
+    local token="$1"
+    [[ "$token" =~ ^ghp_[a-zA-Z0-9]{36}$ ]] || [[ "$token" =~ ^github_pat_[a-zA-Z0-9_]+$ ]]
+}
+
+# 验证 Slack API 连接
+test_slack_connection() {
+    local token="$1"
+
+    if ! command_exists curl; then
+        warn "无法测试连接: 缺少 curl"
+        return 0
+    fi
+
+    debug "测试 Slack API 连接..."
+
+    local response
+    response=$(curl -fsSL -H "Authorization: Bearer $token" \
+        "https://slack.com/api/auth.test" 2>/dev/null || echo '{"ok":false}')
+
+    if echo "$response" | grep -q '"ok":true'; then
+        return 0
+    else
+        local error=$(echo "$response" | grep -oE '"error"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "unknown")
+        debug "Slack API 错误: $error"
+        return 1
+    fi
+}
+
+# ==============================================================================
+# 核心功能
+# ==============================================================================
+
+# 帮助信息
+show_help() {
+    cat << 'EOF'
+HotPlex 一键安装脚本 v2.1
+
+用法:
+  curl -sL https://raw.githubusercontent.com/hrygo/hotplex/main/install.sh | bash
+  install.sh [命令] [选项]
+
+命令:
+  (无命令)             交互式菜单 (默认)
+  install              安装 HotPlex (默认，二进制模式)
+  docker               安装 HotPlex (Docker 模式)
+  upgrade              升级 HotPlex (保留配置)
+  status               查看状态
+  uninstall            卸载 HotPlex (保留配置)
+  purge                完全清理 (删除所有数据)
+  config               仅运行配置向导
+
+选项:
+  -v, --version VERSION  指定安装版本 (默认: 最新版本)
+  -d, --dir DIR          安装目录 (默认: /usr/local/bin)
+  -m, --mode MODE        安装模式: binary(默认) 或 docker
+  -c, --config           仅运行配置向导
+  -u, --uninstall        卸载 HotPlex
+      --upgrade          升级 HotPlex
+      --status           查看状态
+      --purge            完全清理
+  -f, --force            强制重新安装
+  -n, --dry-run          干运行模式，显示将执行的操作
+  -q, --quiet            静默模式
+  -V, --verbose          详细输出
+  --skip-verify          跳过校验和验证
+  --skip-health-check    跳过健康检查
+  --skip-autostart       跳过开机自启配置
+  --skip-wizard          跳过安装后配置向导
+  --non-interactive      非交互模式
+  -h, --help             显示帮助信息
+  --version              显示脚本版本
+
+示例:
+  install.sh                     # 交互式菜单
+  install.sh install             # 安装最新版本 + 配置向导
+  install.sh -v v0.21.0          # 安装指定版本
+  install.sh -m docker           # Docker 模式安装
+  install.sh upgrade             # 升级到最新版本
+  install.sh status              # 查看状态
+  install.sh uninstall           # 卸载
+  install.sh purge               # 完全清理
+  install.sh config              # 仅运行配置向导
+
+环境变量:
+  NO_COLOR=true                  禁用颜色输出
+
+更多信息: https://github.com/hrygo/hotplex/blob/main/INSTALL.md
+EOF
+    exit 0
+}
+
+# 显示版本
+show_version() {
+    echo "HotPlex 安装脚本 v${SCRIPT_VERSION}"
+    exit 0
+}
+
+# 解析参数
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -v|--version)         VERSION="$2"; shift 2 ;;
+            -d|--dir)             INSTALL_DIR="$2"; shift 2 ;;
+            -m|--mode)            INSTALL_MODE="$2"; shift 2 ;;
+            -c|--config)          CONFIG_ONLY=true; shift ;;
+            -u|--uninstall)       UNINSTALL=true; shift ;;
+            --upgrade)            DO_UPGRADE=true; shift ;;
+            --status)             DO_STATUS=true; shift ;;
+            --purge)              DO_PURGE=true; shift ;;
+            -f|--force)           FORCE=true; shift ;;
+            -n|--dry-run)         DRY_RUN=true; shift ;;
+            -q|--quiet)           QUIET=true; shift ;;
+            -V|--verbose)         VERBOSE=true; shift ;;
+            --skip-verify)        SKIP_VERIFY=true; shift ;;
+            --skip-health-check)  SKIP_HEALTH_CHECK=true; shift ;;
+            --skip-autostart)     SKIP_AUTOSTART=true; shift ;;
+            --skip-wizard)        SKIP_WIZARD=true; shift ;;
+            --non-interactive)   INTERACTIVE=false; shift ;;
+            -h|--help)            show_help ;;
+            --version)            show_version ;;
+            -*)                   error "未知选项: $1\n使用 -h 查看帮助" ;;
+            *)                    break ;;
+        esac
+    done
+
+    # 设置默认值
+    INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+    # 冲突检查
+    [[ "$QUIET" == "true" ]] && [[ "$VERBOSE" == "true" ]] && warn "同时设置了 -q 和 -V，忽略 -q" || true
+
+    # 模式验证
+    case "$INSTALL_MODE" in
+        binary|docker) ;;
+        *) error "无效安装模式: $INSTALL_MODE (支持: binary, docker)" ;;
+    esac
+}
+
+# 卸载
+do_uninstall() {
+    info "卸载 HotPlex..."
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
+
+    if [[ ! -f "$binary" ]]; then
+        warn "HotPlex 未安装在 $binary"
+        exit 0
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] 将删除: $binary"
+        return
+    fi
+
+    # 检查是否在运行
+    if pgrep -x "$BINARY_NAME" &>/dev/null; then
+        warn "HotPlex 正在运行"
+        if confirm "是否停止并卸载?" "y"; then
+            pkill -x "$BINARY_NAME" 2>/dev/null || true
+            sleep 1
+        else
+            exit 1
+        fi
+    fi
+
+    if [[ -w "$INSTALL_DIR" ]]; then
+        rm -f "$binary"
+    else
+        sudo rm -f "$binary"
+    fi
+
+    success "已删除: $binary"
+
+    # 清理备份
+    local backups="${CONFIG_DIR}/backups"
+    if [[ -d "$backups" ]]; then
+        local count=$(find "$backups" -name "${BINARY_NAME}.*" 2>/dev/null | wc -l)
+        if [[ $count -gt 0 ]]; then
+            info "发现 $count 个备份文件"
+            if confirm "是否删除备份?" "n"; then
+                rm -rf "$backups"
+                success "已删除备份"
+            fi
+        fi
+    fi
+
+    if [[ -d "$CONFIG_DIR" ]]; then
+        echo ""
+        info "配置目录: $CONFIG_DIR"
+        if confirm "是否删除配置目录?" "n"; then
+            rm -rf "$CONFIG_DIR"
+            success "已删除配置目录"
+        fi
+    fi
+
+    success "卸载完成"
+}
+
+# ==============================================================================
+# Phase 3: 升级功能
+# ==============================================================================
+
+do_upgrade() {
+    info "升级 HotPlex..."
+
+    local os arch current_version
+    os=$(detect_os)
+    arch=$(detect_arch)
+    current_version=$(get_installed_version "${INSTALL_DIR}/${BINARY_NAME}")
+
+    if [[ -z "$current_version" ]] || [[ "$current_version" == "unknown" ]]; then
+        error "未检测到已安装的 HotPlex，请先运行安装"
+    fi
+
+    info "当前版本: ${GREEN}${current_version}${NC}"
+
+    # 获取目标版本
+    if [[ -z "$VERSION" ]]; then
+        step "获取最新版本..."
+        VERSION=$(get_latest_version) || error "无法获取最新版本，请使用 -v 指定"
+        [[ "$VERSION" != v* ]] && VERSION="v${VERSION}"
+    fi
+
+    local target_version="${VERSION#v}"
+    if [[ "$current_version" == "$target_version" ]]; then
+        success "已是最新版本 (${current_version})"
+        exit 0
+    fi
+
+    info "目标版本: ${GREEN}${target_version}${NC}"
+
+    # 确认升级
+    if [[ "$INTERACTIVE" == "true" ]] && [[ -t 0 ]]; then
+        if ! confirm "是否升级?" "y"; then
+            info "升级已取消"
+            exit 0
+        fi
+    fi
+
+    # 下载新版本
+    local archive_name="hotplex_${target_version}_${os}_${arch}"
+    [[ "$os" == "windows" ]] && archive_name="${archive_name}.zip" || archive_name="${archive_name}.tar.gz"
+    local archive_url="https://github.com/${REPO}/releases/download/v${target_version}/${archive_name}"
+
+    TEMP_DIR=$(mktemp -d)
+    local archive_path="${TEMP_DIR}/${archive_name}"
+
+    step "正在下载 v${target_version}..."
+    download_with_retry "$archive_url" "$archive_path"
+
+    # 校验
+    if [[ "$SKIP_VERIFY" != "true" ]]; then
+        local checksums_path="${TEMP_DIR}/checksums.txt"
+        if download_checksums "${target_version}" "$checksums_path"; then
+            step "验证校验和..."
+            verify_checksum "$archive_path" "$checksums_path"
+        else
+            warn "无法下载校验和文件，跳过验证"
+        fi
+    fi
+
+    # 停止现有服务
+    step "停止现有服务..."
+    if pgrep -f "$BINARY_NAME" &>/dev/null; then
+        pkill -f "$BINARY_NAME" 2>/dev/null || sudo pkill -f "$BINARY_NAME"
+        sleep 1
+    fi
+
+    # 解压
+    step "正在解压..."
+    if [[ "$os" == "windows" ]]; then
+        unzip -q "$archive_path" -d "$TEMP_DIR"
+    else
+        tar -xzf "$archive_path" -C "$TEMP_DIR"
+    fi
+
+    # 替换二进制
+    step "正在更新二进制..."
+    local binary_path="${TEMP_DIR}/${BINARY_NAME}"
+
+    if [[ -w "$INSTALL_DIR" ]]; then
+        cp "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+        chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        sudo cp "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+        sudo chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    # 验证
+    local new_version
+    new_version=$("${INSTALL_DIR}/${BINARY_NAME}" -version 2>/dev/null | head -1 || echo "unknown")
+    success "升级完成: ${GREEN}${new_version}${NC}"
+
+    # 重启服务
+    step "重启服务..."
+    if [[ "${SKIP_AUTOSTART:-false}" != "true" ]]; then
+        install_autostart
+    fi
+
+    # 健康检查
+    if [[ "${SKIP_HEALTH_CHECK:-false}" != "true" ]]; then
+        health_check || true
+    fi
+
+    CLEANUP_PENDING=false
+}
+
+# ==============================================================================
+# Phase 3: 状态检查
+# ==============================================================================
+
+do_status() {
+    info "检查 HotPlex 状态..."
+    echo ""
+
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
+
+    # 1. 检查二进制
+    echo -e "  ${BOLD}二进制文件:${NC}"
+    if [[ -x "$binary" ]]; then
+        local installed_version
+        installed_version=$("$binary" -version 2>/dev/null | head -1 || echo "unknown")
+        echo -e "    ${GREEN}✓${NC} 已安装: $installed_version"
+        echo -e "    ${DIM}   路径: ${INSTALL_DIR}/${BINARY_NAME}${NC}"
+    else
+        echo -e "    ${RED}✗${NC} 未安装或不可执行"
+    fi
+
+    # 2. 检查配置文件
+    echo ""
+    echo -e "  ${BOLD}配置文件:${NC}"
+    local env_file="${CONFIG_DIR}/.env"
+    if [[ -f "$env_file" ]]; then
+        echo -e "    ${GREEN}✓${NC} 已配置: $env_file"
+
+        # 显示关键配置（打码）
+        local bot_token app_token
+        bot_token=$(grep "^HOTPLEX_SLACK_BOT_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+        app_token=$(grep "^HOTPLEX_SLACK_APP_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+        local port
+        port=$(grep "^HOTPLEX_PORT=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "8080")
+
+        echo -e "    ${DIM}   Bot Token:  ${GREEN}$(mask_token "$bot_token" 8)${NC}"
+        echo -e "    ${DIM}   App Token:  ${GREEN}$(mask_token "$app_token" 8)${NC}"
+        echo -e "    ${DIM}   端口:      ${GREEN}${port}${NC}"
+    else
+        echo -e "    ${YELLOW}○${NC} 未配置 (运行安装)"
+    fi
+
+    # 3. 检查进程
+    echo ""
+    echo -e "  ${BOLD}运行状态:${NC}"
+    local pid
+    pid=$(pgrep -f "$BINARY_NAME" 2>/dev/null | head -1 || true)
+    if [[ -n "$pid" ]]; then
+        echo -e "    ${GREEN}✓${NC} 运行中 (PID: $pid)"
+
+        # 内存使用
+        if command_exists ps; then
+            local mem
+            mem=$(ps -p "$pid" -o rss= 2>/dev/null | tr -d ' ' || echo "unknown")
+            if [[ "$mem" != "unknown" ]]; then
+                echo -e "    ${DIM}   内存: $((mem / 1024)) MB${NC}"
+            fi
+        fi
+
+        # 健康检查
+        local port="${HOTPLEX_PORT:-8080}"
+        local endpoint="http://localhost:${port}/health"
+        if command_exists curl; then
+            if curl -sf --connect-timeout 2 --max-time 5 "$endpoint" 2>/dev/null | grep -q "ok\|OK\|healthy"; then
+                echo -e "    ${GREEN}✓${NC} 健康检查: 通过"
+            else
+                echo -e "    ${YELLOW}○${NC} 健康检查: 未通过 (服务可能仍在启动)"
+            fi
+        fi
+    else
+        echo -e "    ${YELLOW}○${NC} 未运行"
+    fi
+
+    # 4. 检查开机自启
+    echo ""
+    echo -e "  ${BOLD}开机自启:${NC}"
+    local init_system
+    init_system=$(detect_init_system)
+    case "$init_system" in
+        systemd)
+            if systemctl is-enabled "${BINARY_NAME}.service" &>/dev/null; then
+                echo -e "    ${GREEN}✓${NC} systemd 服务已启用"
+            else
+                echo -e "    ${YELLOW}○${NC} systemd 服务未启用"
+            fi
+            ;;
+        launchd)
+            if launchctl list | grep -q "com.hotplex.daemon"; then
+                echo -e "    ${GREEN}✓${NC} launchd 服务已启用"
+            else
+                echo -e "    ${YELLOW}○${NC} launchd 服务未启用"
+            fi
+            ;;
+        *)
+            echo -e "    ${YELLOW}○${NC} 不支持的开机自启系统"
+            ;;
+    esac
+
+    # 5. 备份信息
+    local backups="${CONFIG_DIR}/backups"
+    if [[ -d "$backups" ]]; then
+        local backup_count
+        backup_count=$(find "$backups" -name "${BINARY_NAME}.*" 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+        if [[ "$backup_count" -gt 0 ]]; then
+            echo ""
+            echo -e "  ${BOLD}备份:${NC}"
+            echo -e "    ${GREEN}✓${NC} 备份文件: $backup_count 个 (${backups})"
+        fi
+    fi
+
+    echo ""
+}
+
+# ==============================================================================
+# Phase 3: 清理功能 (完全清理)
+# ==============================================================================
+
+do_purge() {
+    info "完全清理 HotPlex..."
+
+    # 检查是否安装
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
+    if [[ ! -f "$binary" ]] && [[ ! -d "$CONFIG_DIR" ]]; then
+        warn "HotPlex 未安装，无需清理"
+        exit 0
+    fi
+
+    # 确认危险操作
+    if [[ "$INTERACTIVE" == "true" ]] && [[ -t 0 ]]; then
+        echo ""
+        raw "${RED}${BOLD}⚠️  警告: 此操作将删除所有数据!${NC}"
+        echo ""
+        echo "  将删除:"
+        echo "    • 二进制文件: ${INSTALL_DIR}/${BINARY_NAME}"
+        echo "    • 配置目录: ${CONFIG_DIR}"
+        echo "    • 所有备份"
+        echo "    • 开机自启服务"
+        echo ""
+        if ! confirm "确认完全清理?" "n"; then
+            info "清理已取消"
+            exit 0
+        fi
+    fi
+
+    # 停止服务
+    step "停止服务..."
+    if pgrep -f "$BINARY_NAME" &>/dev/null; then
+        pkill -f "$BINARY_NAME" 2>/dev/null || sudo pkill -f "$BINARY_NAME"
+        sleep 1
+    fi
+
+    # 移除 systemd 服务
+    if [[ -f "/etc/systemd/system/${BINARY_NAME}.service" ]]; then
+        step "移除 systemd 服务..."
+        sudo systemctl stop "${BINARY_NAME}.service" 2>/dev/null || true
+        sudo systemctl disable "${BINARY_NAME}.service" 2>/dev/null || true
+        sudo rm -f "/etc/systemd/system/${BINARY_NAME}.service"
+        sudo systemctl daemon-reload
+    fi
+
+    # 移除 launchd 服务
+    local plist_file="${HOME}/Library/LaunchAgents/com.hotplex.daemon.plist"
+    if [[ -f "$plist_file" ]]; then
+        step "移除 launchd 服务..."
+        launchctl unload "$plist_file" 2>/dev/null || true
+        rm -f "$plist_file"
+    fi
+
+    # 删除二进制
+    step "删除二进制..."
+    if [[ -f "$binary" ]]; then
+        if [[ -w "$INSTALL_DIR" ]]; then
+            rm -f "$binary"
+        else
+            sudo rm -f "$binary"
+        fi
+        success "已删除: $binary"
+    fi
+
+    # 删除配置目录（递归删除所有数据）
+    if [[ -d "$CONFIG_DIR" ]]; then
+        step "删除配置目录..."
+        rm -rf "$CONFIG_DIR"
+        success "已删除: $CONFIG_DIR"
+    fi
+
+    success "完全清理完成"
+}
+
+# ==============================================================================
+# 配置向导
+# ==============================================================================
+
+# 向导：配置 Slack Bot 凭据
+wizard_slack_credentials() {
+    local env_file="${CONFIG_DIR}/.env"
+
+    echo ""
+    raw "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    raw "${BOLD}  Step 1/2: Slack 凭据配置${NC}"
+    raw "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    if [[ ! -f "$env_file" ]]; then
+        warn "配置文件不存在，请先运行安装"
+        return 1
+    fi
+
+    # 读取当前配置
+    local current_bot_token=$(grep "^HOTPLEX_SLACK_BOT_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+    local current_app_token=$(grep "^HOTPLEX_SLACK_APP_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+    local current_user_id=$(grep "^HOTPLEX_SLACK_BOT_USER_ID=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+    local current_github=$(grep "^GITHUB_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+
+    # 检查配置状态
+    local has_valid_slack=false
+    [[ "$current_bot_token" =~ ^xoxb- ]] && has_valid_slack=true
+
+    echo -e "  ${BOLD}当前配置状态:${NC}"
+    echo ""
+    echo -e "    Slack Bot Token:    $([[ "$current_bot_token" =~ ^xoxb- ]] && echo "${GREEN}✓ 已配置${NC}" || echo "${YELLOW}○ 未配置${NC}")"
+    echo -e "    Slack App Token:    $([[ "$current_app_token" =~ ^xapp- ]] && echo "${GREEN}✓ 已配置${NC}" || echo "${YELLOW}○ 未配置${NC}")"
+    echo -e "    Slack Bot User ID:  $([[ "$current_user_id" =~ ^[UBW][A-Z0-9]+$ ]] && echo "${GREEN}✓ 已配置${NC}" || echo "${YELLOW}○ 未配置${NC}")"
+    echo -e "    GitHub Token:       $([[ "$current_github" =~ ^ghp_ ]] && echo "${GREEN}✓ 已配置${NC}" || echo "${YELLOW}○ 未配置${NC}")"
+    echo ""
+
+    # 如果都已配置，询问是否重新配置
+    if [[ "$has_valid_slack" == "true" ]]; then
+        if ! confirm "是否重新配置 Slack?" "n"; then
+            success "Slack 配置保持不变"
+            return 0
+        fi
+    fi
+
+    echo -e "  ${BOLD}${CYAN}如何获取 Slack 凭据:${NC}"
+    echo ""
+    echo -e "  ${DIM}1. 访问${NC} ${UNDERLINE}https://api.slack.com/apps${NC}"
+    echo -e "  ${DIM}2. 创建新 App 或选择现有 App${NC}"
+    echo -e "  ${DIM}3. 启用 Socket Mode (推荐)${NC}"
+    echo ""
+
+    # 交互式配置
+    if [[ "$INTERACTIVE" == "true" ]] && [[ -t 0 ]]; then
+        local bot_token app_token user_id github_token
+        local updated=false
+
+        # Bot Token
+        echo -e "${CYAN}Bot User OAuth Token (xoxb-...)${NC}"
+        echo -e "  ${DIM}→ OAuth & Permissions → Bot User OAuth Token${NC}"
+        bot_token=$(prompt_input "请输入" "$current_bot_token" "true")
+
+        if [[ -n "$bot_token" ]]; then
+            if validate_slack_token "$bot_token"; then
+                # 测试连接
+                step "验证 Token..."
+                if test_slack_connection "$bot_token"; then
+                    success "Token 验证成功"
+                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file"
+                    updated=true
+                else
+                    warn "Token 验证失败，但仍会保存"
+                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file"
+                    updated=true
+                fi
+            else
+                warn "Token 格式无效 (应为 xoxb-...)"
+            fi
+        fi
+
+        # App Token
+        echo ""
+        echo -e "${CYAN}App-Level Token (xapp-...)${NC}"
+        echo -e "  ${DIM}→ Basic Information → App-Level Tokens${NC}"
+        app_token=$(prompt_input "请输入" "$current_app_token" "true")
+
+        if [[ -n "$app_token" ]]; then
+            if validate_slack_app_token "$app_token"; then
+                sed -i.bak "s|^HOTPLEX_SLACK_APP_TOKEN=.*|HOTPLEX_SLACK_APP_TOKEN=${app_token}|" "$env_file"
+                updated=true
+            else
+                warn "Token 格式无效 (应为 xapp-...)"
+            fi
+        fi
+
+        # Bot User ID
+        echo ""
+        echo -e "${CYAN}Bot User ID (U... 或 B... 或 W...)${NC}"
+        echo -e "  ${DIM}→ 点击机器人头像，查看 Member ID${NC}"
+        echo -e "  ${DIM}  U=用户 B=Bot W=企业用户${NC}"
+        user_id=$(prompt_input "请输入" "$current_user_id")
+
+        if [[ -n "$user_id" ]]; then
+            if validate_slack_user_id "$user_id"; then
+                sed -i.bak "s|^HOTPLEX_SLACK_BOT_USER_ID=.*|HOTPLEX_SLACK_BOT_USER_ID=${user_id}|" "$env_file"
+                updated=true
+            else
+                warn "User ID 格式无效 (应以 U、B 或 W 开头)"
+            fi
+        fi
+
+        # GitHub Token
+        echo ""
+        if confirm "是否配置 GitHub Token?" "$([[ "$current_github" =~ ^ghp_ ]] && echo "n" || echo "y")"; then
+            echo -e "${CYAN}GitHub Personal Access Token (ghp_...)${NC}"
+            echo -e "  ${DIM}→ https://github.com/settings/tokens${NC}"
+            github_token=$(prompt_input "请输入" "$current_github" "true")
+
+            if [[ -n "$github_token" ]]; then
+                if validate_github_token "$github_token"; then
+                    sed -i.bak "s|^GITHUB_TOKEN=.*|GITHUB_TOKEN=${github_token}|" "$env_file"
+                    updated=true
+                else
+                    warn "Token 格式无效 (应为 ghp_...)"
+                fi
+            fi
+        fi
+
+        # 清理备份
+        rm -f "${env_file}.bak"
+
+        if [[ "$updated" == "true" ]]; then
+            success "配置已更新: $env_file"
+        fi
+    else
+        # 非交互模式，显示指南
+        echo -e "  ${BOLD}请手动编辑配置文件:${NC}"
+        echo "    ${CONFIG_DIR}/.env"
+        echo ""
+    fi
+}
+
+# 向导：配置 Slack YAML
+wizard_slack_yaml() {
+    local yaml_file="${CONFIG_DIR}/slack.yaml"
+    local yaml_source=""
+
+    # 查找源配置文件
+    if [[ -f "${INSTALL_DIR}/../configs/chatapps/slack.yaml" ]]; then
+        yaml_source="${INSTALL_DIR}/../configs/chatapps/slack.yaml"
+    elif [[ -f "/usr/local/share/hotplex/configs/chatapps/slack.yaml" ]]; then
+        yaml_source="/usr/local/share/hotplex/configs/chatapps/slack.yaml"
+    fi
+
+    echo ""
+    raw "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    raw "${BOLD}  Step 2/2: ChatApps 行为配置${NC}"
+    raw "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    # 复制默认配置（如果不存在）
+    if [[ ! -f "$yaml_file" ]]; then
+        if [[ -n "$yaml_source" ]] && [[ -f "$yaml_source" ]]; then
+            mkdir -p "$(dirname "$yaml_file")"
+            cp "$yaml_source" "$yaml_file"
+            success "已创建配置文件: $yaml_file"
+        else
+            # 生成默认配置
+            generate_slack_yaml "$yaml_file"
+        fi
+    else
+        success "配置文件已存在: $yaml_file"
+    fi
+
+    echo ""
+    echo -e "  ${BOLD}${CYAN}ChatApps 配置选项:${NC}"
+    echo ""
+
+    # 读取当前配置
+    local current_work_dir=$(grep -E "^  work_dir:" "$yaml_file" 2>/dev/null | awk '{print $2}' || echo "~/projects")
+    local current_mode=$(grep "^mode:" "$yaml_file" 2>/dev/null | awk '{print $2}' || echo "socket")
+    local current_group_policy=$(grep -E "    group_policy:" "$yaml_file" 2>/dev/null | awk '{print $2}' || echo "multibot")
+    local current_model=$(grep -E "  default_model:" "$yaml_file" 2>/dev/null | awk '{print $2}' || echo "sonnet")
+
+    echo -e "  ${DIM}当前设置:${NC}"
+    echo -e "    工作目录:     ${GREEN}$current_work_dir${NC}"
+    echo -e "    连接模式:     ${GREEN}$current_mode${NC}"
+    echo -e "    群组策略:     ${GREEN}$current_group_policy${NC}"
+    echo -e "    AI 模型:      ${GREEN}$current_model${NC}"
+    echo ""
+
+    if ! confirm "是否修改 ChatApps 配置?" "n"; then
+        return 0
+    fi
+
+    # 工作目录
+    echo ""
+    echo -e "  ${DIM}工作目录 (work_dir)${NC}"
+    echo -e "  ${DIM}Agent 执行代码的工作空间${NC}"
+    local work_dir
+    work_dir=$(prompt_input "请输入路径" "$current_work_dir")
+    if [[ -n "$work_dir" ]] && [[ "$work_dir" != "$current_work_dir" ]]; then
+        sed -i.bak "s|  work_dir:.*|  work_dir: ${work_dir}|" "$yaml_file"
+        # 确保目录存在
+        mkdir -p "$work_dir" 2>/dev/null || true
+    fi
+
+    # 连接模式
+    echo ""
+    echo -e "${CYAN}连接模式 (mode)${NC}"
+    echo -e "  ${DIM}socket${NC} - 本地开发，无需公网 IP (推荐)"
+    echo -e "  ${DIM}http${NC}   - 生产环境，使用 Webhook"
+    echo ""
+    local mode
+    if confirm "使用 Socket Mode?" "y"; then
+        mode="socket"
+    else
+        mode="http"
+    fi
+    if [[ "$mode" != "$current_mode" ]]; then
+        sed -i.bak "s/^mode:.*/mode: ${mode}/" "$yaml_file"
+    fi
+
+    # 群组策略
+    echo ""
+    echo -e "${CYAN}群组响应策略 (group_policy)${NC}"
+    echo -e "  ${DIM}allow${NC}     - 响应所有消息"
+    echo -e "  ${DIM}mention${NC}   - 仅 @提及 时响应"
+    echo -e "  ${DIM}multibot${NC}  - 多 Bot 模式，@提及时响应，无 @ 时广播提示"
+    echo ""
+    echo "  选择群组策略:"
+    echo "    1) allow"
+    echo "    2) mention"
+    echo "    3) multibot (默认)"
+    local policy_choice
+    policy_choice=$(prompt_input "请选择 [1-3]" "3")
+    local group_policy="multibot"
+    case "$policy_choice" in
+        1) group_policy="allow" ;;
+        2) group_policy="mention" ;;
+        3) group_policy="multibot" ;;
+    esac
+    if [[ "$group_policy" != "$current_group_policy" ]]; then
+        sed -i.bak "s/    group_policy:.*/    group_policy: ${group_policy}/" "$yaml_file"
+    fi
+
+    # AI 模型
+    echo ""
+    echo -e "${CYAN}AI 模型 (default_model)${NC}"
+    echo -e "  ${DIM}sonnet${NC} - 平衡性能与成本 (推荐)"
+    echo -e "  ${DIM}haiku${NC}  - 快速响应，低成本"
+    echo -e "  ${DIM}opus${NC}   - 最强性能，较高成本"
+    echo ""
+    echo "  选择 AI 模型:"
+    echo "    1) sonnet (默认)"
+    echo "    2) haiku"
+    echo "    3) opus"
+    local model_choice
+    model_choice=$(prompt_input "请选择 [1-3]" "1")
+    local model="sonnet"
+    case "$model_choice" in
+        1) model="sonnet" ;;
+        2) model="haiku" ;;
+        3) model="opus" ;;
+    esac
+    if [[ "$model" != "$current_model" ]]; then
+        sed -i.bak "s/  default_model:.*/  default_model: ${model}/" "$yaml_file"
+    fi
+
+    # 清理备份
+    rm -f "${yaml_file}.bak"
+
+    echo ""
+    success "ChatApps 配置已更新"
+    echo ""
+    echo -e "  ${DIM}完整配置文件: ${yaml_file}${NC}"
+    echo -e "  ${DIM}配置文档: https://github.com/hrygo/hotplex/blob/main/docs/chatapps/chatapps-slack.md${NC}"
+}
+
+# 生成默认 Slack YAML 配置
+generate_slack_yaml() {
+    local yaml_file="$1"
+    local work_dir="${HOME}/projects"
+
+    mkdir -p "$(dirname "$yaml_file")"
+
+    cat > "$yaml_file" << 'EOF'
+# =============================================================================
+# HotPlex Slack Adapter Configuration
+# 由安装向导生成
+# =============================================================================
+
+platform: slack
+
+# AI Provider
+provider:
+  type: claude-code
+  enabled: true
+  default_model: sonnet
+  default_permission_mode: bypass-permissions
+  dangerously_skip_permissions: true
+
+# Engine
+engine:
+  work_dir: ~/projects
+  timeout: 30m
+  idle_timeout: 1h
+
+# Session
+session:
+  timeout: 1h
+  cleanup_interval: 5m
+
+# Connection
+mode: socket
+server_addr: :8080
+
+# AI Identity
+system_prompt: |
+  You are HotPlex, an expert software engineer in a Slack conversation.
+
+  ## Environment
+  - Running under HotPlex engine (stdin/stdout)
+  - Headless mode - cannot prompt for user input
+
+  ## Slack Context
+  - Replies go to thread automatically
+  - Keep answers concise - user expects quick responses
+
+  ## Output
+  - Be concise - short messages preferred
+  - Use bullet lists over paragraphs
+  - Use code blocks for code snippets
+  - Avoid tables - use lists instead
+
+task_instructions: |
+  1. Understand before acting
+  2. Avoid operations requiring user input
+  3. Summarize tool output - don't dump raw data
+
+# Features
+features:
+  chunking:
+    enabled: true
+    max_chars: 4000
+  threading:
+    enabled: true
+  rate_limit:
+    enabled: true
+    max_attempts: 3
+    base_delay_ms: 500
+    max_delay_ms: 5000
+  markdown:
+    enabled: true
+
+# Security
+security:
+  verify_signature: true
+  permission:
+    dm_policy: allow
+    group_policy: multibot
+    bot_user_id: ${HOTPLEX_SLACK_BOT_USER_ID}
+    broadcast_response: |
+      👋 Hello! I'm ready to help.
+      Please @mention me if you'd like me to respond specifically to you.
+    allowed_users: []
+    blocked_users: []
+    slash_command_rate_limit: 10.0
+EOF
+
+    # 替换工作目录
+    sed -i.bak "s|  work_dir: ~/projects|  work_dir: ${work_dir}|" "$yaml_file"
+    rm -f "${yaml_file}.bak"
+
+    success "已生成配置文件: $yaml_file"
+}
+
+# 运行安装向导
+run_setup_wizard() {
+    # 检查是否跳过向导
+    if [[ "$SKIP_WIZARD" == "true" ]]; then
+        debug "跳过配置向导"
+        show_quick_start
+        return 0
+    fi
+
+    # 检查是否是非交互模式
+    if [[ ! -t 0 ]] || [[ "$QUIET" == "true" ]] || [[ "$DRY_RUN" == "true" ]]; then
+        debug "非交互模式，跳过向导"
+        return 0
+    fi
+
+    # 显示向导标题
+    echo ""
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+    raw "${BOLD}                    🧙 配置向导                              ${NC}"
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+
+    wizard_slack_credentials
+    wizard_slack_yaml
+
+    # 完成提示
+    echo ""
+    raw "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    raw "${BOLD}  ✓ 配置完成${NC}"
+    raw "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    show_quick_start
+}
+
+# 显示快速开始指南
+show_quick_start() {
+    echo ""
+    raw "${GREEN}${BOLD}🎉 HotPlex 安装成功!${NC}"
+    echo ""
+    echo -e "  ${BOLD}快速开始:${NC}"
+    echo ""
+    echo "    1. 编辑配置 (如需要):"
+    echo -e "       ${DIM}${CONFIG_DIR}/.env${NC}"
+    echo ""
+    echo "    2. 启动服务:"
+    echo -e "       ${GREEN}${BINARY_NAME} -env ${CONFIG_DIR}/.env${NC}"
+    echo ""
+    echo "    3. 查看帮助:"
+    echo -e "       ${DIM}${BINARY_NAME} -h${NC}"
+    echo ""
+    echo -e "  ${DIM}文档: https://github.com/hrygo/hotplex#readme${NC}"
+    echo -e "  ${DIM}问题: https://github.com/hrygo/hotplex/issues${NC}"
+    echo ""
+}
+
+# 生成配置文件
+generate_config() {
+    info "生成配置文件..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] 将创建: ${CONFIG_DIR}/.env"
+        return
+    fi
+
+    mkdir -p "$CONFIG_DIR"
+    mkdir -p "${CONFIG_DIR}/projects"
+    mkdir -p "${CONFIG_DIR}/backups"
+
+    local env_file="${CONFIG_DIR}/.env"
+
+    if [[ -f "$env_file" ]] && [[ "$FORCE" != "true" ]]; then
+        warn "配置文件已存在: $env_file"
+        if ! confirm "是否覆盖?" "n"; then
+            return
+        fi
+    fi
+
+    # 备份现有配置
+    if [[ -f "$env_file" ]]; then
+        cp "$env_file" "${env_file}.bak.$(date +%Y%m%d%H%M%S)"
+    fi
+
+    # 生成随机 API Key
+    local api_key
+    if command_exists openssl; then
+        api_key=$(openssl rand -hex 32)
+    else
+        api_key="change-me-$(date +%s)-$$"
+    fi
+
+    local config_content="# ==============================================================================
+# HotPlex 环境配置
+# 生成时间: $(date '+%Y-%m-%d %H:%M:%S %z')
+# 完整配置参考: https://github.com/hrygo/hotplex/blob/main/.env.example
+# ==============================================================================
+
+# 核心服务器
+HOTPLEX_PORT=\${HOTPLEX_PORT:-8080}
+HOTPLEX_LOG_LEVEL=INFO
+HOTPLEX_LOG_FORMAT=text
+HOTPLEX_API_KEY=\${api_key}
+HOTPLEX_DATA_DIR=\${CONFIG_DIR}
+
+# Provider 配置
+HOTPLEX_PROVIDER_TYPE=claude-code
+HOTPLEX_PROVIDER_MODEL=sonnet
+
+# Slack Bot 配置 (必填 - P0 安全验证)
+HOTPLEX_SLACK_BOT_USER_ID=\${SLACK_BOT_USER_ID:-UXXXXXXXXXX}
+HOTPLEX_SLACK_BOT_TOKEN=\${SLACK_BOT_TOKEN:-xoxb-}
+HOTPLEX_SLACK_APP_TOKEN=\${SLACK_APP_TOKEN:-xapp-}
+
+# 消息存储
+HOTPLEX_MESSAGE_STORE_ENABLED=true
+HOTPLEX_MESSAGE_STORE_TYPE=sqlite
+HOTPLEX_MESSAGE_STORE_SQLITE_PATH=\${CONFIG_DIR}/chatapp_messages.db
+
+# GitHub Token (用于 Git 操作)
+GITHUB_TOKEN=
+"
+
+    atomic_install_config "$config_content"
+    success "已生成配置文件: $env_file"
+}
+
+# ==============================================================================
+# 健康检查 (P0)
+# ==============================================================================
+
+health_check() {
+    local port="${HOTPLEX_PORT:-8080}"
+    local timeout="${2:-15}"
+    local elapsed=0
+
+    step "执行健康检查 (超时: ${timeout}s)..."
+
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
+    if [[ ! -x "$binary" ]]; then
+        error "健康检查失败: 二进制文件不可执行"
+        return 1
+    fi
+
+    if pgrep -f "$BINARY_NAME" &>/dev/null; then
+        debug "进程检查: 已有运行实例"
+    fi
+
+    local endpoint="http://localhost:${port}/health"
+
+    while [[ $elapsed -lt $timeout ]]; do
+        local start_time=$(date +%s)
+
+        if command_exists curl; then
+            local response
+            response=$(curl -sf --connect-timeout 2 --max-time 5 "$endpoint" 2>/dev/null || echo "")
+
+            if [[ -n "$response" ]] && echo "$response" | grep -q "ok\|OK\|healthy"; then
+                success "健康检查通过"
+                return 0
+            fi
+        fi
+
+        local now=$(date +%s)
+        elapsed=$((now - start_time + elapsed))
+        [[ $elapsed -lt $timeout ]] && sleep 1
+    done
+
+    warn "健康检查超时 (${timeout}s) - 服务可能仍在启动"
+    return 1
+}
+
+# ==============================================================================
+# 开机自启 (P0)
+# ==============================================================================
+
+detect_init_system() {
+    if command_exists systemctl && systemctl --version &>/dev/null; then
+        echo "systemd"
+    elif command_exists launchd; then
+        echo "launchd"
+    else
+        echo "unknown"
+    fi
+}
+
+install_systemd_service() {
+    debug "安装 systemd 服务..."
+    local service_file="/etc/systemd/system/${BINARY_NAME}.service"
+    local systemd_content="[Unit]
+Description=HotPlex AI Agent Control Plane
+After=network.target
+
+[Service]
+Type=simple
+User=${USER}
+ExecStart=${INSTALL_DIR}/${BINARY_NAME} start
+Restart=on-failure
+RestartSec=10
+Environment=HOTPLEX_DATA_DIR=${CONFIG_DIR}
+Environment=HOTPLEX_PORT=${HOTPLEX_PORT:-8080}
+
+[Install]
+WantedBy=multi-user.target
+"
+
+    if [[ -w "/etc/systemd/system" ]]; then
+        echo "$systemd_content" > "$service_file" || return 1
+        chmod 644 "$service_file"
+        systemctl daemon-reload
+        systemctl enable "${BINARY_NAME}.service"
+    else
+        sudo sh -c "cat > '$service_file' << 'SYSTEMD_EOF'
+$systemd_content
+SYSTEMD_EOF
+chmod 644 '$service_file'
+systemctl daemon-reload
+systemctl enable '${BINARY_NAME}.service'" || return 1
+    fi
+    return 0
+}
+
+install_launchd_service() {
+    debug "安装 launchd 服务..."
+    local plist_dir="$HOME/Library/LaunchAgents"
+    local plist_file="${plist_dir}/com.hotplex.daemon.plist"
+    mkdir -p "$plist_dir"
+
+    cat > "$plist_file" << 'PLIST_EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.hotplex.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${INSTALL_DIR}/${BINARY_NAME}</string>
+        <string>start</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOTPLEX_DATA_DIR</key><string>${CONFIG_DIR}</string>
+    </dict>
+</dict>
+</plist>
+PLIST_EOF
+    chmod 644 "$plist_file"
+    launchctl load "$plist_file" 2>/dev/null || true
+    return 0
+}
+
+install_autostart() {
+    if [[ "${SKIP_AUTOSTART:-false}" == "true" ]]; then
+        debug "跳过开机自启配置"
+        return 0
+    fi
+
+    local init_system=$(detect_init_system)
+    step "配置开机自启 ($init_system)..."
+
+    case "$init_system" in
+        systemd)
+            if install_systemd_service; then
+                success "systemd 服务已配置"
+                systemctl start "${BINARY_NAME}.service" 2>/dev/null || true
+            else
+                warn "systemd 服务配置失败"
+            fi
+            ;;
+        launchd)
+            if install_launchd_service; then
+                success "launchd 服务已配置"
+            else
+                warn "launchd 服务配置失败"
+            fi
+            ;;
+        *) warn "不支持的初始化系统: $init_system，跳过开机自启" ;;
+    esac
+}
+
+# ==============================================================================
+# 原子安装操作 (P0)
+# ==============================================================================
+
+atomic_install_config() {
+    local config_content="$1"
+    local config_path="${CONFIG_DIR}/.env"
+    local temp_config
+
+    temp_config=$(mktemp /tmp/hotplex-env.XXXXXX) || error "无法创建临时配置文件"
+    echo "$config_content" > "$temp_config" || {
+        rm -f "$temp_config"
+        error "无法写入配置"
+    }
+
+    [[ ! -d "$CONFIG_DIR" ]] && mkdir -p "$CONFIG_DIR" 2>/dev/null || {
+        rm -f "$temp_config"
+        error "无法创建配置目录 $CONFIG_DIR"
+    }
+
+    mv "$temp_config" "$config_path" || {
+        rm -f "$temp_config"
+        error "无法写入配置文件"
+    }
+
+    chmod 600 "$config_path" 2>/dev/null || sudo chmod 600 "$config_path"
+    debug "配置安装完成: $config_path"
+}
+
+
+# 安装
+do_install() {
+    # Docker 模式
+    if [[ "$INSTALL_MODE" == "docker" ]]; then
+        install_docker
+        return
+    fi
+
+    local os arch
+
+    os=$(detect_os)
+    arch=$(detect_arch)
+
+    info "系统: $(uname -s) $(uname -m)"
+    info "平台: ${os}/${arch}"
+
+    # Phase 2: 端口冲突检测
+    local check_port_num="${HOTPLEX_PORT:-8080}"
+    if check_port "$check_port_num" &>/dev/null; then
+        resolve_port_conflict "$check_port_num"
+    fi
+
+    # 获取/验证版本
+    if [[ -z "$VERSION" ]]; then
+        step "获取最新版本..."
+        VERSION=$(get_latest_version) || error "无法获取最新版本，请使用 -v 指定"
+        [[ "$VERSION" != v* ]] && VERSION="v${VERSION}"
+    fi
+    info "目标版本: ${GREEN}$VERSION${NC}"
+
+    # 检查已安装版本
+    check_existing_installation
+
+    # 构建下载信息
+    local archive_name="hotplex_${VERSION#v}_${os}_${arch}"
+    [[ "$os" == "windows" ]] && archive_name="${archive_name}.zip" || archive_name="${archive_name}.tar.gz"
+    local archive_url="https://github.com/${REPO}/releases/download/${VERSION}/${archive_name}"
+
+    debug "下载地址: $archive_url"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] 将下载: $archive_url"
+        info "[DRY-RUN] 将安装到: ${INSTALL_DIR}/${BINARY_NAME}"
+        info "[DRY-RUN] 将生成配置: ${CONFIG_DIR}/.env"
+        return
+    fi
+
+    # 创建临时目录
+    TEMP_DIR=$(mktemp -d)
+    debug "临时目录: $TEMP_DIR"
+
+    # 备份现有安装
+    backup_existing
+
+    # 下载
+    local archive_path="${TEMP_DIR}/${archive_name}"
+    step "正在下载..."
+    download_with_retry "$archive_url" "$archive_path"
+
+    # 下载并验证校验和
+    if [[ "$SKIP_VERIFY" != "true" ]]; then
+        local checksums_path="${TEMP_DIR}/checksums.txt"
+        if download_checksums "$VERSION" "$checksums_path"; then
+            step "验证校验和..."
+            verify_checksum "$archive_path" "$checksums_path"
+        else
+            warn "无法下载校验和文件，跳过验证"
+        fi
+    fi
+
+    # 解压
+    step "正在解压..."
+    if [[ "$os" == "windows" ]]; then
+        command_exists unzip || error "需要 unzip 来解压 .zip 文件"
+        unzip -q "$archive_path" -d "$TEMP_DIR"
+    else
+        tar -xzf "$archive_path" -C "$TEMP_DIR"
+    fi
+
+    # 安装
+    step "正在安装到 ${INSTALL_DIR}..."
+
+    if [[ ! -w "$INSTALL_DIR" ]] && [[ ! -d "$INSTALL_DIR" ]]; then
+        if [[ -w "$(dirname "$INSTALL_DIR")" ]]; then
+            mkdir -p "$INSTALL_DIR"
+        else
+            sudo mkdir -p "$INSTALL_DIR"
+        fi
+    fi
+
+    local binary_path="${TEMP_DIR}/${BINARY_NAME}"
+    [[ -f "$binary_path" ]] || error "解压后未找到 ${BINARY_NAME}"
+
+    if [[ -w "$INSTALL_DIR" ]]; then
+        cp "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+        chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        sudo cp "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+        sudo chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    # 验证安装
+    local installed_binary="${INSTALL_DIR}/${BINARY_NAME}"
+    if [[ ! -x "$installed_binary" ]]; then
+        error "安装验证失败: $installed_binary 不可执行"
+    fi
+
+    local installed_version
+    installed_version=$("$installed_binary" -version 2>/dev/null | head -1 || echo "unknown")
+    success "安装成功: ${GREEN}$installed_version${NC}"
+
+    # 生成配置
+    generate_config
+
+    # 运行配置向导
+    run_setup_wizard
+
+    # 配置开机自启 (P0)
+    install_autostart
+
+    # 健康检查 (P0)
+    if [[ "${SKIP_HEALTH_CHECK:-false}" != "true" ]]; then
+        health_check || true
+    fi
+
+    # 清理备份标记
+    CLEANUP_PENDING=false
+}
+
+# ==============================================================================
+# Phase 4: Docker 模式安装
+# ==============================================================================
+
+# 检查 Docker 环境
+check_docker() {
+    if ! command_exists docker; then
+        error "Docker 未安装。请先安装 Docker: https://docs.docker.com/get-docker/"
+        return 1
+    fi
+
+    if ! command_exists docker-compose && ! docker compose version &>/dev/null; then
+        error "Docker Compose 未安装。请先安装 Docker Compose: https://docs.docker.com/compose/install/"
+        return 1
+    fi
+
+    if ! docker info &>/dev/null; then
+        error "Docker 守护进程未运行。请启动 Docker 后重试。"
+        return 1
+    fi
+
+    return 0
+}
+
+# 生成 docker-compose.yml
+generate_docker_compose() {
+    local compose_file="${CONFIG_DIR}/docker-compose.yml"
+    local bot_configs=""
+
+    info "生成 Docker Compose 配置..."
+
+    # 多 Bot 配置
+    if [[ "$MULTI_BOT_ENABLED" == "true" ]] && [[ "$BOT_COUNT" -gt 1 ]]; then
+        for ((i=1; i<=BOT_COUNT; i++)); do
+            local bot_num=$(printf "%02d" $i)
+            local bot_name="bot-${bot_num}"
+            local env_file="${CONFIG_DIR}/${bot_name}.env"
+
+            if [[ -f "$env_file" ]]; then
+                bot_configs="${bot_configs}
+  ${bot_name}:
+    container_name: hotplex-${bot_num}
+    image: ghcr.io/hrygo/hotplex:latest
+    restart: unless-stopped
+    env_file:
+      - ./${bot_name}.env
+    volumes:
+      - ./data:/app/data
+      - ./projects:/app/projects
+    ports:
+      - \"$((8080 + i - 1)):8080\"
+    networks:
+      - hotplex-net"
+            fi
+        done
+    fi
+
+    local compose_content="# ==============================================================================
+# HotPlex Docker Compose 配置
+# 生成时间: $(date '+%Y-%m-%d %H:%M:%S %z')
+# ==============================================================================
+
+services:
+  hotplex:
+    container_name: hotplex
+    image: ghcr.io/hrygo/hotplex:latest
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+      - ./projects:/app/projects
+      - ./logs:/app/logs
+    ports:
+      - \"8080:8080\"
+    networks:
+      - hotplex-net${bot_configs}
+${bot_configs:+$'\n'}
+
+networks:
+  hotplex-net:
+    driver: bridge
+"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] 将创建: $compose_file"
+        return
+    fi
+
+    mkdir -p "$CONFIG_DIR"
+    mkdir -p "${CONFIG_DIR}/data"
+    mkdir -p "${CONFIG_DIR}/projects"
+    mkdir -p "${CONFIG_DIR}/logs"
+
+    echo "$compose_content" > "$compose_file"
+    chmod 600 "$compose_file"
+    success "已生成: $compose_file"
+}
+
+# Docker 模式安装
+install_docker() {
+    info "开始 Docker 模式安装..."
+
+    # 检查 Docker 环境
+    if ! check_docker; then
+        return 1
+    fi
+
+    # 多 Bot 配置
+    if [[ "$MULTI_BOT_ENABLED" == "true" ]]; then
+        wizard_multi_bot
+    fi
+
+    # 生成 .env 文件
+    generate_config
+
+    # 生成 docker-compose.yml
+    generate_docker_compose
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] Docker 模式安装准备完成"
+        return
+    fi
+
+    # 拉取镜像并启动
+    step "拉取最新镜像..."
+    if docker_compose pull -q; then
+        success "镜像拉取成功"
+    else
+        warn "镜像拉取失败，将使用本地镜像启动"
+    fi
+
+    step "启动容器..."
+    if docker_compose up -d; then
+        success "容器启动成功"
+    else
+        error "容器启动失败"
+        return 1
+    fi
+
+    # 等待服务就绪
+    sleep 3
+
+    # 健康检查
+    step "检查服务状态..."
+    if silent_run docker compose ps | grep -q "Up"; then
+        success "服务运行中"
+    else
+        warn "请手动检查: docker compose logs hotplex"
+    fi
+
+    echo ""
+    raw "${GREEN}${BOLD}🎉 Docker 模式安装成功!${NC}"
+    echo ""
+    echo -e "  ${BOLD}管理命令:${NC}"
+    echo ""
+    echo "    cd ${CONFIG_DIR}"
+    echo "    docker compose up -d      # 启动"
+    echo "    docker compose logs -f    # 查看日志"
+    echo "    docker compose down       # 停止"
+    echo "    docker compose restart    # 重启"
+    echo ""
+    echo -e "  ${DIM}配置文件: ${CONFIG_DIR}/.env${NC}"
+    echo -e "  ${DIM}编排文件: ${CONFIG_DIR}/docker-compose.yml${NC}"
+    echo ""
+}
+
+# ==============================================================================
+# Phase 4: 多 Bot 支持
+# ==============================================================================
+
+# 多 Bot 配置向导
+wizard_multi_bot() {
+    echo ""
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+    raw "${BOLD}                    🤖 多 Bot 配置向导                      ${NC}"
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    if [[ ! -t 0 ]] || [[ "$INTERACTIVE" != "true" ]]; then
+        debug "非交互模式，跳过多 Bot 配置"
+        return 0
+    fi
+
+    echo -e "  ${BOLD}多 Bot 模式允许在一台服务器上运行多个独立的 HotPlex Bot${NC}"
+    echo -e "  ${DIM}每个 Bot 有独立的配置和 Token，适合复杂组织结构${NC}"
+    echo ""
+
+    if [[ "$MULTI_BOT_ENABLED" == "true" ]]; then
+        echo -e "  ${GREEN}✓ 多 Bot 模式已启用${NC}"
+    else
+        if ! confirm "是否启用多 Bot 模式?" "n"; then
+            info "多 Bot 配置已跳过"
+            return 0
+        fi
+        MULTI_BOT_ENABLED=true
+    fi
+
+    # 询问 Bot 数量
+    echo ""
+    echo -e "  ${BOLD}请选择 Bot 数量:${NC}"
+    echo ""
+    echo "    1) 单 Bot (默认)"
+    echo "    2) 双 Bot"
+    echo "    3) 三 Bot"
+    echo "    4) 自定义数量"
+    echo ""
+
+    local count_choice
+    count_choice=$(prompt_input "选择" "1")
+
+    case "$count_choice" in
+        1) BOT_COUNT=1 ;;
+        2) BOT_COUNT=2 ;;
+        3) BOT_COUNT=3 ;;
+        4)
+            local custom_count
+            custom_count=$(prompt_input "请输入 Bot 数量 (1-10)" "1")
+            BOT_COUNT=$((custom_count >= 1 && custom_count <= 10 ? custom_count : 1))
+            ;;
+        *) BOT_COUNT=1 ;;
+    esac
+
+    info "将配置 ${BOT_COUNT} 个 Bot"
+
+    # 为每个 Bot 生成配置
+    for ((i=1; i<=BOT_COUNT; i++)); do
+        local bot_num=$(printf "%02d" $i)
+        local bot_name="bot-${bot_num}"
+        local env_file="${CONFIG_DIR}/${bot_name}.env"
+
+        echo ""
+        raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+        raw "${BOLD}              🤖 配置 Bot ${i}/${BOT_COUNT} (${bot_name})           ${NC}"
+        raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+        echo ""
+
+        # 获取现有配置（如有）
+        local current_bot_token=""
+        local current_user_id=""
+        if [[ -f "$env_file" ]]; then
+            current_bot_token=$(grep "^HOTPLEX_SLACK_BOT_TOKEN=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+            current_user_id=$(grep "^HOTPLEX_SLACK_BOT_USER_ID=" "$env_file" 2>/dev/null | cut -d'=' -f2- || echo "")
+        fi
+
+        # Bot Token
+        echo -e "  ${BOLD}Bot ${i} 配置${NC}"
+        echo ""
+
+        local bot_token
+        bot_token=$(prompt_input "输入 Bot Token (xoxb-...)" "$current_bot_token" "true")
+
+        if [[ -z "$bot_token" ]]; then
+            warn "Bot Token 不能为空，跳过 Bot ${i}"
+            continue
+        fi
+
+        # 验证 Token
+        if ! validate_slack_token "$bot_token"; then
+            warn "Token 格式验证失败，继续使用"
+        fi
+
+        # Bot User ID
+        local bot_user_id
+        bot_user_id=$(prompt_input "输入 Bot User ID (U...)" "$current_user_id")
+
+        # 生成 Bot 配置
+        cat > "$env_file" << EOF
+# ==============================================================================
+# HotPlex Bot ${i} 配置文件
+# Bot 名称: ${bot_name}
+# 生成时间: $(date '+%Y-%m-%d %H:%M:%S %z')
+# ==============================================================================
+
+HOTPLEX_PORT=${HOTPLEX_PORT:-8080}
+HOTPLEX_LOG_LEVEL=INFO
+HOTPLEX_DATA_DIR=/app/data
+
+# Bot ${i} 特定配置
+BOT_NAME=${bot_name}
+HOTPLEX_SLACK_BOT_USER_ID=${bot_user_id}
+HOTPLEX_SLACK_BOT_TOKEN=${bot_token}
+HOTPLEX_SLACK_APP_TOKEN=${HOTPLEX_SLACK_APP_TOKEN:-xapp-}
+
+# Provider 配置
+HOTPLEX_PROVIDER_TYPE=claude-code
+HOTPLEX_PROVIDER_MODEL=sonnet
+
+# 消息存储
+HOTPLEX_MESSAGE_STORE_ENABLED=true
+HOTPLEX_MESSAGE_STORE_TYPE=sqlite
+HOTPLEX_MESSAGE_STORE_SQLITE_PATH=/app/data/chatapp_messages_${bot_num}.db
+EOF
+
+        chmod 600 "$env_file"
+        success "已生成: $env_file"
+    done
+
+    # 更新主配置
+    if [[ "$BOT_COUNT" -gt 1 ]]; then
+        MULTI_BOT_ENABLED=true
+        wizard_slack_yaml
+    fi
+
+    echo ""
+    raw "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    raw "${BOLD}  ✓ 多 Bot 配置完成${NC}"
+    raw "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+# ==============================================================================
+# Phase 4: 日志轮转配置
+# ==============================================================================
+
+# 配置日志轮转
+configure_logrotate() {
+    echo ""
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+    raw "${BOLD}                    📋 日志管理                         ${NC}"
+    raw "${BOLD}════════════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    echo -e "  ${BOLD}当前日志状态:${NC}"
+    echo ""
+
+    local log_dir="${CONFIG_DIR}/logs"
+    local binary_log="${CONFIG_DIR}/${BINARY_NAME}.log"
+
+    if [[ -d "$log_dir" ]]; then
+        local log_count=$(find "$log_dir" -name "*.log" 2>/dev/null | wc -l)
+        local total_size=$(du -sh "$log_dir" 2>/dev/null | cut -f1 || echo "未知")
+        echo -e "  ${GREEN}✓${NC}  日志目录: ${log_dir}"
+        echo -e "  ${GREEN}✓${NC}  日志文件数: ${log_count}"
+        echo -e "  ${GREEN}✓${NC}  总大小: ${total_size}"
+    else
+        echo -e "  ${YELLOW}○${NC}  日志目录不存在: ${log_dir}"
+    fi
+
+    if [[ -f "$binary_log" ]]; then
+        local binary_size=$(du -h "$binary_log" 2>/dev/null | cut -f1 || echo "未知")
+        echo -e "  ${GREEN}✓${NC}  二进制日志: ${binary_log} (${binary_size})"
+    fi
+
+    echo ""
+    echo -e "  ${BOLD}请选择操作:${NC}"
+    echo ""
+    echo "    1) 配置日志轮转      (自动清理旧日志)"
+    echo "    2) 手动清理日志      (删除所有日志文件)"
+    echo "    3) 查看日志目录      (ls -la)"
+    echo "    4) 返回"
+    echo ""
+
+    local log_choice
+    log_choice=$(prompt_input "选择" "4")
+
+    case "$log_choice" in
+        1)
+            install_logrotate
+            ;;
+        2)
+            cleanup_logs
+            ;;
+        3)
+            echo ""
+            if [[ -d "$log_dir" ]]; then
+                ls -lah "$log_dir"
+            else
+                echo -e "  ${DIM}日志目录不存在${NC}"
+            fi
+            echo ""
+            if [[ -f "$binary_log" ]]; then
+                ls -lah "$binary_log"
+            fi
+            echo ""
+            ;;
+        4|*)
+            return 0
+            ;;
+    esac
+}
+
+# 安装 logrotate 配置
+install_logrotate() {
+    step "配置日志轮转..."
+
+    # 检测权限
+    local logrotate_conf="/etc/logrotate.d/hotplex"
+    local need_sudo=false
+
+    if [[ ! -w "/etc/logrotate.d" ]]; then
+        need_sudo=true
+    fi
+
+    local logrotate_content="# HotPlex 日志轮转配置
+# 生成时间: $(date '+%Y-%m-%d %H:%M:%S')
+
+${CONFIG_DIR}/*.log {
+    daily
+    rotate ${MAX_LOG_FILES}
+    size ${MAX_LOG_SIZE}
+    missingok
+    notifempty
+    compress
+    delaycompress
+    create 0600 \$(whoami) \$(whoami)
+    sharedscripts
+    postrotate
+        # 通知服务重新打开日志文件（如支持）
+        kill -USR1 \$(pgrep -f ${BINARY_NAME}) 2>/dev/null || true
+    endscript
+}
+
+${CONFIG_DIR}/logs/*.log {
+    daily
+    rotate ${MAX_LOG_FILES}
+    size ${MAX_LOG_SIZE}
+    missingok
+    notifempty
+    compress
+    delaycompress
+    create 0600 \$(whoami) \$(whoami)
+}
+"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] 将创建: $logrotate_conf"
+        info "[DRY-RUN] 日志轮转规则: daily, rotate ${MAX_LOG_FILES}, size ${MAX_LOG_SIZE}"
+        return
+    fi
+
+    if [[ "$need_sudo" == "true" ]]; then
+        echo "$logrotate_content" | sudo tee "$logrotate_conf" > /dev/null
+        sudo chmod 644 "$logrotate_conf"
+    else
+        echo "$logrotate_content" > "$logrotate_conf"
+        chmod 644 "$logrotate_conf"
+    fi
+
+    success "已配置日志轮转: $logrotate_conf"
+    info "规则: 每天轮转，保留 ${MAX_LOG_FILES} 份，大小超过 ${MAX_LOG_SIZE} 时触发"
+}
+
+# 清理日志
+cleanup_logs() {
+    echo ""
+    warn "即将清理所有日志文件!"
+    echo ""
+
+    if ! confirm "确认清理?" "n"; then
+        info "已取消"
+        return
+    fi
+
+    local cleaned=0
+    local log_dir="${CONFIG_DIR}/logs"
+    local binary_log="${CONFIG_DIR}/${BINARY_NAME}.log"
+
+    # 清理日志目录
+    if [[ -d "$log_dir" ]]; then
+        local count
+        count=$(find "$log_dir" -name "*.log" 2>/dev/null | wc -l)
+        if [[ "$count" -gt 0 ]]; then
+            find "$log_dir" -name "*.log" -delete 2>/dev/null
+            cleaned=$((cleaned + count))
+            info "已清理: $count 个日志文件"
+        fi
+    fi
+
+    # 清理二进制日志
+    if [[ -f "$binary_log" ]] && [[ -s "$binary_log" ]]; then
+        : > "$binary_log"
+        cleaned=$((cleaned + 1))
+        info "已清空: $binary_log"
+    fi
+
+    if [[ "$cleaned" -eq 0 ]]; then
+        info "没有日志文件需要清理"
+    else
+        success "共清理 ${cleaned} 个日志文件"
+    fi
+}
+
+# ==============================================================================
+# Phase 2: 交互式主菜单
+# ==============================================================================
+
+show_main_menu() {
+    echo ""
+    raw "${BOLD}${CYAN}╭─ HotPlex 安装程序 ──────────────────────────────╮${NC}"
+    raw "${BOLD}${CYAN}╰───────────────────────────────────────────────────╯${NC}"
+    echo ""
+    echo -e "  ${BOLD}请选择操作:${NC}"
+    echo ""
+    echo "    1) 安装 HotPlex         (Quick Start - 二进制模式)"
+    echo "    2) 安装 HotPlex (Docker) (容器化部署，支持多 Bot)"
+    echo "    3) 升级 HotPlex         (保留配置，替换二进制)"
+    echo "    4) 卸载 HotPlex         (移除二进制，保留配置)"
+    echo "    5) 完全清理            (删除所有数据)"
+    echo "    6) 查看状态            (检查安装和运行状态)"
+    echo "    7) 仅配置              (运行配置向导)"
+    echo "    8) 多 Bot 配置         (添加/管理多个 Bot)"
+    echo "    9) 日志管理           (配置日志轮转)"
+    echo "   10) 退出"
+    echo ""
+}
+
+handle_menu_choice() {
+    local choice="$1"
+
+    case "$choice" in
+        1)
+            echo ""
+            info "开始安装 (二进制模式)..."
+            do_install
+            ;;
+        2)
+            echo ""
+            info "开始安装 (Docker 模式)..."
+            INSTALL_MODE=docker do_install
+            ;;
+        3)
+            echo ""
+            do_upgrade
+            ;;
+        4)
+            echo ""
+            UNINSTALL=true
+            do_uninstall
+            ;;
+        5)
+            echo ""
+            do_purge
+            ;;
+        6)
+            echo ""
+            do_status
+            ;;
+        7)
+            echo ""
+            if [[ ! -f "${CONFIG_DIR}/.env" ]]; then
+                generate_config
+            fi
+            run_setup_wizard
+            ;;
+        8)
+            echo ""
+            wizard_multi_bot
+            ;;
+        9)
+            echo ""
+            configure_logrotate
+            ;;
+        10|q|Q)
+            echo ""
+            info "再见!"
+            exit 0
+            ;;
+        *)
+            error "无效选择: $choice"
+            ;;
+    esac
+}
+
+# ==============================================================================
+# 主入口
+# ==============================================================================
+
+main() {
+    init_colors
+    setup_traps
+    parse_args "$@"
+
+    # 显示 banner
+    if [[ "$QUIET" != "true" ]]; then
+        echo ""
+        raw "  ${BOLD}╔═══════════════════════════════════════════╗${NC}"
+        raw "  ${BOLD}║${NC}         ${CYAN}HotPlex${NC} 安装程序 v${SCRIPT_VERSION}          ${BOLD}║${NC}"
+        raw "  ${BOLD}║${NC}       AI Agent Control Plane            ${BOLD}║${NC}"
+        raw "  ${BOLD}╚═══════════════════════════════════════════╝${NC}"
+        echo ""
+    fi
+
+    # 创建日志目录并设置安全权限
+    mkdir -p "$CONFIG_DIR" 2>/dev/null || true
+    setup_secure_logging
+
+    # 处理子命令 (非交互模式)
+    if [[ "$#" -gt 0 ]]; then
+        case "$1" in
+            upgrade)   do_upgrade; exit 0 ;;
+            status)    do_status; exit 0 ;;
+            purge)     do_purge; exit 0 ;;
+            uninstall) UNINSTALL=true; do_uninstall; exit 0 ;;
+            config)    CONFIG_ONLY=true ;;
+            docker)    INSTALL_MODE=docker; do_install; exit 0 ;;
+            install)   shift; parse_args "$@" ;;
+        esac
+    fi
+
+    # 处理 flags
+    [[ "$DO_UPGRADE" == "true" ]] && { do_upgrade; exit 0; }
+    [[ "$DO_STATUS" == "true" ]]  && { do_status; exit 0; }
+    [[ "$DO_PURGE" == "true" ]]   && { do_purge; exit 0; }
+
+    # 卸载模式
+    if [[ "$UNINSTALL" == "true" ]]; then
+        do_uninstall
+        exit 0
+    fi
+
+    # 仅配置模式
+    if [[ "$CONFIG_ONLY" == "true" ]]; then
+        if [[ ! -f "${CONFIG_DIR}/.env" ]]; then
+            generate_config
+        fi
+        run_setup_wizard
+        exit 0
+    fi
+
+    # 检查依赖
+    check_dependencies
+
+    # 交互模式：显示主菜单
+    if [[ "$INTERACTIVE" == "true" ]] && [[ -t 0 ]] && [[ "$#" -eq 0 ]]; then
+        show_main_menu
+        echo -ne "${BOLD}请选择 [1-10]:${NC} "
+        read -r menu_choice
+        echo ""
+        handle_menu_choice "$menu_choice"
+        exit 0
+    fi
+
+    # 安装
+    do_install
+}
+
+main "$@"

--- a/install/hotplex-install.sh
+++ b/install/hotplex-install.sh
@@ -1146,11 +1146,11 @@ wizard_slack_credentials() {
                 step "验证 Token..."
                 if test_slack_connection "$bot_token"; then
                     success "Token 验证成功"
-                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file"
+                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file" && rm -f "$env_file.bak"
                     updated=true
                 else
                     warn "Token 验证失败，但仍会保存"
-                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file"
+                    sed -i.bak "s|^HOTPLEX_SLACK_BOT_TOKEN=.*|HOTPLEX_SLACK_BOT_TOKEN=${bot_token}|" "$env_file" && rm -f "$env_file.bak"
                     updated=true
                 fi
             else
@@ -1166,7 +1166,7 @@ wizard_slack_credentials() {
 
         if [[ -n "$app_token" ]]; then
             if validate_slack_app_token "$app_token"; then
-                sed -i.bak "s|^HOTPLEX_SLACK_APP_TOKEN=.*|HOTPLEX_SLACK_APP_TOKEN=${app_token}|" "$env_file"
+                sed -i.bak "s|^HOTPLEX_SLACK_APP_TOKEN=.*|HOTPLEX_SLACK_APP_TOKEN=${app_token}|" "$env_file" && rm -f "$env_file.bak"
                 updated=true
             else
                 warn "Token 格式无效 (应为 xapp-...)"
@@ -1182,7 +1182,7 @@ wizard_slack_credentials() {
 
         if [[ -n "$user_id" ]]; then
             if validate_slack_user_id "$user_id"; then
-                sed -i.bak "s|^HOTPLEX_SLACK_BOT_USER_ID=.*|HOTPLEX_SLACK_BOT_USER_ID=${user_id}|" "$env_file"
+                sed -i.bak "s|^HOTPLEX_SLACK_BOT_USER_ID=.*|HOTPLEX_SLACK_BOT_USER_ID=${user_id}|" "$env_file" && rm -f "$env_file.bak"
                 updated=true
             else
                 warn "User ID 格式无效 (应以 U、B 或 W 开头)"
@@ -1198,7 +1198,7 @@ wizard_slack_credentials() {
 
             if [[ -n "$github_token" ]]; then
                 if validate_github_token "$github_token"; then
-                    sed -i.bak "s|^GITHUB_TOKEN=.*|GITHUB_TOKEN=${github_token}|" "$env_file"
+                    sed -i.bak "s|^GITHUB_TOKEN=.*|GITHUB_TOKEN=${github_token}|" "$env_file" && rm -f "$env_file.bak"
                     updated=true
                 else
                     warn "Token 格式无效 (应为 ghp_...)"


### PR DESCRIPTION
## 概述

实现 issue #348 的一键安装脚本功能 (closes #348)。

## 目录结构

```
install/
├── hotplex-install.sh      # Linux/macOS 主脚本 (Phase 1-3)
├── hotplex-install.ps1     # Windows PowerShell (Phase 4 占位)
└── README.md
```

## Phase 1 P0 安全基线 ✅

- [x] SHA256 校验
- [x] Slack Token 验证 (auth.test API)
- [x] 原子安装操作 (mktemp + mv)
- [x] 日志权限 chmod 600
- [x] 开机自启 (systemd/launchd)
- [x] 健康检查 (带超时)

## 选项

- `--skip-health-check` - 跳过健康检查
- `--skip-autostart` - 跳过开机自启配置

## Windows 支持

`hotplex-install.ps1` 已创建占位脚本。Phase 4 完整实现待后续完成。

## 设计文档

https://github.com/hrygo/hotplex/blob/main/docs/superpowers/specs/2026-03-24-one-click-install-design.md