### PR TITLE
docs(research): add ACP integration research documentation

### DIFF
--- a/docs/research/acp-integration-research.md
+++ b/docs/research/acp-integration-research.md
@@ -1,0 +1,340 @@
+# ACP 协议集成 HotPlex Provider 技术调研
+
+**调研日期**: 2026-03-25
+**调研目标**: 分析如何将 ACP (Agent Communication Protocol) 接入 HotPlex Provider 层，实现多 Agent 协作能力
+
+---
+
+## 1. ACP 协议概述
+
+### 1.1 什么是 ACP？
+
+**Agent Communication Protocol (ACP)** 是由 IBM 开发的开放协议，用于解决 AI Agent 间互操作性问题。
+
+**核心特性**：
+- **RESTful API**: 标准 HTTP 端点，无需特殊协议
+- **多模态支持**: 文本、图像、音频、视频等（基于 MimeType）
+- **同步/异步通信**: 支持长时间运行任务
+- **流式交互**: 支持实时数据流
+- **无 SDK 依赖**: 可用 curl/Postman 直接调用（但也提供 Python/TypeScript SDK）
+- **Offline Discovery**: 支持未激活 Agent 的发现
+
+### 1.2 ACP vs MCP 对比
+
+| 维度 | MCP (Anthropic) | ACP (IBM) |
+|------|----------------|-----------|
+| **架构** | Client-Server | Peer-to-Peer |
+| **主要用途** | Agent ↔ Tools 连接 | Agent ↔ Agent 通信 |
+| **通信方式** | 单个 Agent 访问多个工具 | 多个 Agent 相互协作 |
+| **任务委托** | 有限 | 强大的任务委托机制 |
+| **发起方** | 仅客户端发起 | 任意 Agent 可发起 |
+
+**关键洞察**：
+- MCP 专注于"工具访问"（Agent 使用外部 API/DB）
+- ACP 专注于"Agent 协作"（多个 Agent 共同完成任务）
+- 两者可以共存：MCP 提供工具，ACP 编排 Agent
+
+---
+
+## 2. HotPlex Provider 架构分析
+
+### 2.1 当前 Provider 接口
+
+```go
+type Provider interface {
+    Metadata() ProviderMeta
+    BuildCLIArgs(providerSessionID string, opts *ProviderSessionOptions) []string
+    BuildInputMessage(prompt string, taskInstructions string) (map[string]any, error)
+    ParseEvent(line string) ([]*ProviderEvent, error)
+    DetectTurnEnd(event *ProviderEvent) bool
+    ValidateBinary() (string, error)
+    CleanupSession(providerSessionID string, workDir string) error
+    VerifySession(providerSessionID string, workDir string) bool
+    Name() string
+}
+```
+
+**设计特点**：
+- 基于 CLI 进程管理（stdin/stdout 通信）
+- 事件驱动解析（`ParseEvent`）
+- 会话隔离（`ProviderSessionID`）
+
+### 2.2 集成挑战
+
+**问题 1: 协议差异**
+- 当前 Provider: CLI stdin/stdout (本地进程)
+- ACP: HTTP REST API (网络服务)
+
+**问题 2: 生命周期管理**
+- CLI Provider: HotPlex 启动进程（PGID 隔离）
+- ACP Provider: 外部服务，需 HTTP 客户端
+
+**问题 3: 事件流转换**
+- CLI Provider: 实时 stdout 流（JSON lines）
+- ACP Provider: HTTP 响应流（SSE 或 chunked）
+
+---
+
+## 3. 集成方案头脑风暴
+
+### 方案 A: ACP 作为 Provider（推荐）
+
+**概念**: 将 ACP Agent 包装为 HotPlex Provider
+
+**架构**：
+```
+ChatApp (Slack/TG)
+      ↓
+HotPlex Engine
+      ↓
+ACP Provider (implements Provider interface)
+      ↓
+HTTP Client → ACP Server (External Agent)
+```
+
+**实现要点**：
+1. 新增 `acp_provider.go` 实现 `Provider` 接口
+2. `BuildInputMessage`: 构造 ACP 请求 JSON
+3. `ParseEvent`: 解析 ACP 响应流（SSE/chunked）
+4. `DetectTurnEnd`: 识别 ACP 任务完成信号
+5. `ValidateBinary`: 验证 ACP endpoint 可达性
+
+**优势**：
+- 复用现有 Engine 和 ChatApps 层
+- 统一的会话管理（`ProviderSessionID`）
+- 支持混合部署（本地 CLI + 远程 ACP Agent）
+
+**代码示例**：
+```go
+type ACPProvider struct {
+    ProviderBase
+    endpoint string // ACP server URL
+    client   *http.Client
+}
+
+func (p *ACPProvider) BuildInputMessage(prompt, taskInstructions string) (map[string]any, error) {
+    return map[string]any{
+        "messages": []map[string]any{
+            {
+                "role": "user",
+                "parts": []map[string]any{
+                    {"content": prompt, "type": "text/plain"},
+                },
+            },
+        },
+        "context": taskInstructions,
+    }, nil
+}
+
+func (p *ACPProvider) ParseEvent(line string) ([]*ProviderEvent, error) {
+    // Parse SSE event from ACP server
+    var acpEvent ACPEvent
+    if err := json.Unmarshal([]byte(line), &acpEvent); err != nil {
+        return nil, err
+    }
+    return []*ProviderEvent{{
+        Type:    acpEvent.Type,
+        Content: acpEvent.Content,
+    }}, nil
+}
+```
+
+---
+
+### 方案 B: ACP 作为 Relay 通道
+
+**概念**: 利用 ACP 协议实现 HotPlex Agent 间通信
+
+**架构**：
+```
+HotPlex Agent A (Slack Bot)
+      ↓
+ACP Client → ACP Server (Broker)
+      ↓
+HotPlex Agent B (Telegram Bot)
+```
+
+**实现要点**：
+1. 在 `internal/relay/` 新增 `acp_relay.go`
+2. 实现 `RelayTransport` 接口（基于 ACP 协议）
+3. 支持 Agent 发现（ACP Discovery）
+4. 路由与负载均衡
+
+**优势**：
+- 跨平台 Agent 协作（Slack ↔ Telegram）
+- 支持第三方 ACP Agent 加入
+- 标准化通信协议
+
+**挑战**：
+- 需要独立的 ACP Broker 服务
+- 配置复杂度提升
+
+---
+
+### 方案 C: ACP Server 模式（托管 Agent）
+
+**概念**: HotPlex 自身作为 ACP Server，托管多个内部 Agent
+
+**架构**：
+```
+External ACP Client
+      ↓
+ACP Server (HotPlex)
+      ↓
+Engine → CLI Provider (Claude/OpenCode)
+```
+
+**实现要点**：
+1. 在 `internal/server/` 新增 `acp_server.go`
+2. 实现 ACP REST API 端点
+3. 将 ACP 请求转发给 Engine
+4. 暴露 Agent 元数据（Discovery）
+
+**优势**：
+- HotPlex 成为标准 ACP 服务
+- 可被其他 ACP 客户端发现和调用
+- 适合企业内部部署
+
+**挑战**：
+- 需要完整实现 ACP spec
+- 安全认证（API key/JWT）
+
+---
+
+## 4. 技术选型建议
+
+### 4.1 优先级排序
+
+1. **方案 A (ACP Provider)** - **推荐首先实现**
+   - 理由: 复用现有架构，最小化改动
+   - 价值: 立即获得远程 Agent 能力
+   - 风险: 低
+
+2. **方案 B (Relay)** - **中期规划**
+   - 理由: 需要明确的跨平台协作场景
+   - 价值: 解锁 Agent-to-Agent 工作流
+   - 风险: 中（依赖外部 Broker）
+
+3. **方案 C (ACP Server)** - **长期规划**
+   - 理由: 需要完整的 ACP spec 实现
+   - 价值: HotPlex 成为平台级服务
+   - 风险: 高（安全、性能、合规）
+
+### 4.2 实现路径
+
+**Phase 1: ACP Provider (2-3 周)**
+- [ ] 研究 ACP SDK (Python/TypeScript)
+- [ ] 实现 `acp_provider.go`
+- [ ] 支持 SSE 流式响应解析
+- [ ] 单元测试 + 集成测试
+
+**Phase 2: ACP Relay (4-6 周)**
+- [ ] 评估 ACP Broker 方案（BeeAI? 自建?）
+- [ ] 实现 `acp_relay.go`
+- [ ] Agent 发现机制
+- [ ] 跨平台测试（Slack ↔ Telegram）
+
+**Phase 3: ACP Server (8-12 周)**
+- [ ] 实现完整 ACP spec
+- [ ] 安全认证（OAuth2/JWT）
+- [ ] Agent 元数据管理
+- [ ] 性能优化与监控
+
+---
+
+## 5. 风险与缓解
+
+### 5.1 协议演进风险
+- **风险**: ACP 协议仍在快速演进（2026 年可能合并到 A2A）
+- **缓解**: 抽象协议层（`acp_protocol.go`），支持版本切换
+
+### 5.2 网络依赖风险
+- **风险**: 远程 ACP Agent 可能不可达
+- **缓解**: 实现超时、重试、降级机制
+
+### 5.3 安全风险
+- **风险**: 暴露 HTTP endpoint 增加攻击面
+- **缓解**: 使用 `internal/security/` WAF，API key 验证
+
+---
+
+## 6. 重要：两个 ACP 协议的区别
+
+### 命名混淆澄清
+
+| 协议全称 | 缩写 | 官方站点 | 用途 |
+|---------|------|---------|------|
+| **Agent Communication Protocol** | ACP | agentcommunicationprotocol.dev | Agent ↔ Agent 通信 |
+| **Agent Client Protocol** | ACP | agentclientprotocol.com | Agent ↔ IDE/编辑器 通信 |
+
+**本文档聚焦**: **Agent Communication Protocol** (Agent 间协作)
+
+### Agent Client Protocol 概览
+
+**定义**: Agent 与 IDE/编辑器间的标准化协议（JSON-RPC 2.0）
+
+**核心特点**:
+- 基于 JSON-RPC 2.0
+- Agent 作为 Client 的子进程运行
+- Methods: `initialize`, `session/new`, `session/prompt`
+- Notifications: `session/cancel`, `session/update`
+
+**与 HotPlex 的关系**:
+- **场景**: 如果要让 HotPlex 接入 IDE（如 Cursor/VSCode）
+- **集成点**: HotPlex Agent 暴露 Agent Client Protocol 接口
+- **优先级**: 低（HotPlex 主要面向 ChatApp，非 IDE）
+
+### 协议对比总结
+
+| 协议 | 用途 | 通信方式 | 适用场景 |
+|------|------|---------|---------|
+| **MCP** | Agent ↔ Tools | Client-Server | 访问外部 API/DB |
+| **Agent Communication Protocol** | Agent ↔ Agent | REST (Peer-to-Peer) | 多 Agent 协作 |
+| **Agent Client Protocol** | Agent ↔ IDE | JSON-RPC 2.0 | 编辑器集成 |
+| **HotPlex Provider** | Engine ↔ CLI | stdin/stdout | CLI 工具包装 |
+
+---
+
+## 7. 参考资源
+
+### 7.1 Agent Communication Protocol (本文档焦点)
+- [ACP 官方站点](https://agentcommunicationprotocol.dev/)
+- [IBM ACP 介绍](https://www.ibm.com/think/topics/agent-communication-protocol)
+- [GitHub - i-am-bee/acp](https://github.com/i-am-bee/acp)
+
+### 7.2 Agent Client Protocol (补充参考)
+- [Agent Client Protocol 官方站点](https://agentclientprotocol.com/)
+- [GitHub - agent-client-protocol](https://github.com/agentclientprotocol/agent-client-protocol)
+- [JetBrains ACP](https://www.jetbrains.com/acp/)
+- [Zed ACP](https://zed.dev/acp)
+
+### 7.3 相关协议
+- [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) - Anthropic
+- [A2A (Agent-to-Agent)](https://akka.io/blog/mcp-a2a-acp-what-does-it-all-mean) - Google
+
+### 7.4 竞品分析
+- BeeAI Platform (IBM) - ACP 参考实现
+- LangChain Agent 执行器
+- CrewAI 多 Agent 框架
+
+---
+
+## 7. 下一步行动
+
+### 7.1 立即行动
+1. **阅读 ACP Spec**: 详细研究 REST API 定义
+2. **验证可行性**: 用 curl 测试 ACP server（如 BeeAI）
+3. **原型开发**: 实现 `acp_provider.go` POC
+
+### 7.2 短期（1 个月）
+- 完成 ACP Provider 实现
+- 集成测试（Slack → ACP Agent）
+- 文档更新（CLAUDE.md）
+
+### 7.3 中期（3 个月）
+- 评估 Relay 方案的业务价值
+- 探索与 MCP 的协同（MCP 提供工具，ACP 编排 Agent）
+
+---
+
+**总结**: ACP 协议为 HotPlex 提供了标准化 Agent 通信能力。推荐首先实现 **方案 A (ACP Provider)**，复用现有架构，最小化风险。后续可根据业务需求逐步推进 Relay 和 Server 模式。

--- a/docs/research/openclaw-acp-deep-dive.md
+++ b/docs/research/openclaw-acp-deep-dive.md
@@ -1,0 +1,521 @@
+# OpenClaw ACP 实践深度调研
+
+**调研日期**: 2026-03-26
+**目标**: 深入分析 OpenClaw 的 Agent Client Protocol (ACP) 实现，提炼可借鉴的实践经验
+
+---
+
+## 1. OpenClaw ACP 架构概览
+
+### 1.1 核心设计理念
+
+**定位**: **Gateway-backed ACP Bridge** (基于网关的 ACP 桥接器)
+
+**关键洞察**:
+- **不是完整 ACP 运行时**，而是协议转换层
+- **复用现有基础设施**（Gateway + Session Store）
+- **最小化实现范围**，聚焦核心场景
+
+### 1.2 架构分层
+
+```
+┌─────────────────────────────────────────┐
+│   IDE / ACP Client (Zed, VSCode, etc.)  │
+└─────────────────┬───────────────────────┘
+                  │ stdio (ACP Protocol)
+                  ▼
+┌─────────────────────────────────────────┐
+│         openclaw acp (Bridge)            │
+│  • ACP ↔ Gateway Protocol 翻译          │
+│  • Session 映射 (ACP ID → Gateway Key)   │
+│  • 事件流转换                           │
+└─────────────────┬───────────────────────┘
+                  │ WebSocket
+                  ▼
+┌─────────────────────────────────────────┐
+│        OpenClaw Gateway (Control Plane)  │
+│  • Session 生命周期管理                  │
+│  • Agent 路由                           │
+│  • MCP Server 集成                      │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│    Backend Agent (Claude, GPT, etc.)    │
+└─────────────────────────────────────────┘
+```
+
+**核心职责划分**:
+- **Bridge**: 协议翻译 + Session 映射
+- **Gateway**: 会话持久化 + Agent 调度
+- **Agent**: 实际 AI 能力
+
+---
+
+## 2. 核心实现细节
+
+### 2.1 ACP 协议支持矩阵
+
+| ACP 功能 | 实现状态 | 关键说明 |
+|---------|---------|---------|
+| **核心流程** | | |
+| `initialize` | ✅ 完整 | 版本协商 |
+| `newSession` | ✅ 完整 | 创建 ACP Session → 映射到 Gateway Key |
+| `loadSession` | ⚠️ 部分 | 重放文本历史，但不重建工具调用 |
+| `prompt` | ✅ 完整 | ACP Prompt → Gateway `chat.send` |
+| `cancel` | ✅ 完整 | ACP Cancel → Gateway `chat.abort` |
+| `listSessions` | ✅ 完整 | 列出 Gateway Sessions |
+| **内容支持** | | |
+| 文本输入 | ✅ 完整 | 直接传递 |
+| 资源链接 | ✅ 完整 | 扁平化为文本 |
+| 图片附件 | ✅ 完整 | 转换为 Gateway Attachments |
+| **会话模式** | ⚠️ 部分 | 暴露部分 Gateway 控制项（思考级别、工具详细度等） |
+| **事件流** | | |
+| `message` | ✅ 完整 | 文本输出 |
+| `tool_call` | ⚠️ 部分 | 原始 I/O + 文件路径（无终端/结构化 diff） |
+| `session_info_update` | ⚠️ 部分 | 从 Gateway 快照推断（非实时） |
+| `usage_update` | ⚠️ 部分 | 近似值，仅当 Gateway Token 数据标记为"新鲜"时发送 |
+| **不支持的 ACP 功能** | | |
+| Per-session MCP Servers | ❌ 拒绝 | 在 Gateway 层配置 MCP |
+| Client 文件系统方法 | ❌ 不调用 | Bridge 不请求 Client 读写文件 |
+| Client 终端方法 | ❌ 不调用 | Bridge 不创建 Client 终端 |
+| 计划/思考流 | ❌ 不支持 | 仅输出文本 + 工具状态 |
+
+### 2.2 Session 映射机制
+
+**核心挑战**: ACP Session ID 与 Gateway Session Key 的映射
+
+**默认策略**: 隔离模式
+```
+ACP Session ID: acp:<uuid>
+Gateway Session Key: acp:<uuid>
+```
+- 每次连接创建新会话
+- 多个连接之间完全隔离
+
+**显式绑定策略**: 复用模式
+```bash
+# 直接指定 Gateway Key
+openclaw acp --session agent:main:main
+
+# 通过 Label 查找
+openclaw acp --session-label "support inbox"
+
+# 重置会话（保持 Key，清空历史）
+openclaw acp --session agent:main:main --reset-session
+```
+
+**Metadata 覆盖**: ACP Client 可在请求中注入配置
+```json
+{
+  "_meta": {
+    "sessionKey": "agent:main:main",
+    "sessionLabel": "support inbox",
+    "resetSession": true,
+    "requireExisting": false
+  }
+}
+```
+
+**关键设计**:
+- **内存映射**: Bridge 进程生命周期内保持 ACP ID → Gateway Key 映射
+- **持久化**: 由 Gateway 负责（Session Store）
+- **冲突处理**: 多个 Client 共享同一 Gateway Key 时，事件路由是"尽力而为"（推荐使用隔离模式）
+
+### 2.3 Prompt 翻译流程
+
+**ACP Prompt → Gateway Chat.Send**
+
+```typescript
+// ACP 输入格式
+{
+  "prompt": {
+    "parts": [
+      { "type": "text", "text": "Refactor this function" },
+      {
+        "type": "resource_link",
+        "uri": "file:///path/to/code.ts",
+        "mimeType": "text/typescript"
+      },
+      {
+        "type": "resource_link",
+        "uri": "data:image/png;base64,...",
+        "mimeType": "image/png"
+      }
+    ]
+  }
+}
+
+// ↓ Bridge 转换 ↓
+
+// Gateway chat.send
+{
+  "text": "Refactor this function\n\n[Resource: file:///path/to/code.ts]",
+  "attachments": [
+    { "mimeType": "image/png", "data": "base64,..." }
+  ]
+}
+```
+
+**工作目录注入**:
+```bash
+# 默认行为：在 Prompt 前添加 CWD
+--prefix-cwd (默认开启)
+
+# 禁用
+--no-prefix-cwd
+```
+
+### 2.4 事件流转换
+
+**Gateway 事件 → ACP 事件**
+
+| Gateway 事件 | ACP 事件 | 映射逻辑 |
+|-------------|---------|---------|
+| `chat.message` | `message` | 文本块直接传递 |
+| `tool.start` | `tool_call` | 初始化工具调用对象 |
+| `tool.output` | `tool_call_update` | 追加原始 I/O + 文件路径（尽力而为） |
+| `chat.done` (complete) | `done` (stop) | 正常完成 |
+| `chat.done` (aborted) | `done` (cancel) | 用户取消 |
+| `chat.done` (error) | `done` (error) | 错误终止 |
+
+**已知限制**:
+- **工具历史不可重建**: `loadSession` 只重放文本，不重放工具调用
+- **终端不支持**: 无法暴露 ACP Client 终端
+- **Usage 非实时**: 从 Gateway 快照推断，仅当 Token 数据标记为"新鲜"时发送
+
+---
+
+## 3. acpx: Headless CLI 客户端
+
+### 3.1 设计哲学
+
+**定位**: **最小的实用 ACP 客户端**
+
+**核心原则**:
+1. **轻量级**: 无需 PTY 抓取或适配器胶水代码
+2. **Agent-to-Agent**: 主要用户是其他 Agent/Orchestrator（非人类）
+3. **聚焦**: 只做 ACP 客户端，不做大型编排层
+4. **稳定优先**: 减少约定（conventions），保持向后兼容
+
+### 3.2 核心命令
+
+**会话管理**:
+```bash
+# 创建新会话
+acpx codex sessions new
+acpx codex sessions new --name docs
+
+# 列出会话
+acpx codex sessions list
+
+# 查看当前会话状态
+acpx codex sessions show
+
+# 切换会话
+acpx codex -s docs "update CLI docs"
+```
+
+**提示词执行**:
+```bash
+# 一次性执行（默认 codex）
+acpx codex 'fix the failing test'
+acpx codex prompt 'rewrite AGENTS.md'
+acpx codex exec 'summarize this repo'
+
+# 指定工作目录
+acpx codex --cwd /path/to/repo 'analyze code'
+
+# JSON 输出
+acpx --format json codex exec 'review changed files'
+```
+
+**会话控制**:
+```bash
+# 查看状态
+acpx codex status
+
+# 取消当前任务
+acpx codex cancel
+```
+
+### 3.3 配置管理
+
+**初始化**:
+```bash
+acpx config init
+```
+
+**查看配置**:
+```bash
+acpx config show
+```
+
+**自定义 Agent 配置** (`~/.acpx/config.json`):
+```json
+{
+  "agents": {
+    "openclaw": {
+      "command": "env OPENCLAW_HIDE_BANNER=1 openclaw acp --url ws://127.0.0.1:18789 --token-file ~/.openclaw/gateway.token --session agent:main:main"
+    }
+  }
+}
+```
+
+### 3.4 文档策略（重要经验）
+
+**示例排序优先级**（强制规则）:
+1. `pi`
+2. `openclaw`
+3. `codex`
+4. `claude`
+5. `gemini`
+6. `cursor`
+7. `copilot`
+
+**主文档中立性原则**:
+- `README.md` 和 `docs/CLI.md` **必须保持中立**
+- **禁止**在主文档中推广特定 Harness
+- 只有 `pi`, `openclaw`, `codex`, `claude` 可作为命名示例
+- 其他 Harness 的文档必须放在 `agents/{Agent}.md`
+
+**文档同步规则**:
+- 任何修改 Built-in Agent 的 PR **必须同时更新**:
+  1. `skills/acpx/SKILL.md`
+  2. `agents/{Agent}.md`
+- 文档不同步的 PR **禁止合并**
+
+**启示**: 文档治理是长期维护成本的关键
+
+---
+
+## 4. 与 HotPlex 的架构对比
+
+### 4.1 相似之处
+
+| 维度 | OpenClaw ACP | HotPlex Provider |
+|------|-------------|------------------|
+| **桥接模式** | ACP ↔ Gateway | ChatApp ↔ Engine ↔ CLI |
+| **会话管理** | Gateway Session Store | Session Pool + Marker |
+| **协议转换** | ACP → WebSocket | WebSocket → stdin/stdout |
+| **Agent 隔离** | PGID 无（依赖 Gateway） | PGID 进程组 |
+
+### 4.2 差异点
+
+| 维度 | OpenClaw ACP | HotPlex Provider |
+|------|-------------|------------------|
+| **协议层次** | Agent ↔ IDE (JSON-RPC) | Agent ↔ Engine (stdin/stdout) |
+| **Agent 形态** | 外部服务（Gateway 托管） | 本地 CLI 进程（Engine 启动） |
+| **标准化程度** | 高（ACP 开放协议） | 低（Provider 接口内部约定） |
+| **扩展性** | 标准化 Agent 接入 | Plugin 系统 + Provider 接口 |
+| **MCP 集成** | Gateway 层配置 | Engine 层管理（未来） |
+
+### 4.3 可借鉴的设计
+
+**1. Bridge 职责边界**
+- **只做协议转换**，不实现复杂业务逻辑
+- **复用现有基础设施**（Gateway/Session Store）
+- **明确不支持的功能**（拒绝而非静默忽略）
+
+**2. Session 映射策略**
+- **默认隔离**（`acp:<uuid>`）
+- **显式绑定**（`--session` / `--session-label`）
+- **Metadata 覆盖**（`_meta` 字段）
+
+**3. 文档治理**
+- **中立性原则**：主文档不推广特定实现
+- **同步规则**：代码 + 文档同步修改
+- **示例排序**：明确的优先级约定
+
+**4. 配置优先级**
+```bash
+# 1. CLI flags (最高优先级)
+--url --token
+
+# 2. 环境变量
+OPENCLAW_GATEWAY_TOKEN
+
+# 3. 配置文件
+gateway.remote.*
+
+# 4. 默认值 (最低)
+```
+
+**5. 调试工具**
+- `openclaw acp client`: 内置 ACP 客户端用于测试
+- `--verbose`: 日志输出到 stderr（保持 stdout 干净）
+
+---
+
+## 5. 实践经验总结
+
+### 5.1 架构决策
+
+**✅ 正确决策**:
+1. **Bridge 模式** > 完整实现
+   - 理由：复用现有 Gateway，快速落地
+   - 代价：部分 ACP 功能受限（如工具历史重放）
+
+2. **拒绝而非静默忽略**
+   - 示例：Per-session MCP Servers 直接返回错误
+   - 理由：避免隐藏问题，明确边界
+
+3. **内存映射** + Gateway 持久化
+   - 理由：Bridge 无状态，Gateway 统一存储
+   - 代价：多 Client 共享 Key 时路由不严格
+
+**⚠️ 已知限制**:
+1. **工具历史不可重放** → `loadSession` 功能受限
+2. **Usage 非实时** → 依赖 Gateway 快照标记
+3. **终端不支持** → 无法暴露 ACP Client 终端
+
+### 5.2 工程实践
+
+**1. 测试策略**
+- **单元测试**: `src/acp/session.test.ts` - Run ID 生命周期
+- **集成测试**: 完整 Bridge 流程（需要 Gateway）
+- **CI 验证**: `pnpm check` = format + typecheck + lint + build + test
+
+**2. 版本管理**
+- 使用 `@agentclientprotocol/sdk` 0.15.x
+- 严格遵循 ACP spec（否则客户端不兼容）
+
+**3. 安全考虑**
+- `--token-file` 优于 `--token`（避免进程列表泄露）
+- `OPENCLAW_SHELL=acp` 环境变量用于 Shell Profile 规则
+
+**4. 性能优化**
+- Session 映射在内存中（Bridge 生命周期）
+- Gateway 负责重查询/压缩（不放在 Bridge）
+
+### 5.3 避免的陷阱
+
+**1. 过度实现**
+- ❌ 在 Bridge 中实现完整 ACP 运行时
+- ✅ 聚焦协议翻译，复用 Gateway
+
+**2. 静默降级**
+- ❌ 静默忽略不支持的 `mcpServers`
+- ✅ 返回明确错误
+
+**3. 文档膨胀**
+- ❌ 在主文档中推广特定 Harness
+- ✅ 保持中立，Harness 文档独立
+
+**4. 配置混乱**
+- ❌ 多个配置源无优先级
+- ✅ 明确优先级：Flags > Env > Config > Defaults
+
+---
+
+## 6. 对 HotPlex 的启示
+
+### 6.1 短期可借鉴
+
+**1. ACP Provider 实现**
+```go
+type ACPProvider struct {
+    ProviderBase
+    endpoint string
+    client   *http.Client
+}
+
+// 实现 Provider 接口
+func (p *ACPProvider) BuildInputMessage(prompt, taskInstructions string) (map[string]any, error) {
+    // 构造 ACP Prompt 格式
+    return map[string]any{
+        "prompt": map[string]any{
+            "parts": []map[string]any{
+                {"type": "text", "text": prompt},
+            },
+        },
+    }, nil
+}
+```
+
+**2. Session 映射**
+- ACP Session ID → HotPlex Session ID
+- 默认隔离 + 显式绑定（`--session` flag）
+- Metadata 覆盖（`_meta` 字段）
+
+**3. 配置优先级**
+- Flags > Env > YAML Config > Defaults
+
+### 6.2 中期规划
+
+**1. acpx 风格的 CLI 工具**
+```bash
+# 管理远程 HotPlex Agent
+hotplex-cli acp --url wss://hotplex-gateway:18789 --session agent:slack:main
+
+# Agent-to-Agent 通信
+hotplex-cli codex 'ask the slack bot for recent context'
+```
+
+**2. 文档治理**
+- 主文档中立性
+- Provider 文档独立（`docs/providers/{Claude,OpenCode}.md`）
+- 示例排序约定
+
+**3. 调试工具**
+- `hotplex acp client`: 内置测试客户端
+- `--verbose`: 日志到 stderr
+
+### 6.3 长期演进
+
+**1. ACP Server 模式**
+- HotPlex 暴露 ACP 接口
+- 接入 IDE 插件（VSCode/Cursor）
+
+**2. MCP + ACP 共存**
+- MCP: Agent ↔ Tools
+- ACP: Agent ↔ IDE/Agent
+
+**3. 多协议支持**
+- Agent Communication Protocol (Agent 间协作)
+- Agent Client Protocol (IDE 集成)
+- MCP (工具访问)
+
+---
+
+## 7. 关键资源
+
+### 7.1 官方资源
+
+- **OpenClaw ACP 文档**: [docs.openclaw.ai/cli/acp](https://docs.openclaw.ai/cli/acp)
+- **OpenClaw ACP Bridge 实现**: [github.com/openclaw/openclaw/blob/main/docs.acp.md](https://github.com/openclaw/openclaw/blob/main/docs.acp.md)
+- **acpx CLI**: [github.com/openclaw/acpx](https://github.com/openclaw/acpx)
+- **acpx AGENTS.md**: [github.com/openclaw/acpx/blob/main/AGENTS.md](https://github.com/openclaw/acpx/blob/main/AGENTS.md)
+
+### 7.2 教程与指南
+
+- **2026 Complete Guide**: [dev.to/czmilo/2026-complete-guide](https://dev.to/czmilo/2026-complete-guide-openclaw-acp-bridge-your-ide-to-ai-agents-3hl8)
+- **阿里云部署教程**: [developer.aliyun.com/article/1717563](https://developer.aliyun.com/article/1717563)
+- **三大 Agent 解析**: [aivi.fyi/aiagents/OpenClaw-Agent-Tutorial](https://www.aivi.fyi/aiagents/OpenClaw-Agent-Tutorial)
+
+### 7.3 架构分析
+
+- **Lessons from OpenClaw's Architecture**: [techwithibrahim.medium.com](https://techwithibrahim.medium.com/lessons-from-openclaws-architecture-for-agent-builders-243921dcbbad)
+- **Protocol Gaps Analysis**: [shashikantjagtap.net](https://shashikantjagtap.net/openclaw-acp-what-coding-agent-users-need-to-know-about-protocol-gaps/)
+- **Architecture Deep Dive**: [zhuanlan.zhihu.com](https://zhuanlan.zhihu.com/p/2006150745662181825)
+
+---
+
+## 8. 总结
+
+**OpenClaw ACP 的核心价值**:
+1. **标准化**：基于开放协议，接入任何 ACP 兼容客户端
+2. **复用性**：Bridge 模式，复用现有 Gateway 基础设施
+3. **实用性**：聚焦核心场景，明确边界
+4. **可维护性**：清晰的文档治理 + 配置策略
+
+**对 HotPlex 的启示**:
+- **短期**：实现 ACP Provider，复用 Session 映射设计
+- **中期**：开发 acpx 风格 CLI 工具，完善文档治理
+- **长期**：支持 ACP Server 模式，接入 IDE 生态
+
+**关键教训**:
+1. **Bridge > 完整实现**：复用现有基础设施
+2. **拒绝 > 静默**：明确边界，避免隐藏问题
+3. **文档中立**：主文档保持中立，特定实现在独立文档
+4. **配置优先级**：Flags > Env > Config > Defaults


### PR DESCRIPTION
## 概述

添加 Agent Client Protocol (ACP) 集成技术调研文档，为 HotPlex Provider 层的 ACP 集成提供技术基础。

## 新增文档

- **acp-integration-research.md** - ACP 协议概述、集成方案对比（ACP Provider/Relay/Server）、MCP 协议对比
- **openclaw-acp-deep-dive.md** - OpenClaw ACP Bridge 实践深度分析、架构模式、Session 映射、兼容性矩阵

## 关键发现

- OpenCode 原生支持 ACP（`opencode acp` 命令），可直接集成
- Claude Code 官方 ACP 支持仍在 Feature Request 阶段 (#6686)
- OpenClaw Bridge 模式可借鉴：Gateway-backed 协议转换层
- Session 映射策略：默认隔离 + 显式绑定 + Metadata 覆盖

## 相关 Issues

Refs #355 - 跟踪 Claude Code ACP 上游进展
Refs #356 - 实现 OpenCode ACP Provider

## 测试计划

- [x] 文档格式正确（Markdown）
- [x] 链接有效（OpenCode 官方文档、GitHub Issues）
- [x] 技术细节准确（协议格式、架构图）
- [x] 可操作的建议（实现路线图）